### PR TITLE
Don't clobber PKG_CONFIG_PATH, in case we need to set it as a parameter to configure.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,7 +298,11 @@ if test x"$lightgrep" == x"yes"; then
     PKG_CONFIG="$PKG_CONFIG --static"
   else
     # pkg-config doesn't look in /usr/local/lib on some systems
-    export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+    if test x"$PKG_CONFIG_PATH" != x; then
+      export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
+    else
+      export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+    fi
   fi
 
   PKG_CHECK_MODULES([lightgrep], [lightgrep])


### PR DESCRIPTION
Here's a minor change we need to configure.ac in order to build properly on our build bot. (It's also just good autoconf hygiene not to clobber user variables, so this is an improvement regardless.)
