### PR TITLE
git:// protocol isn't recommended for accessing GitHub repositories.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "src/be13_api"]
 	path = src/be13_api
-	url = git://github.com/simsong/be13_api.git
+	url = https://github.com/simsong/be13_api.git
 [submodule "src/dfxml"]
 	path = src/dfxml
 	url = https://github.com/simsong/dfxml.git
 [submodule "src/sceadan"]
 	path = src/sceadan
-	url = git://github.com/nbeebe/sceadan.git
+	url = https://github.com/nbeebe/sceadan.git


### PR DESCRIPTION
Switch the submodules to use https:// instead.