### PR TITLE
Canadian SIN scanner improvements

### DIFF
--- a/src/scan_accts.flex
+++ b/src/scan_accts.flex
@@ -358,7 +358,7 @@ sin:?[ \t]*[0-9][0-9][0-9][ -]?[0-9][0-9][0-9][ -]?[0-9][0-9][0-9]/{END} {
     s.pos += yyleng;
 }
 
-[^0-9][0-9][0-9]-[0-9][0-9][0-9]-[0-9][0-9][0-9]/{END} {
+[^0-9][0-9][0-9][0-9]-[0-9][0-9][0-9]-[0-9][0-9][0-9]/{END} {
     /* Canadian SIN without prefix, dashes required */
     accts_scanner &s = *yyaccts_get_extra(yyscanner);
     s.sin_recorder->write_buf(SBUF,s.pos+1,yyleng-1);


### PR DESCRIPTION
This fixes an error in one of the regular expressions to identify Canadian Social Insurance Numbers (SINs) in the `accts` scanner and adds a feature recorder and regular expressions for SINs to `accts_lg`.

Should be the last PR for a while (eventually I'd also like to add some additional functionality to these scanners, e.g. to identify SWIFT and IBAN numbers, but the SIN scanning functionality is the priority for now).

Thanks!