### PR TITLE
Updating URL for Git Project in Ubuntu 18.04 LTS

### DIFF
--- a/etc/CONFIGURE_UBUNTU18LTS.bash
+++ b/etc/CONFIGURE_UBUNTU18LTS.bash
@@ -7,7 +7,7 @@ cat <<EOF
 Install Ubuntu 18.04 and follow these commands:
 
 # apt-get install git
-# git clone --recursive git@github.com:simsong/bulk_extractor.git
+# git clone --recursive https://github.com/simsong/bulk_extractor.git
 # cd bulk_extractor
 # bash etc/CONFIGURE_UBUNTU18.bash
 # bootstrap.sh


### PR DESCRIPTION
Updating URL for Cloning GIT

The URL in the original file is not working:

bulkextractor: command not found
gra@NPCB214Gra:~$ git clone --recursive git@github.com:simsong/bulk_extractor.git
Cloning into 'bulk_extractor'...
The authenticity of host 'github.com (140.82.118.3)' can't be established.
RSA key fingerprint is SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added 'github.com,140.82.118.3' (RSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

-> New URL was taken from actual Github Project