### PR TITLE
Updated COPYING symbolic link

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,1 +1,1 @@
-LICENSE
+LICENSE.md


### PR DESCRIPTION
Currently running `sh bootstrap.sh' will overwrite COPYING since the link points to a non-existing file.