### PR TITLE
Fix src/scan_json.cpp to compile with libjson-c versions < 0.15

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -74,10 +74,7 @@ Licensed under the MIT License
 
 * src/old_scanners/scan_ascii85.cpp is Copyright (C) 2011 Remy Oukaour
 
-
-Licensed under the JSON License
-
-* src/scan_json.cpp is Copyright (C) 2005 JSON.org
+* src/scan_json.cpp is Copyright (C) 2021 Simson L. Garfinkel and Jan Gruber
 
 
 Licensed under General Public License version 3 and later
@@ -117,6 +114,6 @@ Licensed under General Public License version 3 with the Autoconf exception:
 * m4/ac_check_classpath.m4 is Copyright (C) 2000 Stephane Bortzmeyer <bortzmeyer@pasteur.fr>
 
 
-Licensed under OpenSSL License  
+Licensed under OpenSSL License
 
 Because of the fact, that the GPL (including version 3) is incompatible with some terms of the OpenSSL license, the author hereby explicitly states a license exception, which permits the linking of bulk_extractor with OpenSSL.

--- a/src/scan_json.cpp
+++ b/src/scan_json.cpp
@@ -5,7 +5,9 @@
 #include <json-c/json.h>
 
 #define MIN_SIZE 16
-static bool is_json_second_char[256];		// shared between all threads
+#define IS_STRICT 1
+
+static bool is_json_second_char[256]; /* shared between all threads */
 
 static const char *json_second_chars = "0123456789.-{[ \t\n\r\"";
 extern "C"
@@ -44,7 +46,6 @@ void scan_json(const class scanner_params &sp,const recursion_control_block &rcb
       char* js = NULL; 
       size_t end = 0;
       enum json_tokener_error je;
-
       
       for(size_t pos = 0;pos+1<sbuf.pagesize;pos++){
 
@@ -53,7 +54,8 @@ void scan_json(const class scanner_params &sp,const recursion_control_block &rcb
 
 	  /* Setup parser */
 	  jt = json_tokener_new();
-	  //json_tokener_set_flags(jt, JSON_TOKENER_STRICT);
+	  if (IS_STRICT)
+	    json_tokener_set_flags(jt, JSON_TOKENER_STRICT);
 	  
 	  /* Try to parse string */
 	  const char* c = (const char*) &sbuf.buf[pos]; /* Solution for 1.6 */
@@ -62,7 +64,8 @@ void scan_json(const class scanner_params &sp,const recursion_control_block &rcb
 	  
 	  /* String was a valid JSON object */
 	  if (je == json_tokener_success && jo){
-	    end = json_tokener_get_parse_end(jt);
+	    /* Change this to `json_tokener_get_parse_end(jt);` for libjson-c > 0.15 */
+	    end = jt->char_offset;
 	    js = (char*) json_object_to_json_string_ext(jo, JSON_C_TO_STRING_PLAIN);
 
 	    /* Discard very short matches */


### PR DESCRIPTION
Dear Simson, 

this PR fixes a compilation issue introduced by #170, which stemmed from using a function named `json_tokener_get_parse_end(...)`. This function was introduced in version 0.15 of libjson-c, whereas this library version is not available in Ubuntu's package sources yes. Calling this not existing function resulted in 
https://github.com/simsong/bulk_extractor/runs/2910172008?check_suite_focus=true#step:5:579, which should be fixed now.

Best regards   
   Jan 

