### PR TITLE
Fix spelling errors (patch from S. Brun)

### DIFF
--- a/src/exif_entry.cpp
+++ b/src/exif_entry.cpp
@@ -101,7 +101,7 @@ const std::string exif_entry::get_full_name() const {
     case IFD1_INTEROPERABILITY:
         return "ifd1.interoperability." + name;
     default:
-        std::cerr << "Program state errror: Invalid ifd type " << ifd_type << "\n";
+        std::cerr << "Program state error: Invalid ifd type " << ifd_type << "\n";
         assert(0);
     }
     return "ERROR";			// required to avoid compiler warning

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -826,7 +826,7 @@ int main(int argc,char **argv)
 	{
 	    std::vector<std::string> params = split(optarg,'=');
 	    if(params.size()!=2){
-		std::cerr << "Invalid paramter: " << optarg << "\n";
+		std::cerr << "Invalid parameter: " << optarg << "\n";
 		exit(1);
 	    }
 	    s_config.namevals[params[0]] = params[1];


### PR DESCRIPTION
Dear Simson, 

this PR fixes two spelling errors. This patch was created by @sbrun in the course of packaging bulk_extractor for Kali.
I think, it is a good idea forward it to you, so that it finds its way inside the upstream code base. 

Best regards,
    Jan