### PR TITLE
Duplicate autoremove in Ubuntu 18 config script

### DIFF
--- a/etc/CONFIGURE_UBUNTU18LTS.bash
+++ b/etc/CONFIGURE_UBUNTU18LTS.bash
@@ -55,7 +55,7 @@ echo Will now try to install
 # I use emacs. Installing it may install requiremnts
 sudo apt update -y
 sudo apt install -y emacs
-sudo apt autoremove -y autoremove
+sudo apt autoremove -y
 # Now install what is required
 
 echo apt install -y $MKPGS


### PR DESCRIPTION
The apt autoremove on line 58 had a duplicate autoremove, this is interpreted as a package by apt and throws an error.