### PR TITLE
ftpmirror url for autoconf & automake updated

### DIFF
--- a/etc/CONFIGURE_UBUNTU20LTS.bash
+++ b/etc/CONFIGURE_UBUNTU20LTS.bash
@@ -2,8 +2,8 @@
 RELEASE=20
 CONFIGURE="./configure -q --enable-silent-rules"
 LIBEWF_DIST=https://github.com/libyal/libewf-legacy/releases/download/20140812/libewf-20140812.tar.gz
-AUTOCONF_DIST=https://ftpmirror.gnu.org/autoconf/autoconf-2.71.tar.gz
-AUTOMAKE_DIST=https://ftpmirror.gnu.org/automake/automake-1.16.3.tar.gz
+AUTOCONF_DIST=https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz
+AUTOMAKE_DIST=https://ftp.gnu.org/gnu/automake/automake-1.16.3.tar.gz
 MKPGS="autoconf automake build-essential flex libexpat1-dev libssl-dev libtool libxml2-utils make pkg-config zlib1g-dev"
 WGET="wget -nv --no-check-certificate"
 CONFIGURE="./configure -q --enable-silent-rules"


### PR DESCRIPTION
ftpmirror URL doesn't work so replaced with working URLs for AUTOCONF and AUTOMAKE