### PR TITLE
Include bootstrap.sh instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ To build bulk_extractor in Linux or Mac OS:
 2. Then run these commands:
 
 ```
+./bootstrap.sh
 ./configure
 make
 make install


### PR DESCRIPTION
I think it would be useful to mention in the README.md that you need to run `bootstrap.sh` to generate the configure command. I don't believe it's mentioned in the INSTALL, but people will probably see the README on GitHub first anyway.