### PR TITLE
Add a workflow to release a tarball including all submodules

### DIFF
--- a/.github/workflows/create-tarball.yml
+++ b/.github/workflows/create-tarball.yml
@@ -1,0 +1,48 @@
+name: Create tarball including submodules
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Bump Version
+        default: v2.0.0
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository and init submodules recursively
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Get context
+      id: ctx
+      run: |
+        echo "::set-output name=date::$(date +'%Y%m%d')"
+        echo "::set-output name=sha::$(git rev-parse --short HEAD)"
+    - name: cleanup
+      run: rm -rf ./.git
+
+    - name: Compress action step
+      uses: a7ul/tar-action@v1.1.0
+      id: compress
+      with:
+        command: c
+        files: |
+          ./
+        outPath: |
+          ${{ inputs.version }}-git${{ steps.ctx.outputs.date }}.${{ steps.ctx.outputs.sha }}.tar.gz
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ${{ inputs.version }}-git${{ steps.ctx.outputs.date }}.${{ steps.ctx.outputs.sha }}.tar.gz
+        asset_name: ${{ inputs.version }}-git${{ steps.ctx.outputs.date }}/${{ steps.ctx.outputs.sha }}.tar.gz
+        tag: ${{ github.ref }}
+        release_name: "Release ${{ inputs.version }} of bulk_extractor including subdirectories"
+        overwrite: true
+        body: "Release ${{ inputs.version }} of bulk_extractor including subdirectories"

--- a/.github/workflows/create-tarball.yml
+++ b/.github/workflows/create-tarball.yml
@@ -1,6 +1,6 @@
 name: Create tarball including submodules
 
-on: ["push"]
+on: [workflow_dispatch]
 
 jobs:
   release:

--- a/.github/workflows/create-tarball.yml
+++ b/.github/workflows/create-tarball.yml
@@ -1,12 +1,6 @@
 name: Create tarball including submodules
 
-on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: Bump Version
-        default: v2.0.0
-        required: true
+on: ["push"]
 
 jobs:
   release:
@@ -21,28 +15,27 @@ jobs:
     - name: Get context
       id: ctx
       run: |
-        echo "::set-output name=date::$(date +'%Y%m%d')"
-        echo "::set-output name=sha::$(git rev-parse --short HEAD)"
-    - name: cleanup
-      run: rm -rf ./.git
+        echo "::set-output name=version::$(grep 'AC_INIT(\[BULK_EXTRACTOR\]' configure.ac| cut -d',' -f2 | tr -d "[]")" 
 
-    - name: Compress action step
-      uses: a7ul/tar-action@v1.1.0
-      id: compress
-      with:
-        command: c
-        files: |
-          ./
-        outPath: |
-          ${{ inputs.version }}-git${{ steps.ctx.outputs.date }}.${{ steps.ctx.outputs.sha }}.tar.gz
-
+    - name: Setup
+      run: |
+        chmod +x etc/install_autotools.sh
+        bash ./etc/install_autotools.sh
+        chmod +x && bootstrap.sh
+        ./bootstrap.sh
+        ./configure -q
+    
+    - name: Create release tarball
+      run: |
+        make dist
+        
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ inputs.version }}-git${{ steps.ctx.outputs.date }}.${{ steps.ctx.outputs.sha }}.tar.gz
-        asset_name: ${{ inputs.version }}-git${{ steps.ctx.outputs.date }}/${{ steps.ctx.outputs.sha }}.tar.gz
+        file: bulk_extractor-${{ steps.ctx.outputs.version }}.tar.gz
+        asset_name: bulk_extractor-${{ steps.ctx.outputs.version }}.tar.gz
         tag: ${{ github.ref }}
-        release_name: "Release ${{ inputs.version }} of bulk_extractor including subdirectories"
+        release_name: "Release ${{ steps.ctx.outputs.version  }} of bulk_extractor including subdirectories"
         overwrite: true
-        body: "Release ${{ inputs.version }} of bulk_extractor including subdirectories"
+        body: "Release ${{ steps.ctx.outputs.version }} of bulk_extractor including subdirectories"


### PR DESCRIPTION
Dear Simson,

this PR provides a GitHub workflow that creates a tarball including all submodules. The workflow is configured to be triggered manually from the default branch, as described [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).

Maybe this is of interest since it could ease distributing new versions of `bulk_extractor`. 

Best regards, 
jgru