### PR TITLE
Restrict permissions of secrets.GITHUB_TOKEN in workflow

### DIFF
--- a/.github/workflows/create-tarball.yml
+++ b/.github/workflows/create-tarball.yml
@@ -2,6 +2,22 @@ name: Create tarball including submodules
 
 on: [workflow_dispatch]
 
+permissions:
+  actions: read
+  checks: none
+  contents: write
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Dear Simson,

this PR addresses #371 by restricting permissions of `secrets.GITHUB_TOKEN` in the workflow file to publish a release. All permissions are removed except the one to write contents, which is needed to place the tarball in the release section according to the [documentation](https://docs.github.com/en/rest/overview/permissions-required-for-github-apps#permission-on-contents).


Best regards,
jgru
