### PR TITLE
fix --disable-rar build

### DIFF
--- a/src/scan_rar.cpp
+++ b/src/scan_rar.cpp
@@ -608,7 +608,7 @@ void scan_rar(scanner_params &sp)
         sp.get_scanner_config("rar_find_volumes",&record_volumes,"Search for RAR volumes");
 #else
         sp.info->description = "(disabled in configure)";
-        sp.info->flags.default_enabled = false;
+        sp.info->scanner_flags.default_enabled = false;
 #endif
 	return;
     }


### PR DESCRIPTION
Building v2.0.0 and Git HEAD both fail when configuring `--disable-rar` with:
```
scan_rar.cpp:611:23: error: member reference base type 'uint64_t' (aka 'unsigned long long') is not a structure or union
        sp.info->flags.default_enabled = false;
        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [scan_rar.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

Updating `flags` to `scanner_flags` should at least get build to finish. Not sure if there are any other issues.