### PR TITLE
Minor typo fix in program comment

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@
 
 SUBDIRS = doc doc/latex_manuals man src src/tests python specfiles tests
 
-# don't include bootstrap. People run it, and they shoudln't
+# Don't include bootstrap. People run it, and they shouldn't
 # It's only for people who check out the git repo
 
 EXTRA_DIST = \


### PR DESCRIPTION
Two small typo corrections on the same comment line. The first correction was a misspelling ("shoudln't" into "shouldn't") and the second change was capitalizing the beginning of a sentence ("don't" into "Don't").