### PR TITLE
Disable scanners before enabling

### DIFF
--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -272,6 +272,12 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         sc.banner_file = result["banner_file"].as<std::string>();
     } catch ( cxxopts::option_has_no_value_exception &e ) { }
 
+    try {
+        for ( const auto &name : result["disable"].as<std::vector<std::string>>() ) {
+            sc.push_scanner_command( name, scanner_config::scanner_command::DISABLE);
+        }
+    } catch ( cxxopts::option_has_no_value_exception &e ) { }
+
     if ( result.count( "enable_exclusive" )) {
         sc.push_scanner_command( scanner_config::scanner_command::ALL_SCANNERS, scanner_config::scanner_command::DISABLE);
         sc.push_scanner_command( result["enable_exclusive"].as<std::string>(), scanner_config::scanner_command::ENABLE);
@@ -280,13 +286,6 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     try {
         for ( const auto &name : result["enable"].as<std::vector<std::string>>() ) {
             sc.push_scanner_command( name, scanner_config::scanner_command::ENABLE);
-        }
-    } catch ( cxxopts::option_has_no_value_exception &e ) { }
-
-
-    try {
-        for ( const auto &name : result["disable"].as<std::vector<std::string>>() ) {
-            sc.push_scanner_command( name, scanner_config::scanner_command::DISABLE);
         }
     } catch ( cxxopts::option_has_no_value_exception &e ) { }
 

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -138,6 +138,22 @@ TEST_CASE("e2e-0", "[end-to-end]") {
     REQUIRE( code==0 );
 }
 
+TEST_CASE("select_scanners", "[end-to-end]") {
+    std::filesystem::path inpath = test_dir() / "pdf_words2.pdf";
+    std::filesystem::path outdir = NamedTemporaryDirectory();
+    std::string inpath_string = inpath.string();
+    std::string outdir_string = outdir.string();
+    std::stringstream ss;
+    const char *argv[] = {"bulk_extractor", "-0q", "-x", "all", "-e", "wordlist", "-o", outdir_string.c_str(), inpath_string.c_str(), nullptr};
+    int ret = run_be(ss, std::cerr, argv);
+    REQUIRE( ret==0 );
+
+    auto lines = getLines( outdir / "report.xml" );
+    auto startpos = std::find(lines.begin(), lines.end(), "    <scanners>");
+    auto endpos = std::find(lines.begin(), lines.end(), "    </scanners>");
+    REQUIRE( startpos != lines.end());
+    REQUIRE( endpos != startpos + 1);
+}
 
 TEST_CASE("scan_find", "[end-to-end]") {
     std::filesystem::path inpath = test_dir() / "pdf_words2.pdf";


### PR DESCRIPTION
Fixes #430 

Disable scanners provided in arguments before enabling other scanners. This solves a bug where using `-x all` results in no scanners being active regardless of `-e` arguments provided.