### PR TITLE
GH Workflows: Create CI job for Coverity scan

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,48 @@
+# Creates and uploads a Coverity build on a schedule
+# Requires that two secrets be created:
+# COVERITY_SCAN_EMAIL, with the email address that should be notified with scan results
+# COVERITY_SCAN_TOKEN, with the token from the Coverity project page (e.g., https://scan.coverity.com/projects/moshekaplan-duckdb?tab=project_settings )
+# Also, ensure that the 'github.repository' comparison and 'COVERITY_PROJECT_NAME' values below are accurate
+name: Coverity Scan
+on:
+  schedule:
+  # Run once daily, bulk_extractor is at ~175k LOC
+  # Scan frequency limits from https://scan.coverity.com/faq#frequency :
+  # Up to 28 builds per week, with a maximum of 4 builds per day, for projects with fewer than 100K lines of code
+  # Up to 21 builds per week, with a maximum of 3 builds per day, for projects with 100K to 500K lines of code
+  # Up to 14 builds per week, with a maximum of 2 build per day, for projects with 500K to 1 million lines of code
+  # Up to 7 builds per week, with a maximum of 1 build per day, for projects with more than 1 million lines of code
+  - cron: '0 0 * * *'
+  # Support manual execution
+  workflow_dispatch:
+jobs:
+  coverity:
+    # So it doesn't try to run on forks
+    if: github.repository == 'simsong/bulk_extractor'
+    runs-on: ubuntu-latest
+    env:
+      COVERITY_PROJECT_NAME: bulk_extractor
+    steps:
+    - uses: actions/checkout@main
+    - name: Download and extract the Coverity Build Tool
+      run: |
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=${{ secrets.COVERITY_SCAN_TOKEN }}&project=${{ env.COVERITY_PROJECT_NAME  }}" -O cov-analysis-linux64.tar.gz
+          mkdir cov-analysis-linux64
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+    - name: Install dependencies
+      run: sudo ./etc/CONFIGURE_UBUNTU22LTS.bash  < /dev/null
+    - name: Bootstrap
+      run: ./bootstrap.sh
+    - name: Configure
+      run: ./configure
+    - name: Build with cov-build
+      run: cov-analysis-linux64/bin/cov-build --dir cov-int make
+    - name: Upload the result
+      run: |
+          tar czvf cov-int.tgz cov-int
+          curl \
+            --form project=${{ env.COVERITY_PROJECT_NAME }} \
+            --form email=${{ secrets.COVERITY_SCAN_EMAIL }} \
+            --form token=${{ secrets.COVERITY_SCAN_TOKEN }} \
+            --form file=@cov-int.tgz \
+            https://scan.coverity.com/builds


### PR DESCRIPTION
Coverity Scan is a static source code analyzer to find bugs, security vulnerabilities, and other potential issues. This PR adds a GitHub Workflow CI job to create a new Coverity Scan build daily, to ease detection and remediation of software bugs.

Before this is merged in, the following steps are required: 1) Register the "bulk_extractor" project on Coverity's website here: https://scan.coverity.com/projects/ (it would be best if an official maintainer did this) 2) Create two new secrets:
a) `COVERITY_SCAN_EMAIL` with the email address that should be notified with the scan results. It is not possible to disable the scan result emails. b) `COVERITY_SCAN_TOKEN` with the Project token from the Coverity project page (e.g., https://scan.coverity.com/projects/bulk_extractor?tab=project_settings )

Optionally, you may also wish to:
1) Configure Coverity to ignore directories that you don't want it to scan. (e.g., the `/src/be20_api/.*` directory)

After this PR is merged, GitHub will submit builds to Coverity with the schedule specified in the yaml file. However, if desired, you can trigger a manual run by going to `Actions -> Coverity Scan`, and clicking on the `Run workflow` button.