### PR TITLE
coverity.yml: Change Coverity project name to simsong/bulk_extractor

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,7 +21,7 @@ jobs:
     if: github.repository == 'simsong/bulk_extractor'
     runs-on: ubuntu-latest
     env:
-      COVERITY_PROJECT_NAME: bulk_extractor
+      COVERITY_PROJECT_NAME: simsong/bulk_extractor
     steps:
     - uses: actions/checkout@main
     - name: Download and extract the Coverity Build Tool


### PR DESCRIPTION
Based on https://scan.coverity.com/projects/simsong-bulk_extractor , it appears that you registered the Coverity project as `simsong/bulk_extractor` . This change changes the COVERITY_PROJECT_NAME to refer to `simsong/bulk_extractor` .