### PR TITLE
Update identify_filenames.py

### DIFF
--- a/python/identify_filenames.py
+++ b/python/identify_filenames.py
@@ -11,8 +11,8 @@ examined for every byte run, or a database of byte runs, which is
 examined for every feature.
 """
 
-import platform
-if platform.python_version_tuple() < ('3','2','0'):
+import sys
+if sys.version_info < (3,2):
     raise RuntimeError('This script now requires Python 3.2 or above')
 
 try:


### PR DESCRIPTION
- platform.python_version_tuple() was returning a string tuple which when compared with ('3','2','0') returned incorrectly

+ replaced with sys.version_info and issue is now fixed