### PR TITLE
Run yara-x rules against small blocks of sbufs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,6 +217,39 @@ if test x"$lightgrep" == x"yes"; then
 fi
 
 ################################################################
+## yara-x support
+##
+AC_ARG_ENABLE([yara],
+              AS_HELP_STRING([--disable-yara], [Disable YARA scanning]),
+              [],
+              [AC_DEFINE(USE_YARA, 1, [Use YARA scanning]) yara="yes"])
+if test x"$yara" == x"yes"; then
+  m4_ifndef([PKG_CHECK_MODULES],
+            [AC_MSG_ERROR([pkg-config autoconf macros are missing; try installing pkgconfig])])
+
+  if test x"$mingw" == x"yes" ; then
+    # get static flags when cross-compiling with mingw
+    PKG_CONFIG="$PKG_CONFIG --static"
+  else
+    # pkg-config doesn't look in /usr/local/lib on some systems
+    if test x"$PKG_CONFIG_PATH" != x; then
+      export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig
+    else
+      export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+    fi
+  fi
+
+  m4_ifdef([PKG_CHECK_MODULES],
+           [PKG_CHECK_MODULES([yara], [yara_x_capi])])
+
+  AC_DEFINE([HAVE_LIBYARA_X_CAPI], 1, [Define to 1 if you have libyara_x_capi.])
+
+  CPPFLAGS="$CPPFLAGS $yara_CFLAGS"
+  LIBS="$LIBS `$PKG_CONFIG --libs-only-l yara_x_capi`"
+  LDFLAGS="$LDFLAGS `$PKG_CONFIG --libs-only-L --libs-only-other yara_x_capi`"
+fi
+
+################################################################
 ## LIBEWF support
 
 AC_ARG_ENABLE([libewf],

--- a/configure.ac
+++ b/configure.ac
@@ -242,7 +242,7 @@ if test x"$yara" == x"yes"; then
   m4_ifdef([PKG_CHECK_MODULES],
            [PKG_CHECK_MODULES([yara], [yara_x_capi])])
 
-  AC_DEFINE([HAVE_LIBYARA_X_CAPI], 1, [Define to 1 if you have libyara_x_capi.])
+  AC_DEFINE([HAVE_YARAX], 1, [Define to 1 if you have libyara_x_capi.])
 
   CPPFLAGS="$CPPFLAGS $yara_CFLAGS"
   LIBS="$LIBS `$PKG_CONFIG --libs-only-l yara_x_capi`"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -103,6 +103,7 @@ scanners_builtin = \
 	scan_winprefetch.cpp \
 	scan_wordlist.cpp scan_wordlist.h \
 	scan_xor.cpp \
+	scan_yarax.cpp \
 	scan_zip.cpp \
 	pcap_writer.cpp \
 	pcap_writer.h

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -254,6 +254,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         ("V,version",       "Display PACKAGE_VERSION (currently) " PACKAGE_VERSION)
         ("w,stop_list",     "file to read stop list from", cxxopts::value<std::string>())
         ("Y,scan",          "specify <start>[-end] of area on disk to scan", cxxopts::value<std::string>())
+        ("yara_x_rules",    "directory containing yara-x rules", cxxopts::value<std::string>())
         ("z,page_start",    "specify a starting page number", cxxopts::value<int>())
         ("Z,zap",           "wipe the output directory (recursively) before starting")
         ("0,no_notify",     "disable real-time notification")
@@ -327,6 +328,10 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     } catch ( cxxopts::option_has_no_value_exception &e ) { }
 
     cfg.opt_recurse = result.count( "recurse" );
+
+    try {
+        sc.yara_x_rules_path = result["yara_x_rules"].as<std::string>();
+    } catch ( cxxopts::option_has_no_value_exception &e ) { }
 
     try {
         for ( const auto &it : result["set"].as<std::vector<std::string>>() ) {

--- a/src/bulk_extractor_scanners.h
+++ b/src/bulk_extractor_scanners.h
@@ -60,6 +60,9 @@ SCANNER(winpe)
 SCANNER(winprefetch)
 SCANNER(wordlist)
 SCANNER(xor)
+#ifdef HAVE_YARAX
+SCANNER(yarax)
+#endif
 SCANNER(zip)
 
 

--- a/src/scan_yarax.cpp
+++ b/src/scan_yarax.cpp
@@ -1,0 +1,26 @@
+/**
+ * Plugin: scan_yarax
+ * Purpose: Run yara-x rules against raw pages
+ * Reference: https://virustotal.github.io/yara-x/
+ **/
+
+#include <iostream>
+
+#include "config.h"
+#include "be20_api/scanner_params.h"
+
+#ifdef HAVE_YARAX
+extern "C" void scan_yarax(scanner_params &sp);
+
+void scan_yarax(scanner_params &sp) {
+  sp.check_version();
+  if (sp.phase == scanner_params::PHASE_INIT){
+    sp.info->set_name("yarax");
+    sp.info->author          = "Jon Stewart";
+    sp.info->description     = "Scans for yara-x rule matches in raw pages";
+    sp.info->scanner_version = "1.0";
+    return;
+  }
+}
+#endif
+

--- a/src/scan_yarax.cpp
+++ b/src/scan_yarax.cpp
@@ -10,7 +10,38 @@
 #include "be20_api/scanner_params.h"
 
 #ifdef HAVE_YARAX
-extern "C" void scan_yarax(scanner_params &sp);
+extern "C" {
+#include <yara_x.h>
+
+void scan_yarax(scanner_params &sp);
+}
+
+auto YARA_RULE = R"(
+rule test_rule {
+  strings:
+    $a = "asdfoiqweofiuxkbjvlkjdlksdjflaisjflkvlkfvnbzkdfjasoei;lzkxcvnkaslfkjqlkj"
+  condition:
+    $a
+}
+)";
+
+using rules_ptr = std::unique_ptr<YRX_RULES, decltype(&yrx_rules_destroy)>;
+
+rules_ptr& getYaraRules() {
+  static rules_ptr rules(nullptr, yrx_rules_destroy);
+  return rules;
+}
+
+void yara_callback(const YRX_RULE* rule, void*) {
+  const uint8_t* ruleID = nullptr;
+  size_t   idLen = 0;
+  if (yrx_rule_identifier(rule, &ruleID, &idLen) != SUCCESS) {
+    std::cerr << "Failed to get rule ID in yara_callback" << std::endl;
+    return;
+  }
+  std::string_view ruleIDView(reinterpret_cast<const char*>(ruleID), idLen);
+  std::cout << "Matched rule: " << ruleIDView << std::endl;
+}
 
 void scan_yarax(scanner_params &sp) {
   sp.check_version();
@@ -20,6 +51,51 @@ void scan_yarax(scanner_params &sp) {
     sp.info->description     = "Scans for yara-x rule matches in raw pages";
     sp.info->scanner_version = "1.0";
     return;
+  }
+  else if (sp.phase == scanner_params::PHASE_INIT2) {
+    YRX_RULES* rules = nullptr;
+    YRX_RESULT result = yrx_compile(YARA_RULE, &rules);
+    if (result != SUCCESS) {
+      std::cerr << "Failed to compile yara-x rule: " << yrx_last_error() << std::endl;
+      return;
+    }
+    else {
+      getYaraRules().reset(rules);
+    }
+  }
+  else if (sp.phase == scanner_params::PHASE_SCAN) {
+    rules_ptr& rules = getYaraRules();
+    if (!rules) {
+      return;
+    }
+    YRX_SCANNER* scannerRawPtr = nullptr;
+    YRX_RESULT result = yrx_scanner_create(rules.get(), &scannerRawPtr);
+    if (result != SUCCESS) {
+      std::cerr << "Failed to create yara-x scanner: " << yrx_last_error() << std::endl;
+      return;
+    }
+    std::unique_ptr<YRX_SCANNER, decltype(&yrx_scanner_destroy)> scanner(scannerRawPtr, yrx_scanner_destroy);
+
+    result = yrx_scanner_on_matching_rule(scanner.get(), yara_callback, nullptr);
+    if (result != SUCCESS) {
+      std::cerr << "Failed to set yara-x callback: " << yrx_last_error() << std::endl;
+      return;
+    }
+
+    // Iterate the sbuf 4KB at a time and scan these pages individually
+    const sbuf_t *sbuf = sp.sbuf;
+    const size_t blockSize = 4096;
+    const uint8_t* curBlock = sbuf->get_buf();
+    const uint8_t* end = curBlock + sbuf->pagesize;
+    while (curBlock < end) {
+      const size_t len = std::min(blockSize, static_cast<size_t>(end - curBlock));
+      result = yrx_scanner_scan(scanner.get(), curBlock, len);
+      if (result != SUCCESS) {
+        std::cerr << "Failed to scan yara-x: " << yrx_last_error() << std::endl;
+        return;
+      }
+      curBlock += len;
+    }
   }
 }
 #endif


### PR DESCRIPTION
This is currently draft. The idea is to link against the new `yara-x` library with its C API (https://virustotal.github.io/yara-x/docs/api/c/c-/) and then run rules against 4KB-sized chunks contained in each sbuf. Like lightgrep, yara invokes a callback when there's a match on a file, and the name of the matching rule is written out to the feature recorder along with the pos_t of the 4KB block (and, oops, just realized I have a bug here, oh well, it's draft).

What's left to do:
- take yara rules location from a CLI arg
- load yara rules from the CLI arg (finding all .yar files recursively if the path is a directory)
- fix pos_t bug above
- some unit testing
- more error-handling
- outputting the "namespace" of a matching rule along with its identifier
- outputting some more context??
- adding an option to change the block size from 4KB?? (an old Python script called `page_brute` used 4KB)
- documentation??????