### PR TITLE
Fix sbuf bounds contract

### DIFF
--- a/src/TECH_DEBT.md
+++ b/src/TECH_DEBT.md
@@ -681,6 +681,30 @@ The repository move is complete and reduces the cost of maintaining these
 fixes. It does not change their runtime priority or substitute for focused
 regression tests.
 
+## Open issue reconciliation
+
+Issue [#497](https://github.com/simsong/bulk_extractor/issues/497) is the
+parent tracker for the P0 and P1 source findings above. Its sub-issues are
+[#501](https://github.com/simsong/bulk_extractor/issues/501) through
+[#510](https://github.com/simsong/bulk_extractor/issues/510), with one issue
+per independently reviewable finding group. Issue
+[#500](https://github.com/simsong/bulk_extractor/issues/500) separately tracks
+the E01 chunk-level performance investigation: determine whether libewf can
+prove that a chunk contains only zero bytes and skip its decompression without
+changing logical offsets, margins, hashing, checksums, or output.
+
+The open tracker also contains older issues that are clearly technical debt.
+They remain useful supporting or narrower work items and are labeled
+`tech debt`; the audit findings above take precedence where descriptions
+overlap.
+
+| Area | Existing open issues |
+|---|---|
+| Build, dependencies, and portability | [#471](https://github.com/simsong/bulk_extractor/issues/471), [#464](https://github.com/simsong/bulk_extractor/issues/464), [#444](https://github.com/simsong/bulk_extractor/issues/444), [#398](https://github.com/simsong/bulk_extractor/issues/398), [#376](https://github.com/simsong/bulk_extractor/issues/376), [#159](https://github.com/simsong/bulk_extractor/issues/159) |
+| CI and test infrastructure | [#490](https://github.com/simsong/bulk_extractor/issues/490), [#420](https://github.com/simsong/bulk_extractor/issues/420), [#419](https://github.com/simsong/bulk_extractor/issues/419), [#394](https://github.com/simsong/bulk_extractor/issues/394), [#308](https://github.com/simsong/bulk_extractor/issues/308), [#259](https://github.com/simsong/bulk_extractor/issues/259), [#238](https://github.com/simsong/bulk_extractor/issues/238), [#237](https://github.com/simsong/bulk_extractor/issues/237), [#204](https://github.com/simsong/bulk_extractor/issues/204), [#202](https://github.com/simsong/bulk_extractor/issues/202), [#201](https://github.com/simsong/bulk_extractor/issues/201), [#186](https://github.com/simsong/bulk_extractor/issues/186), [#185](https://github.com/simsong/bulk_extractor/issues/185), [#94](https://github.com/simsong/bulk_extractor/issues/94) |
+| Code and runtime maintenance | [#488](https://github.com/simsong/bulk_extractor/issues/488), [#485](https://github.com/simsong/bulk_extractor/issues/485), [#404](https://github.com/simsong/bulk_extractor/issues/404), [#395](https://github.com/simsong/bulk_extractor/issues/395), [#249](https://github.com/simsong/bulk_extractor/issues/249), [#246](https://github.com/simsong/bulk_extractor/issues/246), [#240](https://github.com/simsong/bulk_extractor/issues/240), [#225](https://github.com/simsong/bulk_extractor/issues/225), [#162](https://github.com/simsong/bulk_extractor/issues/162) |
+| Documentation and repository scope | [#476](https://github.com/simsong/bulk_extractor/issues/476), [#424](https://github.com/simsong/bulk_extractor/issues/424), [#264](https://github.com/simsong/bulk_extractor/issues/264), [#139](https://github.com/simsong/bulk_extractor/issues/139) |
+
 ## Remediation checklist
 
 Each unchecked line below identifies one independently reviewable defect or
@@ -691,15 +715,15 @@ appropriate validation.
 
 - [ ] Reject PCAP records whose `caplen` exceeds the buffer allocated from `snaplen`.
 - [ ] Impose a defensible upper bound on input-controlled PCAP `snaplen` allocations.
-- [ ] Make `sbuf_t::memcmp` compare byte zero instead of beginning at byte one.
-- [ ] Make zero-length `sbuf_t::memcmp` return equality without underflowing its length.
-- [ ] Make `sbuf_t::wbuf` reject the one-past-end index `i == bufsize`.
-- [ ] Remove the ineffective negative-index test on unsigned `sbuf_t::wbuf` indexes.
-- [ ] Correct `sbuf_t` slice primary-page arithmetic so an in-page offset reduces `pagesize`.
-- [ ] Make `sbuf_t` slices beginning in the margin have a zero primary-page size instead of an underflowed size.
-- [ ] Prevent `sbuf_t` child constructors from forming pointers beyond the source buffer when an offset is out of range.
-- [ ] Replace overflow-prone `i + width > bufsize` checks in `sbuf_t` integer readers with subtraction-based checked ranges.
-- [ ] Cast bytes to unsigned destination widths before shifting in `sbuf_t` integer readers.
+- [x] Make `sbuf_t::memcmp` compare byte zero instead of beginning at byte one (#502).
+- [x] Make zero-length `sbuf_t::memcmp` return equality without underflowing its length (#502).
+- [x] Make `sbuf_t::wbuf` reject the one-past-end index `i == bufsize` (#502).
+- [x] Remove the ineffective negative-index test on unsigned `sbuf_t::wbuf` indexes (#502).
+- [x] Correct `sbuf_t` slice primary-page arithmetic so an in-page offset reduces `pagesize` (#502).
+- [x] Make `sbuf_t` slices beginning in the margin have a zero primary-page size instead of an underflowed size (#502).
+- [x] Prevent `sbuf_t` child constructors from forming pointers beyond the source buffer when an offset is out of range (#502).
+- [x] Replace overflow-prone `i + width > bufsize` checks in `sbuf_t` integer readers with subtraction-based checked ranges (#502).
+- [x] Cast bytes to unsigned destination widths before shifting in `sbuf_t` integer readers (#502).
 - [ ] Ensure every phase-1 `DiskWriteError` path stops and joins the notification thread without asserting or hanging.
 
 ### P1: ownership, input handling, and advertised features
@@ -749,6 +773,7 @@ appropriate validation.
 - [ ] Replace phase-1 disk-error `exit(1)` calls with structured shutdown and consistent return semantics.
 - [ ] Assign and report `Config::max_wait_time`, or remove the unused `max_minute_wait` option.
 - [ ] Assign `Phase1::image_hash` so the console image-hash result is reachable, or remove the dead output branch.
+- [ ] Investigate chunk-level EWF reads that can skip provably all-zero chunks without decompression while preserving offsets, margins, hashes, checksums, and output (#500).
 - [ ] Add malformed-corpus and fuzz coverage for recursive Base64, gzip, hiberfile, PDF, RAR, XOR, and ZIP decoders.
 - [ ] Replace hostile-input native-structure casts incrementally in ELF, EVTX, EXIF, network, NTFS, Outlook, SQLite, UTMP, WinLNK, WinPE, and WinPrefetch scanners.
 - [ ] Free or transfer ownership of every synthetic EVTX header allocation.

--- a/src/be20_api/sbuf.cpp
+++ b/src/be20_api/sbuf.cpp
@@ -60,10 +60,10 @@ sbuf_t::sbuf_t()
 
 /* from an offset */
 sbuf_t::sbuf_t(const sbuf_t &src, size_t offset):
-    pos0(src.pos0 + (offset < src.bufsize ? offset : src.bufsize)),
-    bufsize( offset < src.bufsize ? src.bufsize - offset : 0),
-    pagesize( offset < src.pagesize ? src.pagesize - offset : 0),
-    parent(&src), buf(src.buf+offset)
+    pos0(src.pos0 + std::min(offset, src.bufsize)),
+    bufsize(offset < src.bufsize ? src.bufsize - offset : 0),
+    pagesize(offset < src.pagesize ? src.pagesize - offset : 0),
+    parent(&src), buf(offset_ptr(src.buf, std::min(offset, src.bufsize)))
 {
     parent->add_child(*this);
     sbuf_total += 1;
@@ -80,10 +80,10 @@ sbuf_t::sbuf_t(const sbuf_t &src, size_t offset):
 
 // start at offset for a given len
 sbuf_t::sbuf_t(const sbuf_t &src, size_t offset, size_t len):
-    pos0(src.pos0 + (offset < src.bufsize ? offset : src.bufsize)),
-    bufsize( offset + len < src.bufsize ? len : (offset > src.bufsize ? 0 : src.bufsize - offset)),
-    pagesize( offset + len < src.pagesize ? len : (offset > src.pagesize ? 0 : src.pagesize - offset)),
-    parent(&src), buf(src.buf+offset)
+    pos0(src.pos0 + std::min(offset, src.bufsize)),
+    bufsize(offset <= src.bufsize ? std::min(len, src.bufsize - offset) : 0),
+    pagesize(offset <= src.pagesize ? std::min(len, src.pagesize - offset) : 0),
+    parent(&src), buf(offset_ptr(src.buf, std::min(offset, src.bufsize)))
 {
     parent->add_child(*this);
     sbuf_total += 1;
@@ -299,24 +299,17 @@ sbuf_t *sbuf_t::realloc(size_t newsize)
  */
 sbuf_t *sbuf_t::new_slice(pos0_t new_pos0, size_t off, size_t len) const
 {
-    if (off > bufsize)     throw range_exception_t(off, len); // check to make sure off is in the buffer
-    if (off+len > bufsize) throw range_exception_t(off, len); // check to make sure off+len is in the buffer
-
-    size_t new_pagesize = pagesize;
-    if (off > pagesize) {
-        new_pagesize -= off;            // we only have this much left
-    }
-    if (new_pagesize > len) {
-        new_pagesize = len;             // we only have this much left
-    }
+    require_range(off, len);
+    const size_t new_pagesize = off < pagesize ? std::min(len, pagesize - off) : 0;
 
     return new sbuf_t(new_pos0, highest_parent(),
-                      buf + off, len, new_pagesize,
+                      offset_ptr(buf, off), len, new_pagesize,
                       NO_FD);
 }
 
 sbuf_t *sbuf_t::new_slice(size_t off, size_t len) const
 {
+    require_range(off, len);
     return new_slice(pos0+off, off, len);
 }
 
@@ -335,29 +328,23 @@ sbuf_t *sbuf_t::new_slice_copy(size_t off, size_t len) const
 
 sbuf_t sbuf_t::slice(size_t off, size_t len) const
 {
-    if (off > bufsize)     throw range_exception_t(off, len); // check to make sure off is in the buffer
-    if (off+len > bufsize) throw range_exception_t(off, len); // check to make sure off+len is in the buffer
-
-    size_t new_pagesize = pagesize;
-    if (off > pagesize) {
-        new_pagesize -= off;            // we only have this much left
-    }
-    if (new_pagesize > len) {
-        new_pagesize = len;             // we only have this much left
-    }
+    require_range(off, len);
+    const size_t new_pagesize = off < pagesize ? std::min(len, pagesize - off) : 0;
 
     return sbuf_t(pos0 + off, highest_parent(),
-                      buf + off, len, new_pagesize,
+                      offset_ptr(buf, off), len, new_pagesize,
                       NO_FD);
 }
 
 sbuf_t *sbuf_t::new_slice(size_t off) const
 {
+    require_range(off, 0);
     return new_slice(off, bufsize - off);
 }
 
 sbuf_t sbuf_t::slice(size_t off) const
 {
+    require_range(off, 0);
     return slice(off, bufsize - off);
 }
 
@@ -433,11 +420,8 @@ void sbuf_t::wbuf(size_t i, uint8_t val)
     if ( buf_writable==nullptr) {
         throw std::runtime_error("Attempt to write to unwritable sbuf");
     }
-    if ( i<0 ){
-        throw std::runtime_error("Attempt to write sbuf i<0");
-    }
-    if ( i>bufsize ){
-        throw std::runtime_error("Attempt to write sbuf i>bufsize");
+    if (i >= bufsize) {
+        throw std::runtime_error("Attempt to write outside sbuf");
     }
     buf_writable[i] = val;
 }

--- a/src/be20_api/sbuf.h
+++ b/src/be20_api/sbuf.h
@@ -31,6 +31,7 @@
  * can move. Added reference_count garbage collection
  */
 
+#include <algorithm>
 #include <atomic>
 #include <cassert>
 #include <cstring>
@@ -292,10 +293,11 @@ public:;
 
     /* Search functions --- memcmp at a particular location */
     int memcmp_unsafe(const uint8_t* cbuf, size_t at, size_t len) const {
-        return ::memcmp(this->buf + at + 1, cbuf + 1 , len - 1);
+        if (len == 0) return 0;
+        return ::memcmp(this->buf + at, cbuf, len);
     }
     int memcmp(const uint8_t* cbuf, size_t at, size_t len) const {
-        if (left(at) < len) throw sbuf_t::range_exception_t(at, len);
+        require_range(at, len);
         return memcmp_unsafe(cbuf, at, len);
     }
 
@@ -312,35 +314,39 @@ public:;
     }
 
     uint8_t get8u(size_t i) const {
-        if (i + 1 > bufsize) throw sbuf_t::range_exception_t(i, 1);
+        require_range(i, 1);
         return get8u_unsafe(i);
     }
 
     uint16_t get16u_unsafe(size_t i) const {
-        return (uint16_t)(this->buf[i + 0] <<  0) | (uint16_t)(this->buf[i + 1] << 8);
+        return static_cast<uint16_t>(this->buf[i]) |
+               static_cast<uint16_t>(static_cast<uint16_t>(this->buf[i + 1]) << 8);
     }
 
     uint16_t get16uBE_unsafe(size_t i) const {
-        return (uint16_t)(this->buf[i + 1] <<  0) | (uint16_t)(this->buf[i + 0] << 8);
+        return static_cast<uint16_t>(this->buf[i + 1]) |
+               static_cast<uint16_t>(static_cast<uint16_t>(this->buf[i]) << 8);
     }
 
     uint16_t get16u(size_t i) const {
-        if (i + 2 > bufsize) throw sbuf_t::range_exception_t(i, 2);
+        require_range(i, 2);
         return get16u_unsafe(i);
     }
 
     uint32_t get32u_unsafe(size_t i) const {
-        return (uint32_t)(this->buf[i + 0] <<  0) | (uint32_t)(this->buf[i + 1] << 8) |
-               (uint32_t)(this->buf[i + 2] << 16) | (uint32_t)(this->buf[i + 3] << 24);
+        return static_cast<uint32_t>(this->buf[i]) |
+               (static_cast<uint32_t>(this->buf[i + 1]) << 8) |
+               (static_cast<uint32_t>(this->buf[i + 2]) << 16) |
+               (static_cast<uint32_t>(this->buf[i + 3]) << 24);
     }
 
     uint32_t get32u(size_t i) const {
-        if (i + 4 > bufsize) throw sbuf_t::range_exception_t(i, 4);
+        require_range(i, 4);
         return get32u_unsafe(i);
     }
 
     uint64_t get64u(size_t i) const {
-        if (i + 8 > bufsize) throw sbuf_t::range_exception_t(i, 8);
+        require_range(i, 8);
         return ((uint64_t)(this->buf[i + 0]) <<  0) | ((uint64_t)(this->buf[i + 1]) <<  8) |
                ((uint64_t)(this->buf[i + 2]) << 16) | ((uint64_t)(this->buf[i + 3]) << 24) |
                ((uint64_t)(this->buf[i + 4]) << 32) | ((uint64_t)(this->buf[i + 5]) << 40) |
@@ -365,23 +371,25 @@ public:;
      * sbuf_range_exception if out of range.
      */
     uint8_t get8uBE(size_t i) const {
-        if (i + 1 > bufsize) throw sbuf_t::range_exception_t(i, 1);
+        require_range(i, 1);
         return this->buf[i];
     }
 
     uint16_t get16uBE(size_t i) const {
-        if (i + 2 > bufsize) throw sbuf_t::range_exception_t(i, 2);
-        return 0 | (uint16_t)(this->buf[i + 1] << 0) | (uint16_t)(this->buf[i + 0] << 8);
+        require_range(i, 2);
+        return get16uBE_unsafe(i);
     }
 
     uint32_t get32uBE(size_t i) const {
-        if (i + 4 > bufsize) throw sbuf_t::range_exception_t(i, 4);
-        return (uint32_t)(this->buf[i + 3] <<  0) | (uint32_t)(this->buf[i + 2] <<  8) |
-               (uint32_t)(this->buf[i + 1] << 16) | (uint32_t)(this->buf[i + 0] << 24);
+        require_range(i, 4);
+        return static_cast<uint32_t>(this->buf[i + 3]) |
+               (static_cast<uint32_t>(this->buf[i + 2]) << 8) |
+               (static_cast<uint32_t>(this->buf[i + 1]) << 16) |
+               (static_cast<uint32_t>(this->buf[i]) << 24);
     }
 
     uint64_t get64uBE(size_t i) const {
-        if (i + 8 > bufsize) throw sbuf_t::range_exception_t(i, 8);
+        require_range(i, 8);
         return ((uint64_t)(this->buf[i + 7]) <<  0) | ((uint64_t)(this->buf[i + 6]) <<  8) |
                ((uint64_t)(this->buf[i + 5]) << 16) | ((uint64_t)(this->buf[i + 4]) << 24) |
                ((uint64_t)(this->buf[i + 3]) << 32) | ((uint64_t)(this->buf[i + 2]) << 40) |
@@ -517,7 +525,7 @@ public:;
     }
 
     template <class TYPE> const TYPE* get_struct_ptr(uint32_t pos) const {
-        if (pos + sizeof(TYPE) <= bufsize) {
+        if (has_range(pos, sizeof(TYPE))) {
             return get_struct_ptr_unsafe<TYPE>(pos);
         }
         return NULL;
@@ -572,6 +580,18 @@ public:;
     mutable std::atomic<uint64_t>    reference_count {0}; // when goes to zero, automatically free
 
 private:
+    bool has_range(size_t off, size_t len) const noexcept {
+        return off <= bufsize && len <= bufsize - off;
+    }
+
+    void require_range(size_t off, size_t len) const {
+        if (!has_range(off, len)) throw range_exception_t(off, len);
+    }
+
+    static const uint8_t* offset_ptr(const uint8_t* ptr, size_t off) noexcept {
+        return off == 0 ? ptr : ptr + off;
+    }
+
     // explicit allocation is only allowed in internal implementation
     explicit sbuf_t(pos0_t pos0_, const sbuf_t *parent_,
                     const uint8_t* buf_, size_t bufsize_, size_t pagesize_,

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -28,6 +28,7 @@
 #include <filesystem>
 #include <functional>
 #include <iostream>
+#include <memory>
 #include <random>
 #include <string>
 #include <csignal>
@@ -540,6 +541,83 @@ TEST_CASE("range_exception", "[sbuf]") {
     catch (const sbuf_t::range_exception_t &e) {
         REQUIRE( std::string("[sbuf_t::range_exception_t: Read past end of sbuf off=100 len=1]") == e.what());
     }
+}
+
+TEST_CASE("sbuf boundary contract", "[sbuf]") {
+    const std::array<uint8_t, 8> bytes{{0x80, 0x01, 0x02, 0xff, 0x04, 0x05, 0x06, 0x87}};
+    const std::array<uint8_t, 8> same = bytes;
+    auto first_diff = bytes;
+    first_diff[0] = 0x81;
+
+    std::unique_ptr<sbuf_t> sbuf(sbuf_t::sbuf_new(pos0_t("bounds"), bytes.data(), bytes.size(), 4));
+
+    SECTION("memcmp checks byte zero and accepts valid empty ranges") {
+        REQUIRE(sbuf->memcmp(same.data(), 0, same.size()) == 0);
+        REQUIRE(sbuf->memcmp(first_diff.data(), 0, first_diff.size()) != 0);
+        REQUIRE(sbuf->memcmp(same.data(), 0, 0) == 0);
+        REQUIRE(sbuf->memcmp(same.data(), sbuf->size(), 0) == 0);
+        REQUIRE_THROWS_AS(sbuf->memcmp(same.data(), sbuf->size() + 1, 0), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->memcmp(same.data(), std::numeric_limits<size_t>::max(), 0), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->memcmp(same.data(), sbuf->size() - 1, 2), sbuf_t::range_exception_t);
+    }
+
+    SECTION("integer readers reject overflowed and one-past-end ranges") {
+        REQUIRE(sbuf->get16u(6) == 0x8706);
+        REQUIRE(sbuf->get16uBE(6) == 0x0687);
+        REQUIRE(sbuf->get32u(0) == 0xff020180);
+        REQUIRE(sbuf->get32uBE(0) == 0x800102ff);
+        REQUIRE(sbuf->get64u(0) == 0x87060504ff020180ULL);
+        REQUIRE(sbuf->get64uBE(0) == 0x800102ff04050687ULL);
+
+        REQUIRE_THROWS_AS(sbuf->get8u(sbuf->size()), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->get16u(sbuf->size() - 1), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->get32u(sbuf->size() - 3), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->get64u(1), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->get32u(std::numeric_limits<size_t>::max()), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->get32uBE(std::numeric_limits<size_t>::max()), sbuf_t::range_exception_t);
+    }
+
+    SECTION("slice page sizes distinguish primary bytes from margins") {
+        auto primary = sbuf->slice(1, 5);
+        REQUIRE(primary.bufsize == 5);
+        REQUIRE(primary.pagesize == 3);
+        REQUIRE(primary.get_buf() == bytes.data() + 1);
+
+        auto margin = sbuf->slice(4, 3);
+        REQUIRE(margin.bufsize == 3);
+        REQUIRE(margin.pagesize == 0);
+        REQUIRE(margin.get_buf() == bytes.data() + 4);
+
+        auto end = sbuf->slice(sbuf->size(), 0);
+        REQUIRE(end.bufsize == 0);
+        REQUIRE(end.pagesize == 0);
+        REQUIRE(end.get_buf() == bytes.data() + bytes.size());
+
+        REQUIRE_THROWS_AS(sbuf->slice(sbuf->size() + 1, 0), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->slice(1, std::numeric_limits<size_t>::max()), sbuf_t::range_exception_t);
+        REQUIRE_THROWS_AS(sbuf->slice(std::numeric_limits<size_t>::max(), 0), sbuf_t::range_exception_t);
+    }
+
+    SECTION("clamping constructors never advance beyond the source") {
+        sbuf_t child(*sbuf, std::numeric_limits<size_t>::max());
+        REQUIRE(child.bufsize == 0);
+        REQUIRE(child.pagesize == 0);
+        REQUIRE(child.get_buf() == bytes.data() + bytes.size());
+
+        sbuf_t bounded(*sbuf, std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max());
+        REQUIRE(bounded.bufsize == 0);
+        REQUIRE(bounded.pagesize == 0);
+        REQUIRE(bounded.get_buf() == bytes.data() + bytes.size());
+    }
+}
+
+TEST_CASE("sbuf writable boundary", "[sbuf]") {
+    std::unique_ptr<sbuf_t> sbuf(sbuf_t::sbuf_malloc(pos0_t("writable"), 2, 2));
+    sbuf->wbuf(0, 0x12);
+    sbuf->wbuf(1, 0x34);
+    REQUIRE(sbuf->get16u(0) == 0x3412);
+    REQUIRE_THROWS_AS(sbuf->wbuf(2, 0x56), std::runtime_error);
+    REQUIRE_THROWS_AS(sbuf->wbuf(std::numeric_limits<size_t>::max(), 0x56), std::runtime_error);
 }
 
 void validate_file(std::filesystem::path path, std::string contents)


### PR DESCRIPTION
## Summary

- centralize overflow-safe `sbuf_t` range validation for comparisons, integer readers, slices, and structure access
- compare byte zero in `memcmp`, define zero-length comparisons, and reject one-past-end writes
- correct slice primary-page arithmetic and prevent out-of-range constructors from forming invalid pointers
- cast bytes before integer shifts and add substantive boundary coverage for exact-end, one-past-end, `SIZE_MAX`, margin, and zero-length cases
- reconcile the audit with GitHub issues and mark the completed `sbuf_t` checklist items in `src/TECH_DEBT.md`

## Root cause

The safety checks were duplicated and mostly expressed as addition-based bounds tests. Those tests could wrap, while the slice page calculation used the wrong inequality. The comparison implementation also advanced both pointers and subtracted one from the requested length, skipping the first byte and underflowing at zero.

## Validation

- `make -j4 check` — 3/3 registered programs pass (`test_be`, `test_be20_api`, `test_dfxml`)
- ASan+UBSan rebuild followed by `make -j4 check TESTS=test_be20_api` — 1/1 passes
- `git diff --check`
- Jean E01 integration regression, first 1 GiB, default scanner set (XOR excluded), target `jean@m57.biz`:
  - pristine `main` and this PR were built with the same Homebrew libewf and ran against the same E01 input.
  - `python/bulk_diff.py --features` found no differences in any reported feature file, including `email.txt`.

Closes #502
Refs #497

_PR drafted and commit authored by Codex AI Assistant._
