### PR TITLE
Stop notifier on phase-one write failures

### DIFF
--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -899,7 +899,7 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp, scanner_t *scanner)
             ar.write(sbuf.pos0, "scanner=" + name, Formatter() << "<exception>" << e.what() << "</exception>");
             ar.flush();
         }
-        catch (feature_recorder_set::NoSuchFeatureRecorder& e2) {
+        catch (...) {
         }
     }
 

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -615,6 +615,9 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     catch ( const feature_recorder::DiskWriteError &e ) {
         notify.stop();
         notify.join();
+        ss.cleanup();                    // Do not generate histograms after a failed write.
+        delete xreport;
+        delete p;
         cerr << "Disk write error during Phase 1 ( scanning). Disk is probably full." << std::endl
              << "Remove extra files and restart bulk_extractor with the exact same command line to continue." << std::endl;
         // do not call ss.shutdown() to avoid writing out histograms

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -630,7 +630,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     }
 
     /*** PHASE 2 --- Shutdown ***/
-    notify.phase = BE_PHASE_2;
+    notify.stop();
     notify.join();
     if ( cfg.opt_notify_main_thread) {
         cout << notify_stream.str();

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -613,6 +613,8 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         ss.join();                          // wait for threads to come together
     }
     catch ( const feature_recorder::DiskWriteError &e ) {
+        notify.stop();
+        notify.join();
         cerr << "Disk write error during Phase 1 ( scanning). Disk is probably full." << std::endl
              << "Remove extra files and restart bulk_extractor with the exact same command line to continue." << std::endl;
         // do not call ss.shutdown() to avoid writing out histograms

--- a/src/notify_thread.cpp
+++ b/src/notify_thread.cpp
@@ -31,6 +31,7 @@ int notify_thread::terminal_width( int default_width )
 
 notify_thread::~notify_thread()
 {
+    stop();
     join();
 }
 
@@ -132,10 +133,14 @@ void notify_thread::start_notify_thread( )
 
 void notify_thread::join()
 {
-    assert( phase!= BE_PHASE_1 );
     if (the_notify_thread != nullptr) {
         the_notify_thread->join();
         delete the_notify_thread;
         the_notify_thread = nullptr;
     }
+}
+
+void notify_thread::stop()
+{
+    phase = BE_PHASE_2;
 }

--- a/src/notify_thread.cpp
+++ b/src/notify_thread.cpp
@@ -121,26 +121,31 @@ void *notify_thread::run()
             }
             os << cd << std::endl << std::endl;
         }
-        std::this_thread::sleep_for( std::chrono::seconds( cfg.opt_notify_rate ));
+        std::unique_lock<std::mutex> lock(Mphase);
+        phase_changed.wait_for(lock, std::chrono::seconds(cfg.opt_notify_rate), [this] {
+            return phase != BE_PHASE_1;
+        });
     }
     return nullptr;
 }
 
 void notify_thread::start_notify_thread( )
 {
-    the_notify_thread = new std::thread( &notify_thread::run, this);    // launch the notify thread
+    if (the_notify_thread.joinable()) {
+        throw std::logic_error("notification thread already started");
+    }
+    the_notify_thread = std::thread(&notify_thread::run, this);
 }
 
 void notify_thread::join()
 {
-    if (the_notify_thread != nullptr) {
-        the_notify_thread->join();
-        delete the_notify_thread;
-        the_notify_thread = nullptr;
+    if (the_notify_thread.joinable()) {
+        the_notify_thread.join();
     }
 }
 
 void notify_thread::stop()
 {
     phase = BE_PHASE_2;
+    phase_changed.notify_all();
 }

--- a/src/notify_thread.h
+++ b/src/notify_thread.h
@@ -35,6 +35,7 @@ public:
     static inline const std::string ESTIMATED_DATE_COMPLETION {"estimated_date_completion"};
 
     void start_notify_thread( );
+    void stop();
     void join();
 };
 

--- a/src/notify_thread.h
+++ b/src/notify_thread.h
@@ -16,7 +16,7 @@ class notify_thread {
     notify_thread() = delete;
     notify_thread(const notify_thread &that) = delete;
     notify_thread &operator=(const notify_thread &that) = delete;
-    std::thread *the_notify_thread {nullptr};
+    std::thread the_notify_thread;
     void *run();
 public:
     notify_thread(std::ostream &os_, scanner_set &ss_, const Phase1::Config &cfg_, aftimer &master_timer_, std::atomic<double> *fraction_done_):
@@ -29,7 +29,8 @@ public:
     aftimer &master_timer;
     std::atomic<double> *fraction_done {};
     std::atomic<int> phase {};
-    std::mutex Mphase {};           // mutex for phase
+    std::mutex Mphase {};
+    std::condition_variable phase_changed;
     static inline const std::string FRACTION_READ {"fraction_read"};
     static inline const std::string ESTIMATED_TIME_REMAINING {"estimated_time_remaining"};
     static inline const std::string ESTIMATED_DATE_COMPLETION {"estimated_date_completion"};

--- a/src/phase1.cpp
+++ b/src/phase1.cpp
@@ -149,7 +149,7 @@ void Phase1::read_process_sbufs()
         si = blocks_to_sample.begin();    // get the new beginning
     } else {
         /* Not sampling */
-        sha1g = new dfxml::sha1_generator();
+        sha1g = std::make_unique<dfxml::sha1_generator>();
     }
     /* Loop over the blocks to sample */
     while(it != p.end()) {
@@ -190,8 +190,7 @@ void Phase1::read_process_sbufs()
                             hash_next += sbufp->pagesize;
 
                         } else {
-                            delete sha1g; // we had a logical gap; stop hashing
-                            sha1g = 0;
+                            sha1g.reset(); // we had a logical gap; stop hashing
                         }
                     }
                     total_bytes += sbufp->pagesize;
@@ -258,7 +257,7 @@ void Phase1::dfxml_write_source()
     if (sha1g){
         dfxml::sha1_t sha1 = sha1g->digest();
         xreport.xmlout("hashdigest",sha1.hexdigest(),"type='SHA1'",false);
-        delete sha1g;
+        sha1g.reset();
     }
     xreport.pop("source");			// source
     xreport.flush();

--- a/src/phase1.cpp
+++ b/src/phase1.cpp
@@ -153,15 +153,10 @@ void Phase1::read_process_sbufs()
     }
     /* Loop over the blocks to sample */
     while(it != p.end()) {
-        /* If there is a disk write error, shut down */
+        /* A worker recorded a disk-write error. Let the caller stop the notifier. */
         if (ss.disk_write_errors > 0 ){
-            for(int i=0;i<5;i++){
-                std::cerr << std::endl;
-            }
-            std::cerr << "*** DISK WRITE ERRORS (" << ss.disk_write_errors << ") ***" << std::endl;
-            std::cerr << "Disk is likely full. Clear space and restart (press up arrow) " << std::endl;
-	    std::cerr << "Check alerts.txt for further info" << std::endl;
-            exit(1);
+            ss.join();
+            throw feature_recorder::DiskWriteError("while scanning input");
         }
 
         if (sampling()){                // if sampling, seek the iterator
@@ -296,6 +291,9 @@ void Phase1::phase1_run()
 
     if (!config.opt_quiet) cout << "All data read; waiting for threads to finish..." << std::endl;
     ss.join();
+    if (ss.disk_write_errors > 0) {
+        throw feature_recorder::DiskWriteError("while scanning input");
+    }
     xreport.pop("runtime");
     dfxml_write_source();               // written here so it may also include hash
 }

--- a/src/phase1.h
+++ b/src/phase1.h
@@ -3,6 +3,7 @@
 
 #include <thread>
 #include <atomic>
+#include <memory>
 #include <ostream>
 
 #include "be20_api/scanner_set.h"
@@ -84,7 +85,7 @@ public:
 
     u_int         notify_ctr  {0};      // for random sampling
     uint64_t      total_bytes {0};      // processed
-    dfxml::sha1_generator *sha1g {nullptr};        // the SHA1 of the image. Set to 0 if a gap is encountered
+    std::unique_ptr<dfxml::sha1_generator> sha1g;  // the SHA1 of the image. Reset if a gap is encountered
     uint64_t      hash_next {0};        // next byte to hash, to detect gaps
     std::string   image_hash {};          // when hashed, the image hash
     dfxml_writer &xreport;              // we always write out the DFXML. Allows restart to be handled in phase1

--- a/src/scan_email.flex
+++ b/src/scan_email.flex
@@ -399,6 +399,10 @@ void scan_email(struct scanner_params &sp)
         catch (sbuf_scanner::sbuf_scanner_exception &e ) {
             std::cerr << "Scanner " << SCANNER << "Exception " << e.what() << " processing " << sp.sbuf->pos0 << "\n";
         }
+        catch (...) {
+            yyemail_lex_destroy(scanner);
+            throw;
+        }
         yyemail_lex(scanner);           // cleanup at end
         yyemail_lex_destroy(scanner);
 	(void)yyunput;			// avoids defined but not used

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -106,26 +106,6 @@ TEST_CASE("sbuf_no_copy", "[threads]") {
     }
 }
 
-TEST_CASE("notify_thread_stops_during_phase_one", "[threads]")
-{
-    feature_recorder_set::flags_t flags;
-    scanner_config sc;
-    sc.outdir = NamedTemporaryDirectory();
-    auto report = std::make_unique<dfxml_writer>(sc.outdir / "report.xml", false);
-    scanner_set ss(sc, flags, report.get());
-    Phase1::Config cfg;
-    cfg.opt_legacy = true;
-    aftimer timer;
-    std::atomic<double> fraction_done {0.0};
-    std::ostringstream output;
-
-    notify_thread notify(output, ss, cfg, timer, &fraction_done);
-    notify.phase = BE_PHASE_1;
-    notify.start_notify_thread();
-    notify.stop();
-    notify.join();
-}
-
 /****************************************************************/
 
 

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -44,6 +44,7 @@
 #include "image_process.h"
 #include "jpeg_validator.h"
 #include "phase1.h"
+#include "notify_thread.h"
 #include "sbuf_decompress.h"
 #include "scan_aes.h"
 #include "scan_base64.h"
@@ -103,6 +104,26 @@ TEST_CASE("sbuf_no_copy", "[threads]") {
         sbuf_buf_loc = sbuf->get_buf();
         test_process_sbuf(sbuf);
     }
+}
+
+TEST_CASE("notify_thread_stops_during_phase_one", "[threads]")
+{
+    feature_recorder_set::flags_t flags;
+    scanner_config sc;
+    sc.outdir = NamedTemporaryDirectory();
+    auto report = std::make_unique<dfxml_writer>(sc.outdir / "report.xml", false);
+    scanner_set ss(sc, flags, report.get());
+    Phase1::Config cfg;
+    cfg.opt_legacy = true;
+    aftimer timer;
+    std::atomic<double> fraction_done {0.0};
+    std::ostringstream output;
+
+    notify_thread notify(output, ss, cfg, timer, &fraction_done);
+    notify.phase = BE_PHASE_1;
+    notify.start_notify_thread();
+    notify.stop();
+    notify.join();
 }
 
 /****************************************************************/

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -16,6 +16,12 @@
 #include <filesystem>
 #include <cstdio>
 #include <stdexcept>
+#ifdef HAVE_SYS_RESOURCE_H
+#include <sys/resource.h>
+#endif
+#ifdef HAVE_SIGNAL_H
+#include <signal.h>
+#endif
 #include <unistd.h>
 #include <string>
 #include <string_view>
@@ -89,6 +95,39 @@ int run_be(std::ostream &ss, const char **argv)
 {
     return run_be(ss, ss, argv);
 }
+
+#if defined(HAVE_SYS_RESOURCE_H) && defined(HAVE_SIGNAL_H)
+class file_size_limit {
+    struct rlimit old_limit {};
+    struct sigaction old_action {};
+public:
+    file_size_limit()
+    {
+        if (getrlimit(RLIMIT_FSIZE, &old_limit) != 0) {
+            throw std::runtime_error("getrlimit(RLIMIT_FSIZE) failed");
+        }
+        struct sigaction action {};
+        action.sa_handler = SIG_IGN;
+        sigemptyset(&action.sa_mask);
+        if (sigaction(SIGXFSZ, &action, &old_action) != 0) {
+            throw std::runtime_error("sigaction(SIGXFSZ) failed");
+        }
+
+        struct rlimit limit = old_limit;
+        limit.rlim_cur = 0;
+        if (setrlimit(RLIMIT_FSIZE, &limit) != 0) {
+            sigaction(SIGXFSZ, &old_action, nullptr);
+            throw std::runtime_error("setrlimit(RLIMIT_FSIZE) failed");
+        }
+    }
+
+    ~file_size_limit()
+    {
+        setrlimit(RLIMIT_FSIZE, &old_limit);
+        sigaction(SIGXFSZ, &old_action, nullptr);
+    }
+};
+#endif
 
 /****************************************************************
  * Test process_dir
@@ -207,6 +246,26 @@ TEST_CASE("e2e-0", "[end-to-end]") {
     /* make sure that both tags ended up in the second XML file (the one created from restarting) */
     grep( "debug:work_start", xml_file);
     grep( "debug:work_stop", xml_file);
+}
+
+TEST_CASE("e2e-disk-write-error-stops-notifier", "[end-to-end]") {
+#if defined(HAVE_SYS_RESOURCE_H) && defined(HAVE_SIGNAL_H)
+    std::filesystem::path inpath = test_dir() / "nps-2010-emails.100k.raw";
+    std::filesystem::path outdir = NamedTemporaryDirectory();
+    std::string inpath_string = inpath.string();
+    std::string outdir_string = outdir.string();
+    std::stringstream cout, cerr;
+
+    {
+        file_size_limit disk_full;
+        const char *argv[] = {"bulk_extractor", "--notify_async", "-0q", "-x", "all", "-e", "email",
+                              "-o", outdir_string.c_str(), inpath_string.c_str(), nullptr};
+        REQUIRE(run_be(cout, cerr, argv) == 6);
+    }
+    REQUIRE(cerr.str().find("Disk write error during Phase 1") != std::string::npos);
+#else
+    SUCCEED("This platform has no file-size resource limit.");
+#endif
 }
 
 /*


### PR DESCRIPTION
## Summary

- replace the heap-owned notifier thread with a value-owned `std::thread` and make `stop()` wake it immediately
- on phase-one disk-write failure, join workers, propagate `DiskWriteError` to `bulk_extractor_main`, then explicitly stop and join the notifier before returning 6
- prevent a failed attempt to write `alerts.txt` from escaping a scanner worker and terminating the process
- clean up scanner state, the DFXML writer, and the image reader on the return-6 path without generating histograms
- destroy per-buffer email Flex scanner state before a disk-write exception propagates
- make Phase1 SHA-1 state owned so any phase-one exception frees it
- replace the synthetic notifier lifecycle test with an end-to-end regression that causes a real OS file-size write failure while the email scanner and asynchronous notifier are running

## Root cause

The existing scanner path counted a `DiskWriteError`, then `Phase1` called `exit(1)` rather than reaching `bulk_extractor_main`'s return-6 handler. A second write failure while recording the alert could escape from a worker thread and call `std::terminate`. The early return and exception paths bypassed several cleanup operations, which the new regression exposed under LeakSanitizer.

## Validation

- `make -C src check TESTS=test_be` — passes, including `e2e-disk-write-error-stops-notifier`
- `make -j4 check` — `test_be` and `test_dfxml` pass; the unrelated `test_be20_api::machine_stats` check fails in this sandbox because macOS denies `/bin/ps`, yielding NaN CPU usage
- GitHub Actions is running the updated ASan and platform matrix.

Closes #503

_PR authored by Codex AI Assistant._