### PR TITLE
Run AddressSanitizer once per pull request

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,18 +46,10 @@ jobs:
         run: bash bootstrap.sh
 
       - name: AddressSanitizer debug build and tests
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-22.04'
         run: |
           source "$HOME/.bashrc"
           ./configure --disable-opt --enable-address-sanitizer
-          make $MAKE_OPTS all
-          make -C src $MAKE_OPTS bulk_extractor
-          make -C src check || (cat src/test-suite.log; exit 1)
-          make distclean
-
-      - name: AddressSanitizer optimized build and tests
-        run: |
-          source "$HOME/.bashrc"
-          ./configure --enable-address-sanitizer --enable-silent-rules --quiet
           make $MAKE_OPTS all
           make -C src $MAKE_OPTS bulk_extractor
           make -C src check || (cat src/test-suite.log; exit 1)


### PR DESCRIPTION
## Summary

- run the AddressSanitizer debug build exactly once per pull request, on Ubuntu 22.04
- remove the duplicate optimized AddressSanitizer run
- retain the regular build matrix and distribution check on macOS, Ubuntu 22.04, and Ubuntu latest

## Validation

- `git diff --check`

_PR authored by Codex AI Assistant._
