### PR TITLE
Make E01 and split-image input selection safe

### DIFF
--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -502,7 +502,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         }
     }
 
-    image_process *p = nullptr;
+    std::unique_ptr<image_process> p;
     try {
         p = image_process::open( sc.input_fname, cfg.opt_recurse, cfg.opt_pagesize, cfg.opt_marginsize );
     }
@@ -522,7 +522,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     /* are we supposed to run the path printer? If so, we can use cout_, since the notify stream won't be running. */
     if ( result.count( "path" ) ) {
         std::string opt_path = result["path"].as<std::string>();
-        path_printer pp( ss, p, cout);
+        path_printer pp( ss, p.get(), cout);
         if ( opt_path=="-http" || opt_path=="--http" ){
             pp.process_http( std::cin);
         } else if ( opt_path=="-i" || opt_path=="-" ){
@@ -530,7 +530,6 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         } else {
             pp.process_path( opt_path);
         }
-        delete p;
 	return 0;
     }
 
@@ -737,8 +736,6 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
     delete xreport;                     // no longer needed
     xreport=nullptr;                    // and zero it out.
-    delete p;
-    p = nullptr;
 
     muntrace();
     return( 0 );

--- a/src/image_process.cpp
+++ b/src/image_process.cpp
@@ -77,18 +77,25 @@ bool image_process::is_multipart_file(std::filesystem::path fn)
 	|| fn_ends_with(fn,"001.vmdk");
 }
 
-/* Given a disk image name, if it contains 000 or 001 replace that with a %03d to make an snprintf template */
-std::string image_process::make_list_template(std::filesystem::path path_,int *start)
+int image_process::multipart_number(const std::filesystem::path &path)
 {
-    /* First find where the digits are */
-    std::string path(path_.string());
-    size_t p = path.rfind("000");
-    if (p==std::string::npos) p = path.rfind("001");
+    const std::string name = path.filename().string();
+    size_t p = name.rfind("000");
+    if (p == std::string::npos) p = name.rfind("001");
     assert(p!=std::string::npos);
+    return std::stoi(name.substr(p, 3));
+}
 
-    *start = atoi(path.substr(p,3).c_str()) + 1;
-    path.replace(p,3,"%03d");	// make it a format
-    return path;
+std::filesystem::path image_process::multipart_filename(const std::filesystem::path &path, int number)
+{
+    std::string name = path.filename().string();
+    size_t p = name.rfind("000");
+    if (p == std::string::npos) p = name.rfind("001");
+    assert(p != std::string::npos);
+    std::string segment = std::to_string(number);
+    if (segment.size() < 3) { segment.insert(0, 3 - segment.size(), '0'); }
+    name.replace(p, 3, segment);
+    return path.parent_path() / name;
 }
 
 
@@ -520,15 +527,11 @@ int process_raw::open()
 
     /* Get the list of the files if this is a split-raw file */
     if (is_multipart_file(image_fname())){
-	int num=0;
-        std::string templ = make_list_template(image_fname(),&num);
-	for(;;num++){
-	    char probename[PATH_MAX];
-	    snprintf(probename, sizeof(probename), templ.c_str(), num);
-            std::filesystem::path probe_path = probename;
+	for(int num = multipart_number(image_fname()) + 1;;num++){
+            const std::filesystem::path probe_path = multipart_filename(image_fname(), num);
             // If the file exists, add it, otherwise break.
-            if (std::filesystem::exists( std::filesystem::path( probename ))) {
-                add_file(std::filesystem::path(probename));
+            if (std::filesystem::exists(probe_path)) {
+                add_file(probe_path);
             } else {
                 break;
             }
@@ -812,9 +815,9 @@ uint64_t process_dir::seek_block(class image_process::iterator &it,uint64_t bloc
  ****************************************************************/
 /* Static function */
 
-image_process *image_process::open(std::filesystem::path fn, bool opt_recurse, size_t pagesize_, size_t margin_)
+std::unique_ptr<image_process> image_process::open(std::filesystem::path fn, bool opt_recurse, size_t pagesize_, size_t margin_)
 {
-    image_process *ip = 0;
+    std::unique_ptr<image_process> ip;
     std::string fname_string = fn.string();
 
     if ( std::filesystem::exists(fn) == false ){
@@ -831,13 +834,15 @@ image_process *image_process::open(std::filesystem::path fn, bool opt_recurse, s
          * If so, give the user an error.
          */
         for( const auto &p : std::filesystem::directory_iterator( fn )){
-            if ( p.path().extension()==".E01" ||
+            std::string ext = p.path().extension().string();
+            std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) { return std::tolower(ch); });
+            if ( ext==".e01" ||
                  p.path().extension()==".000" ||
                  p.path().extension()==".001") {
                 throw FoundDiskImage( fname_string );
             }
         }
-	ip = new process_dir(fn);
+	ip = std::make_unique<process_dir>(fn);
     }
     else {
 	/* Otherwise open a file by checking extension.
@@ -848,16 +853,16 @@ image_process *image_process::open(std::filesystem::path fn, bool opt_recurse, s
 	 */
 
         std::string ext = fn.extension().string();
-	std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
-	if (ext=="e01" || fname_string.find(".E01")!=std::string::npos){
+        std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char ch) { return std::tolower(ch); });
+	if (ext==".e01"){
 #ifdef HAVE_LIBEWF
-	    ip = new process_ewf(fn, pagesize_, margin_);
+	    ip = std::make_unique<process_ewf>(fn, pagesize_, margin_);
 #else
 	    throw NoSupport("This program was compiled without E01 support");
 #endif
-	}
+        }
 	if (ip==nullptr) {
-            ip = new process_raw(fn, pagesize_, margin_);
+            ip = std::make_unique<process_raw>(fn, pagesize_, margin_);
         }
     }
     /* Try to open it */

--- a/src/image_process.h
+++ b/src/image_process.h
@@ -69,7 +69,8 @@ public:
 
     static bool fn_ends_with(std::filesystem::path str,std::string suffix);
     static bool is_multipart_file(std::filesystem::path fn);
-    static std::string make_list_template(std::filesystem::path fn,int *start);
+    static int multipart_number(const std::filesystem::path &fn);
+    static std::filesystem::path multipart_filename(const std::filesystem::path &fn, int number);
 
     struct EndOfImage : public std::exception {
         EndOfImage(){};
@@ -108,7 +109,7 @@ public:
      * open() figures out which child class to call, calls its open, then
      * returns an object.
      */
-    static image_process *open(std::filesystem::path fn, bool recurse, size_t opt_pagesize, size_t opt_margin);
+    static std::unique_ptr<image_process> open(std::filesystem::path fn, bool recurse, size_t opt_pagesize, size_t opt_margin);
     const size_t pagesize;                    // page size we are using
     const size_t margin;                      // margin size we are using
     bool  report_read_errors;

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -247,7 +247,6 @@ std::filesystem::path validate(std::string image_fname, std::vector<Check> &expe
             assert (ss.get_threading() == false);
             ss.phase_scan();
             phase1.phase1_run();
-            delete p;
         } catch (image_process::NoSuchFile &e) {
             std::cerr << "sc.input_fname=" << sc.input_fname << " no such file: " << e.what() << std::endl;
             bool file_found=false;

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -109,7 +109,7 @@ TEST_CASE("process_dir", "[process_dir]") {
     REQUIRE( ret==6 );
 
     /* This should return the jpegs */
-    image_process *p = nullptr;
+    std::unique_ptr<image_process> p;
     try {
         p = image_process::open( test_dir() / "jpegs", true, 65536, 65536);
     }
@@ -133,7 +133,6 @@ TEST_CASE("process_dir", "[process_dir]") {
         pos0_t pos0 = it.get_pos0();
         REQUIRE( pos0.str().find(".jpg") != std::string::npos );
     }
-    delete p;
 }
 
 
@@ -472,7 +471,7 @@ TEST_CASE("restarter", "[restarter]") {
 
 /****************************************************************/
 TEST_CASE("image_process", "[phase1]") {
-    image_process *p = nullptr;
+    std::unique_ptr<image_process> p;
     REQUIRE_THROWS_AS( p = image_process::open( "no-such-file", false, 65536, 65536), image_process::NoSuchFile);
     REQUIRE_THROWS_AS( p = image_process::open( "no-such-file", false, 65536, 65536), image_process::NoSuchFile);
     p = image_process::open( test_dir() / "test_json.txt", false, 65536, 65536);
@@ -489,7 +488,23 @@ TEST_CASE("image_process", "[phase1]") {
         times += 1;
     }
     REQUIRE(times==1);
-    delete p;
+
+    const std::filesystem::path split_dir = NamedTemporaryDirectory();
+    const std::filesystem::path split0 = split_dir / "split%image.000";
+    const std::filesystem::path split1 = split_dir / "split%image.001";
+    {
+        std::ofstream(split0, std::ios::binary) << "a";
+        std::ofstream(split1, std::ios::binary) << "bc";
+    }
+    auto split = image_process::open(split0, false, 65536, 65536);
+    REQUIRE(split->image_size() == 3);
+
+    const std::filesystem::path e01_dir = NamedTemporaryDirectory();
+    const std::filesystem::path lower_e01 = e01_dir / "CFReDS001.e01";
+    std::filesystem::copy_file(test_dir() / "CFReDS001.E01", lower_e01);
+    auto e01 = image_process::open(lower_e01, false, 65536, 65536);
+    REQUIRE(e01 != nullptr);
+    REQUIRE_THROWS_AS(image_process::open(e01_dir, true, 65536, 65536), image_process::FoundDiskImage);
 }
 
 /****************************************************************
@@ -505,9 +520,9 @@ TEST_CASE("path-printer1", "[path_printer]") {
     ss.add_scanners(scanners_builtin);
     ss.apply_scanner_commands();
 
-    image_process *reader = image_process::open( sc.input_fname, false, 65536, 65536 );
+    auto reader = image_process::open( sc.input_fname, false, 65536, 65536 );
     std::stringstream str;
-    class path_printer pp(ss, reader, str);
+    class path_printer pp(ss, reader.get(), str);
     pp.process_path("512-GZIP-0/h");    // create a hex dump
 
     REQUIRE(str.str() == "0000: 6865 6c6c 6f40 776f 726c 642e 636f 6d0a hello@world.com.\n");
@@ -515,5 +530,4 @@ TEST_CASE("path-printer1", "[path_printer]") {
 
     pp.process_path("512-GZIP-2/r");    // create a hex dump with a different path and the /r
     REQUIRE( str.str() == "14\r\nllo@world.com\n" );
-    delete reader;
 }


### PR DESCRIPTION
Closes #508.

This removes the only user-path-derived `snprintf` call. Split image paths are now constructed by replacing just the terminal segment number with ordinary string and filesystem operations, so literal percent characters are safe.

It also normalizes E01 extension handling for individual files and recursive-directory detection, and changes `image_process::open` to return `std::unique_ptr`, so failed opens cannot leak a partially created reader.

Tests cover a literal-percent split filename, a lowercase copy of the real E01 fixture, and lowercase-E01 directory detection.

Validation: `make -s -j4 -C src check TESTS=test_be` passed.

_Codex-authored PR._