### PR TITLE
Handle short image reads

### DIFF
--- a/src/image_process.cpp
+++ b/src/image_process.cpp
@@ -46,6 +46,14 @@
  *** static functions
  ****************************************************************/
 
+static sbuf_t *shrink_sbuf(sbuf_t *sbuf, const pos0_t &pos0, size_t pagesize, size_t bytes_read)
+{
+    auto *short_sbuf = sbuf_t::sbuf_malloc(pos0, bytes_read, std::min(pagesize, bytes_read));
+    memcpy(short_sbuf->malloc_buf(), sbuf->malloc_buf(), bytes_read);
+    delete sbuf;
+    return short_sbuf;
+}
+
 image_process::image_process(std::filesystem::path fn, size_t pagesize_, size_t margin_):
     image_fname_(fn),pagesize(pagesize_),margin(margin_),report_read_errors(true)
 {
@@ -302,6 +310,11 @@ sbuf_t *process_ewf::sbuf_alloc(image_process::iterator &it) const
         this_pagesize = count;
     }
 
+    if (count==0){
+        it.eof = true;
+        return nullptr;
+    }
+
     auto sbuf = sbuf_t::sbuf_malloc(get_pos0(it), count, this_pagesize);
     unsigned char *buf = static_cast<unsigned char *>(sbuf->malloc_buf());
     int count_read = this->pread(buf, count, it.raw_offset);
@@ -309,10 +322,13 @@ sbuf_t *process_ewf::sbuf_alloc(image_process::iterator &it) const
         delete sbuf;
 	throw read_error();
     }
-    if (count==0){
+    if (count_read==0){
         delete sbuf;
 	it.eof = true;
-	return 0;
+	return nullptr;
+    }
+    if (static_cast<size_t>(count_read) < count){
+        return shrink_sbuf(sbuf, get_pos0(it), this_pagesize, count_read);
     }
     return sbuf;
 }
@@ -582,6 +598,7 @@ ssize_t process_raw::pread(void *buf, size_t bytes, uint64_t offset) const
 #endif
 
 
+    fi->stream.clear();
     fi->stream.seekg( file_offset );
     if (fi->stream.rdstate() & (std::ios::failbit|std::ios::badbit)){
         throw SeekError();
@@ -592,20 +609,20 @@ ssize_t process_raw::pread(void *buf, size_t bytes, uint64_t offset) const
     fi->stream.read(reinterpret_cast<char *>(buf), bytes_to_read);
     t.stop();
 
-    if (fi->stream.rdstate() & std::ios::failbit){
-        std::cerr << "read error  failbit bytes=" << bytes << std::endl;
-        throw ReadError();
-    }
+    const auto state = fi->stream.rdstate();
+    const auto bytes_read = fi->stream.gcount();
     if (fi->stream.rdstate() & std::ios::badbit){
         std::cerr << "read error  badbit bytes=" << bytes << std::endl;
         throw ReadError();
     }
-    if (fi->stream.rdstate() & (std::ios::eofbit)){
-        std::cerr << "read error  eof bytes=" << bytes << std::endl;
-        throw EndOfImage();
+    if (bytes_read < static_cast<std::streamsize>(bytes_to_read)){
+        if (!(state & std::ios::eofbit)){
+            std::cerr << "read error  short read bytes=" << bytes << std::endl;
+            throw ReadError();
+        }
+        fi->stream.clear();
+        return bytes_read;
     }
-
-    size_t bytes_read = bytes_to_read;  // guess we got the right amount
 
     /* Need to recurse, which will cause the next segment to be loaded */
     if (bytes_read==bytes) return bytes_read; // read precisely the correct amount!
@@ -686,6 +703,9 @@ sbuf_t *process_raw::sbuf_alloc(image_process::iterator &it) const
     if (count_read<0){
         delete sbuf;
 	throw read_error();
+    }
+    if (static_cast<size_t>(count_read) < count){
+        return shrink_sbuf(sbuf, get_pos0(it), this_pagesize, count_read);
     }
     return sbuf;
 }

--- a/src/image_process.cpp
+++ b/src/image_process.cpp
@@ -625,7 +625,7 @@ ssize_t process_raw::pread(void *buf, size_t bytes, uint64_t offset) const
     }
 
     /* Need to recurse, which will cause the next segment to be loaded */
-    if (bytes_read==bytes) return bytes_read; // read precisely the correct amount!
+    if (static_cast<size_t>(bytes_read)==bytes) return bytes_read; // read precisely the correct amount!
     if (bytes_read==0) return 0;              // This might happen at the end of the image; it prevents infinite recursion
     ssize_t bytes_read2 = this->pread(static_cast<char *>(buf)+bytes_read, bytes-bytes_read, offset+bytes_read);
     if (bytes_read2<0) return -1;	// error on second read

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -598,17 +598,22 @@ TEST_CASE("image_process short raw read", "[phase1]") {
 #ifdef HAVE_LIBEWF
 TEST_CASE("image_process short EWF read", "[phase1]") {
     class partial_ewf_reader final : public process_ewf {
+        size_t max_read;
+
     public:
-        using process_ewf::process_ewf;
+        partial_ewf_reader(std::filesystem::path image, size_t page_size, size_t margin, size_t max_read_)
+            : process_ewf(image, page_size, margin), max_read(max_read_) {}
 
         ssize_t pread(void *buf, size_t bytes, uint64_t offset) const override {
-            return process_ewf::pread(buf, std::min(bytes, size_t(2048)), offset);
+            if (max_read == 0) return 0;
+            return process_ewf::pread(buf, std::min(bytes, max_read), offset);
         }
     };
 
     constexpr size_t page_size = 4096;
     constexpr size_t short_size = 2048;
-    partial_ewf_reader reader(test_dir() / "CFReDS001.E01", page_size, page_size);
+    const auto image = test_dir() / "CFReDS001.E01";
+    partial_ewf_reader reader(image, page_size, page_size, short_size);
     REQUIRE(reader.open() == 0);
 
     std::vector<uint8_t> expected(short_size);
@@ -623,6 +628,12 @@ TEST_CASE("image_process short EWF read", "[phase1]") {
     auto end = reader.end();
     REQUIRE(end.sbuf_alloc() == nullptr);
     REQUIRE(end.eof);
+
+    partial_ewf_reader eof_reader(image, page_size, page_size, 0);
+    REQUIRE(eof_reader.open() == 0);
+    auto eof = eof_reader.begin();
+    REQUIRE(eof.sbuf_alloc() == nullptr);
+    REQUIRE(eof.eof);
 }
 #endif
 

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <filesystem>
@@ -565,6 +566,33 @@ TEST_CASE("image_process", "[phase1]") {
     REQUIRE(e01 != nullptr);
     REQUIRE_THROWS_AS(image_process::open(e01_dir, true, 65536, 65536), image_process::FoundDiskImage);
 }
+
+#if defined(__linux__)
+// Linux makes truncation visible to an already-open descriptor.  APFS retains
+// the old view, so this real short-read test cannot run on macOS.
+TEST_CASE("image_process short raw read", "[phase1]") {
+    constexpr size_t page_size = 128 * 1024;
+    constexpr size_t image_size = 4 * page_size;
+    constexpr size_t short_size = page_size + page_size / 2;
+    const auto dir = NamedTemporaryDirectory();
+    const auto image = dir / "short.raw";
+    {
+        std::ofstream out(image, std::ios::binary);
+        out << std::string(image_size, 'a');
+    }
+
+    process_raw reader(image, page_size, page_size);
+    REQUIRE(reader.open() == 0);
+    std::filesystem::resize_file(image, short_size);
+    REQUIRE(std::filesystem::file_size(image) == short_size);
+
+    auto it = reader.begin();
+    std::unique_ptr<sbuf_t> sbuf(it.sbuf_alloc());
+    REQUIRE(sbuf->bufsize == short_size);
+    REQUIRE(sbuf->pagesize == page_size);
+    REQUIRE(sbuf->asString() == std::string(short_size, 'a'));
+}
+#endif
 
 /****************************************************************
  ** Test the path printer

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <string_view>
 #include <sstream>
+#include <vector>
 
 #include "be20_api/catch.hpp"
 
@@ -591,6 +592,37 @@ TEST_CASE("image_process short raw read", "[phase1]") {
     REQUIRE(sbuf->bufsize == short_size);
     REQUIRE(sbuf->pagesize == page_size);
     REQUIRE(sbuf->asString() == std::string(short_size, 'a'));
+}
+#endif
+
+#ifdef HAVE_LIBEWF
+TEST_CASE("image_process short EWF read", "[phase1]") {
+    class partial_ewf_reader final : public process_ewf {
+    public:
+        using process_ewf::process_ewf;
+
+        ssize_t pread(void *buf, size_t bytes, uint64_t offset) const override {
+            return process_ewf::pread(buf, std::min(bytes, size_t(2048)), offset);
+        }
+    };
+
+    constexpr size_t page_size = 4096;
+    constexpr size_t short_size = 2048;
+    partial_ewf_reader reader(test_dir() / "CFReDS001.E01", page_size, page_size);
+    REQUIRE(reader.open() == 0);
+
+    std::vector<uint8_t> expected(short_size);
+    REQUIRE(reader.process_ewf::pread(expected.data(), expected.size(), 0) == short_size);
+
+    auto it = reader.begin();
+    std::unique_ptr<sbuf_t> sbuf(it.sbuf_alloc());
+    REQUIRE(sbuf->bufsize == short_size);
+    REQUIRE(sbuf->pagesize == short_size);
+    REQUIRE(sbuf->asString() == std::string(expected.begin(), expected.end()));
+
+    auto end = reader.end();
+    REQUIRE(end.sbuf_alloc() == nullptr);
+    REQUIRE(end.eof);
 }
 #endif
 


### PR DESCRIPTION
Codex-authored fix for #507.

Closes #507

## What changed

- Treat a positive raw-image short read as the actual buffer length rather than scanning the unread allocation tail.
- Apply the same safe sbuf construction to EWF short reads and EOF.
- Preserve the logical page size when a page plus margin is shortened.

## Validation

- `make -s -j4 -C src check TESTS=test_be`
- The Linux test truncates an already-open raw image and verifies the reader exposes only the actual bytes. APFS retains the original view on an open descriptor, so that platform cannot reproduce this real short-read condition.