### PR TITLE
Let the image reader clean up on disk errors

### DIFF
--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -616,7 +616,6 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         notify.join();
         ss.cleanup();                    // Do not generate histograms after a failed write.
         delete xreport;
-        delete p;
         cerr << "Disk write error during Phase 1 ( scanning). Disk is probably full." << std::endl
              << "Remove extra files and restart bulk_extractor with the exact same command line to continue." << std::endl;
         // do not call ss.shutdown() to avoid writing out histograms


### PR DESCRIPTION
Codex-authored compile repair for the current `main` branch.

## What changed

Remove the invalid `delete` of the `std::unique_ptr<image_process>` in the DiskWriteError path. The automatic destructor releases the reader when that path returns.

## Why

The merged E01 input change converted the reader to `std::unique_ptr`; the stale manual delete prevents current main from compiling with Clang.

## Validation

`make -s -j4 -C src check TESTS=test_be` (66 tests, 100,444 assertions).