### PR TITLE
Remove unsupported runtime scanner loading

### DIFF
--- a/doc/ROADMAP_2.0.md
+++ b/doc/ROADMAP_2.0.md
@@ -1,3 +1,5 @@
+> Historical planning document (2022). It does not describe the current 2.x implementation. In particular, bulk_extractor has no runtime scanner plug-in system; scanners are compiled into the executable.
+
 Bulk Extractor 2.0.   Planned Release: January 1, 2022
 =========================================================
 
@@ -321,4 +323,3 @@ See Also
 ========
 
 https://github.com/simsong/bulk_extractor/issues
-

--- a/doc/latex_manuals/BETheoryOfOperation.tex
+++ b/doc/latex_manuals/BETheoryOfOperation.tex
@@ -97,6 +97,8 @@
 
 \maketitle % Print the title
 
+\noindent\fbox{\parbox{0.95\linewidth}{\textbf{Historical document.} This fact sheet describes bulk_extractor 1.x. bulk_extractor 2.x has no runtime scanner plug-in ABI or shared-library loader; its scanners are compiled into the executable.}}
+
 \thispagestyle{fancy} % Enabling the custom headers/footers for the first page 
 
 %----------------------------------------------------------------------------------------

--- a/doc/latex_manuals/BEUsage.txt
+++ b/doc/latex_manuals/BEUsage.txt
@@ -1,3 +1,5 @@
+Historical bulk_extractor 1.5.0 help text. It does not describe 2.x; in particular, 2.x has no runtime scanner plug-in loader.
+
 bulk_extractor version 1.5.0
 Usage: bulk_extractor [options] imagefile
   runs bulk extractor and outputs to stdout a summary of what was found where
@@ -55,9 +57,6 @@ Debugging:
    -Z           - zap (erase) output directory
 
 Control of Scanners:
-   -P <dir>     - Specifies a plugin directory
-             Default dirs include /usr/local/lib/bulk_extractor /usr/lib/bulk_extractor and
-             BE_PATH environment variable
    -e <scanner>  enables <scanner> -- -e all   enables all
    -x <scanner>  disable <scanner> -- -x all   disables all
    -E <scanner>    - turn off all scanners except <scanner>

--- a/doc/latex_manuals/BEUsersManual.tex
+++ b/doc/latex_manuals/BEUsersManual.tex
@@ -15,6 +15,8 @@
 
 \begin{document}
 
+\noindent\fbox{\parbox{0.95\linewidth}{\textbf{Historical document.} This manual describes bulk_extractor 1.x. bulk_extractor 2.x has no runtime scanner plug-in ABI or shared-library loader; its scanners are compiled into the executable.}}
+
 %define macros for commonly used terms that require special formatting
 \newcommand \bulk {\textit{bulk\_extractor}\xspace}
 \newcommand \beapi {\textit{be13\_api}\xspace}

--- a/doc/latex_manuals/beviewer_old.tex
+++ b/doc/latex_manuals/beviewer_old.tex
@@ -138,6 +138,8 @@ a specific Image Reader may be set for testing purposes}}
 
 \begin{document}
 
+\noindent\fbox{\parbox{0.95\linewidth}{\textbf{Historical document.} This BEViewer manual describes bulk_extractor 1.x. bulk_extractor 2.x has no runtime scanner plug-in ABI or shared-library loader; its scanners are compiled into the executable.}}
+
 %\titlespacing{\section}{0pt}{0pt}{0pt}
 %\titlespacing{\subsection}{0pt}{0pt}{0pt}
 %\titlespacing{\subsubsection}{0pt}{0pt}{0pt}
@@ -529,4 +531,3 @@ Image Reader
 \end{comment}
 
 \end{document}
-

--- a/doc/programmer_manual/BEProgrammersManual.tex
+++ b/doc/programmer_manual/BEProgrammersManual.tex
@@ -46,6 +46,8 @@
 
 \begin{document}
 
+\noindent\fbox{\parbox{0.95\linewidth}{\textbf{Historical document.} This manual describes the bulk_extractor 1.4 scanner plug-in API. bulk_extractor 2.x has no runtime scanner plug-in ABI or shared-library loader; its scanners are compiled into the executable.}}
+
 %define macros for commonly used terms that require special formatting
 \newcommand \bulk {\textit{bulk\_extractor}\xspace}
 \newcommand \beapi {\textit{be13\_api}\xspace}

--- a/man/bulk_extractor.1
+++ b/man/bulk_extractor.1
@@ -200,9 +200,6 @@ Enable debugging level
 .SH SCANNER CONTROL
 Finally, you can control scanners with these options:
 
-.IP "-P <dir>"
-Specifies a directory in which to find plugins.
-
 .IP "-E scanner"
 Turns off all scanners, then enabled scanner scanner.
 
@@ -225,4 +222,3 @@ multi-threaded
 was released in May 2010.
 .SH AUTHOR
 Simson Garfinkel <simsong@acm.org>
-

--- a/src/TECH_DEBT.md
+++ b/src/TECH_DEBT.md
@@ -30,9 +30,9 @@ The most urgent source issues are independent of that restructuring:
    arithmetic underflows, and several offset checks can wrap.
 3. Returning after a phase-1 `DiskWriteError` leaves the notification thread in
    phase 1. Its destructor then asserts or waits forever.
-4. Runtime scanner loading is advertised in user and API documentation, and
-   the CLI collects plug-in directories, but both loader entry points always
-   throw and the directories are never consumed.
+4. Runtime scanner loading was advertised in user and API documentation, but
+   had no implementation. It was removed in #505; scanners are compiled into
+   the executable.
 5. The optional Lightgrep scanner sources have not been migrated to the current
    API. Enabling Lightgrep exposes duplicate `switch` cases, invalid member
    access, and references to the removed `recursion_control_block`.
@@ -282,23 +282,14 @@ instance in debug leak tracking. `range_exception_t::what()` uses a shared
 static buffer and races between scanner threads. These should be corrected as
 part of the same ownership rewrite.
 
-#### Runtime plug-ins do not exist despite the interface and CLI
+#### Runtime plug-in interface removed
 
-`scanner_set::add_scanner_file()` and `add_scanner_directory()` immediately
-throw; their implementations are inside `#if 0`. `bulk_extractor.cpp` builds a
-default search path, reads `BE_PATH`, and accepts `-P`, but never calls either
-loader. The option loop also stops after the first supplied `-P` value. The root
-manual, 2.0 roadmap, scanner comments, and be20_api README all describe dynamic
-scanner loading as operational.
-
-Choose one product decision:
-
-- implement a versioned, tested plug-in ABI and exercise a real shared-library
-  scanner on each supported platform; or
-- remove the loader methods, `-P`, `BE_PATH`, and all plug-in claims.
-
-Leaving security-sensitive dynamic-loading code disabled but advertised is the
-worst of both choices.
+The advertised runtime scanner loader was never implemented: its entry points
+always threw and `-P`/`BE_PATH` collected directories that no code consumed.
+Issue #505 removes that dead interface, its command-line/environment surface,
+and current documentation claims. Scanners are compiled into the executable.
+Historical 1.x documentation is marked accordingly; it remains a separate
+documentation-porting task.
 
 #### Optional Lightgrep configuration is source-broken
 
@@ -667,8 +658,7 @@ optional/sanitizer configurations recommended in this document.
    intentionally with provenance records, prevent generated dependency paths
    from entering source control, and retain `make check` plus `make distcheck`
    as release gates.
-3. **Resolve false features:** either implement or remove plug-ins and
-   Lightgrep. Correct the CLI and docs in the same changes.
+3. **Resolve false features:** Lightgrep remains to be corrected or removed.
 4. **Repair input/ownership paths:** short reads, E01 detection, split filename
    construction, file mapping, packet accessors, histogram fallback, and EVTX
    ownership.
@@ -737,12 +727,9 @@ appropriate validation.
 - [ ] Replace discarded `std::runtime_error` temporaries in the `sbuf_t` destructor with enforceable invariants or diagnostics.
 - [ ] Insert rather than erase non-owning `sbuf_t` instances in debug leak tracking.
 - [ ] Make `range_exception_t::what()` thread-safe instead of returning a shared mutable static buffer.
-- [ ] Either implement `scanner_set::add_scanner_file` or remove the nonfunctional API.
-- [ ] Either implement `scanner_set::add_scanner_directory` or remove the nonfunctional API.
-- [ ] Remove or implement the unused `BE_PATH` scanner search path.
-- [ ] Remove or implement the unused `-P` scanner-directory option.
-- [ ] Process every supplied `-P` value instead of stopping after the first.
-- [ ] Remove plug-in claims from user/API documentation unless a versioned, tested plug-in ABI is implemented.
+- [x] Remove the nonfunctional runtime scanner-loader API (#505).
+- [x] Remove the unused `BE_PATH` scanner search path and `-P` option (#505).
+- [x] Remove current plug-in claims; label historical 1.x documentation (#505).
 - [ ] Remove the duplicate `PHASE_INIT` case in `scan_lightgrep.cpp`.
 - [ ] Correct the inconsistent pointer/member access in `scan_lightgrep.cpp`.
 - [ ] Remove references to the deleted recursion-control interface from Lightgrep scanner sources.

--- a/src/be20_api/README.md
+++ b/src/be20_api/README.md
@@ -29,8 +29,6 @@ The `test_be20_api` executable is a parent Automake test target. The former stan
 
 The API is internal. There is no installed library, public-header compatibility promise, or runtime scanner plug-in ABI. Scanners compiled into bulk_extractor use `scanner_params`, `scanner_set`, `feature_recorder`, and `sbuf_t` directly.
 
-Runtime scanner-loading methods remain in the source for compatibility but are not implemented; callers must not rely on shared-library or DLL scanner loading until that debt is resolved.
-
 ## Path printing
 
 Path printing uses scanners to decode a forensic path:

--- a/src/be20_api/feature_recorder_set.h
+++ b/src/be20_api/feature_recorder_set.h
@@ -27,7 +27,7 @@
  * It also has the factory method for new feature_recorders. Therefore if you want a different feature_recorder,
  * this set should be subclassed as well.
  *
- * NOTE: plugins can only call virtual functions!
+ * NOTE: scanners access this through scanner_params.
  *
  */
 
@@ -155,7 +155,7 @@ public:
 
     /* support for creating and finding feature recorders
      * Previously called create_name().
-     * functions must be virtual so they can be called by plug-in.
+     * functions are virtual for specialized recorder-set implementations.
      * All return a reference to the named (or created) feature recorder, or else throw exception indicated
      */
     class NoSuchFeatureRecorder : public std::exception {

--- a/src/be20_api/scan_sha1_test.cpp
+++ b/src/be20_api/scan_sha1_test.cpp
@@ -1,7 +1,7 @@
 /**
  *
  * scan_sha1:
- * plug-in demonstration that shows how to write a simple plug-in scanner that calculates
+ * Test scanner that calculates
  * the SHA1 of each sbuf. The hash is written to both the XML file and to the sha1 feature file.
  *
  * Don't use this in production systems! It has a histogram that isn't useful for most applications.

--- a/src/be20_api/scanner_params.h
+++ b/src/be20_api/scanner_params.h
@@ -141,7 +141,7 @@ struct scanner_params {
 
     };
 
-    const int SCANNER_PARAMS_VERSION {20211201}; // allow loadable scanners to validate version number
+    const int SCANNER_PARAMS_VERSION {20211201}; // detect mismatched scanner parameters
     int scanner_params_version {SCANNER_PARAMS_VERSION};
     void check_version() { assert(this->scanner_params_version == SCANNER_PARAMS_VERSION); }
 
@@ -190,7 +190,7 @@ struct scanner_params {
     virtual bool check_previously_processed(const sbuf_t &sbuf) const;
     std::filesystem::path const get_input_fname() const {return sc.input_fname;}; // not sure why this is needed?
 
-    // These methods are implemented in the plugin system for the scanner to get config information.
+    // These methods provide scanner configuration.
     // The get_scanner_config methods should be called on the si object during PHASE_STARTUP (or when help is printed)
     /* When we are asked to get the config:
      * - first build the help string

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -4,11 +4,7 @@
  * bulk_extractor backend stuff, used for both standalone executable and bulk_extractor.
  */
 
-/* needed loading shared libraries and getting free memory*/
 #include "config.h"
-
-#include <sys/types.h>
-
 
 #include <cstdio>
 #include <algorithm>
@@ -21,10 +17,6 @@
 
 #ifdef HAVE_LINUX_SYSCTL_H
 #include <linux/sysctl.h>
-#endif
-
-#ifdef HAVE_DLFCN_H
-#include <dlfcn.h>
 #endif
 
 #include "machine_stats.h"
@@ -42,12 +34,10 @@
 #include "path_printer.h"
 
 /****************************************************************
- *** SCANNER SET IMPLEMENTATION (previously the PLUG-IN SYSTEM)
+ *** SCANNER SET IMPLEMENTATION
  ****************************************************************/
 
-/* BE2 revision:
- * In BE1, the active scanners were maintained by the plugin system's global state.
- * In BE2, there is no global state. Instead, scanners are grouped into scanner set, which
+/* In BE2, there is no global state. Scanners are grouped into scanner set, which
  *        in turn has a feature_recorder_set, which in turn has multiple feature recorders.
  *        The scanner set can then be asked to process a sbuf.
  *        All of the global variables go away.
@@ -331,88 +321,6 @@ void scanner_set::add_scanner(scanner_t scanner) {
 void scanner_set::add_scanners(scanner_t* const* scanners)
 {
     for (int i = 0; scanners[i]; i++) { add_scanner(scanners[i]); }
-}
-
-/* Add a scanner from a file (it's in the file as a shared library) */
-void scanner_set::add_scanner_file(std::string fn)
-{
-    if(time(0)>10) {                    // prevents compiler warning
-        throw std::runtime_error("scanner_set::add_scanner_file: not implemented yet.");
-    }
-#if 0
-    /* Figure out the function name */
-    size_t extloc = fn.rfind('.');
-    if(extloc==std::string::npos){
-        fprintf(stderr,"Cannot find '.' in %s",fn.c_str());
-        exit(1);
-    }
-    std::string func_name = fn.substr(0,extloc);
-    size_t slashloc = func_name.rfind('/');
-    if(slashloc!=std::string::npos) func_name = func_name.substr(slashloc+1);
-    slashloc = func_name.rfind('\\');
-    if(slashloc!=std::string::npos) func_name = func_name.substr(slashloc+1);
-
-    if(debug) std::cout << "Loading: " << fn << " (" << func_name << ")\n";
-    scanner_t *scanner = 0;
-#if defined(HAVE_DLOPEN)
-    void *lib=dlopen(fn.c_str(), RTLD_LAZY);
-
-    if(lib==0){
-        fprintf(stderr,"dlopen: %s\n",dlerror());
-        exit(1);
-    }
-
-    /* Resolve the symbol */
-    scanner = (scanner_t *)dlsym(lib, func_name.c_str());
-
-    if(scanner==0){
-        fprintf(stderr,"dlsym: %s\n",dlerror());
-        exit(1);
-    }
-#elif defined(HAVE_LOADLIBRARY)
-    /* Use Win32 LoadLibrary function */
-    /* See http://msdn.microsoft.com/en-us/library/ms686944(v=vs.85).aspx */
-    HINSTANCE hinstLib = LoadLibrary(TEXT(fn.c_str()));
-    if(hinstLib==0){
-        fprintf(stderr,"LoadLibrary(%s) failed",fn.c_str());
-        exit(1);
-    }
-    scanner = (scanner_t *)GetProcAddress(hinstLib,func_name.c_str());
-    if(scanner==0){
-        fprintf(stderr,"GetProcAddress(%s) failed",func_name.c_str());
-        exit(1);
-    }
-#else
-    std::cout << "  ERROR: Support for loadable libraries not enabled\n";
-    return;
-#endif
-    load_scanner(*scanner,sc);
-#endif
-}
-
-/* Add all of the scanners in a directory */
-void scanner_set::add_scanner_directory(const std::string &dirname)
-{
-    if(time(0)>10) {                    // prevents compiler warning
-        throw std::runtime_error("scanner_set::add_scanner_directory: not implemented yet.");
-    }
-#if 0
-TODO: Re-implement using C++17 directory reading.
-
-
-        if(fname.substr(0,5)=="scan_" || fname.substr(0,5)=="SCAN_"){
-            size_t extloc = fname.rfind('.');
-            if(extloc==std::string::npos) continue; // no '.'
-            std::string ext = fname.substr(extloc+1);
-#ifdef _WIN32
-            if(ext!="DLL") continue;    // not a DLL
-#else
-            if(ext!="so") continue;     // not a shared library
-#endif
-            load_scanner_file(dirname+"/"+fname,sc );
-        }
-    }
-#endif
 }
 
 /* This interface creates if we are in init phase, doesn't if we are in scan phase */

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -28,13 +28,13 @@
  * \file
  * bulk_extractor scanner architecture.
  *
- * The scanner_set class implements loadable scanners from files and
- * keeps track of which are enabled and which are not.
+ * The scanner_set class manages scanners compiled into the process and keeps
+ * track of which are enabled and which are not.
  *
  * Sequence of operations:
  * 1. scanner_config is loaded with any name=value configurations.
  * 2. scanner_set() is created with the config. The scanner_set:
- *     - Loads any scanners from specified directories.
+ *     - Receives the built-in scanners from its caller.
        - Processes all enable/disable commands to determine which scanners are enabled and disabled.
  * 3. Scanners are queried to determine which feature files they write to, and which histograms they created.
  * 4. Data is processed.
@@ -246,10 +246,8 @@ public:
 
 
     /* PHASE_INIT SUPPORT */
-    void add_scanner(scanner_t scanner);                    // load a specific scanner in memory
-    void add_scanners(scanner_t* const* scanners_builtin);  // load a nullptr array of scanners.
-    void add_scanner_file(std::string fn);                  // load a scanner from a shared library file
-    void add_scanner_directory(const std::string& dirname); // load all scanners in the directory
+    void add_scanner(scanner_t scanner);                    // add a specific in-memory scanner
+    void add_scanners(scanner_t* const* scanners_builtin);  // add a nullptr array of scanners
     void info_scanners(std::ostream &out, bool detailed_info, bool detailed_settings,
                        const char enable_opt, const char disable_opt);
     void apply_scanner_commands(); // applies all of the enable/disable commands and create the feature recorders

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -120,12 +120,6 @@ void validate_path( const std::filesystem::path fn)
  */
 
 std::string be_hash_name {"sha1"};
-static void add_if_present( std::vector<std::string> &scanner_dirs,const std::string &dir)
-{
-    if ( access( dir.c_str(),O_RDONLY) == 0){
-        scanner_dirs.push_back( dir);
-    }
-}
 
 std::string ns_to_sec(uint64_t ns)
 {
@@ -178,21 +172,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     bool        opt_write_sqlite3     = false;
 #endif
 
-    /* Startup */
     setvbuf( stdout,0,_IONBF,0);		// don't buffer stdout
-    std::vector<std::string> scanner_dirs; // where to look for scanners
-
-    /* Add the default plugin_path */
-    add_if_present( scanner_dirs,"/usr/local/lib/bulk_extractor" );
-    add_if_present( scanner_dirs,"/usr/lib/bulk_extractor" );
-    add_if_present( scanner_dirs,"." );
-
-    if ( getenv( "BE_PATH" )) {
-        std::vector<std::string> dirs = split( getenv( "BE_PATH" ),':');
-        for( std::vector<std::string>::const_iterator it = dirs.begin(); it!=dirs.end(); it++){
-            add_if_present( scanner_dirs,*it);
-        }
-    }
 
 #ifdef _WIN32
     setmode( 1,O_BINARY);		// make stdout binary
@@ -241,10 +221,6 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         ("notify_main_thread", "Display notifications in the main thread after phase1 completes. Useful for running with ThreadSanitizer")
         ("notify_async", "Display notificaitons asynchronously (default)")
         ("o,outdir",        "output directory [REQUIRED]", cxxopts::value<std::string>())
-        ("P,scanner_dir",
-         "directories for scanner shared libraries (can be repeated). "
-         "Default directories include /usr/local/lib/bulk_extractor, /usr/lib/bulk_extractor "
-         "and any directories specified in the BE_PATH environment variable.", cxxopts::value<std::vector<std::string>>())
         ("p,path",          "print the value of <path>[:length][/h][/r] with optional length, hex output, or raw output.", cxxopts::value<std::string>())
         ("q,quit",          "no status or performance output")
         ("r,alert_list",    "file to read alert list from", cxxopts::value<std::string>())
@@ -313,13 +289,6 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
     sc.max_depth             = result["max_depth"].as<int>();
     cfg.max_bad_alloc_errors = result["max_bad_alloc_errors"].as<int>();
-
-    try {
-        for ( const auto &it : result["scanner_dir"].as<std::vector<std::string>>() ) {
-            scanner_dirs.push_back( it);break;
-        }
-    } catch ( cxxopts::option_has_no_value_exception &e ) { }
-
 
     cfg.opt_quiet = result.count( "quiet" );
     try {

--- a/src/bulk_extractor_scanners.cpp
+++ b/src/bulk_extractor_scanners.cpp
@@ -10,12 +10,7 @@
 
 #include "config.h"
 
-/************************
- *** SCANNER PLUG-INS ***
- ************************/
-
-/* scanner_def is the class that is used internally to track all of the plug-in scanners.
- * Some scanners are compiled-in; others can be loaded at run-time.
+/* scanner_def is the class that is used internally to track built-in scanners.
  * Scanners can have multiple feature recorders. Multiple scanners can record to the
  * same feature recorder.
  */

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -40,6 +40,7 @@
 
 #include "bulk_extractor.h"
 #include "base64_forensic.h"
+#include "cxxopts.hpp"
 #include "bulk_extractor_restarter.h"
 #include "bulk_extractor_scanners.h"
 #include "exif_reader.h"
@@ -191,6 +192,12 @@ TEST_CASE("e2e-h", "[end-to-end]") {
     std::stringstream ss;
     int ret = run_be(ss, argv);
     REQUIRE( ret==1 );                  // -h now produces 1
+}
+
+TEST_CASE("e2e-no-runtime-scanner-loader", "[end-to-end]") {
+    const char *argv[] = {"bulk_extractor", "-P", "scanners", nullptr};
+    std::stringstream ss;
+    REQUIRE_THROWS_AS(run_be(ss, argv), cxxopts::option_not_exists_exception);
 }
 
 /* Test -H */


### PR DESCRIPTION
Codex-authored PR.

Closes #505.

## Summary

- remove the dead shared-library scanner loader API and its disabled implementation;
- remove the unused `-P` option and `BE_PATH` scanner search path;
- document that scanners are compiled into the executable, and label 1.x manuals and roadmaps as historical; and
- add an end-to-end test that `-P` is rejected.

## Why

The previous interface advertised runtime loading but never invoked a loader; both public loader methods always threw. Removing the nonfunctional surface avoids a false security-sensitive feature and establishes the actual compiled-in scanner contract.

## Validation

- `bash bootstrap.sh`
- `./configure`
- `make -s -j4 -C src check TESTS=test_be` (build completed)
- `make -s -j4 check`: `test_be` and `test_dfxml` pass. `test_be20_api` has the existing sandbox-only `machine_stats` failure because macOS denies its `/bin/ps` subprocess, resulting in NaN; it is unrelated to this PR.