### PR TITLE
Repair sbuf file mapping ownership

### DIFF
--- a/src/TECH_DEBT.md
+++ b/src/TECH_DEBT.md
@@ -264,23 +264,17 @@ using a recorder that produces a real write failure; do not mock the thread.
 
 #### File mapping and ownership failures
 
-`be20_api/sbuf.cpp:373-405` does not validate `open()` or `mmap()` failure,
-treats descriptor zero as “not owned” because the destructor only handles
-`fd > 0`, and does not define a safe zero-length mapping path. In the no-`mmap`
-branch, the allocated buffer is passed to the non-owning constructor and never
-stored in `malloced`, leaking every mapped file. `sbuf_malloc` also constructs
-an object after an unchecked `malloc` result.
+Issue #504 makes mapping and allocation ownership explicit: failures from
+`open`, `fstat`, and `mmap` are checked; descriptor zero is owned; empty files
+do not reach `mmap`; copied-file buffers are retained for deletion; and failed
+nonzero allocations throw before object construction. The destructor now
+enforces its no-live-children invariant, non-owning sbufs participate in debug
+leak tracking, and each range exception owns its message.
 
-Use RAII handles and an owning factory with explicit mapping/allocation
-variants. Test empty files, fd 0, open denial, truncated reads, `MAP_FAILED`, and
-the no-`mmap` build.
-
-The destructor's `std::runtime_error(...)` expressions at lines 151-166 merely
-construct and discard exceptions; they do not enforce the live-child or
-platform invariants. The non-owning constructor erases rather than inserts its
-instance in debug leak tracking. `range_exception_t::what()` uses a shared
-static buffer and races between scanner threads. These should be corrected as
-part of the same ownership rewrite.
+The regression tests cover empty and missing files, descriptor zero ownership,
+independent exception messages, and the no-`mmap` configuration. `MAP_FAILED`
+and allocation exhaustion remain system-specific validation targets because
+they cannot be reached safely without test hooks or mocks.
 
 #### Runtime plug-ins do not exist despite the interface and CLI
 
@@ -728,15 +722,10 @@ appropriate validation.
 
 ### P1: ownership, input handling, and advertised features
 
-- [ ] Check `open()` failure before attempting to map a file in `sbuf_t::map_file`.
-- [ ] Check `mmap()` for `MAP_FAILED` before constructing a mapped `sbuf_t`.
-- [ ] Treat file descriptor zero as an owned descriptor that must be closed.
-- [ ] Define a safe, portable zero-length file mapping path.
-- [ ] Retain and free the allocated buffer in the no-`mmap` `map_file` implementation.
-- [ ] Check allocation failure before constructing an `sbuf_t` in `sbuf_malloc`.
-- [ ] Replace discarded `std::runtime_error` temporaries in the `sbuf_t` destructor with enforceable invariants or diagnostics.
-- [ ] Insert rather than erase non-owning `sbuf_t` instances in debug leak tracking.
-- [ ] Make `range_exception_t::what()` thread-safe instead of returning a shared mutable static buffer.
+- [x] Check `open()`/`fstat()`/`mmap()` failures before constructing a mapped `sbuf_t` (#504).
+- [x] Treat descriptor zero as owned and define a safe zero-length mapping path (#504).
+- [x] Retain copied-file buffers and check `sbuf_malloc` allocation failures (#504).
+- [x] Enforce sbuf child ownership, correct debug tracking, and make range-exception text instance-owned (#504).
 - [ ] Either implement `scanner_set::add_scanner_file` or remove the nonfunctional API.
 - [ ] Either implement `scanner_set::add_scanner_directory` or remove the nonfunctional API.
 - [ ] Remove or implement the unused `BE_PATH` scanner search path.

--- a/src/be20_api/sbuf.cpp
+++ b/src/be20_api/sbuf.cpp
@@ -7,12 +7,17 @@
 #include <sys/stat.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cctype>
 #include <cstdio>
+#include <cstring>
 #include <filesystem>
 #include <algorithm>
 #include <iostream>
 #include <ios>
+#include <limits>
+#include <memory>
+#include <system_error>
 
 #include "sbuf.h"
 #include "dfxml_cpp/src/hash_t.h"
@@ -107,7 +112,7 @@ sbuf_t::sbuf_t(pos0_t pos0_, const uint8_t *buf_, size_t bufsize_):
 
     if (debug_leak) {
         const std::lock_guard<std::mutex> lock(sbuf_allocedM); // protect this function
-        sbuf_alloced.erase( this );
+        sbuf_alloced.insert( this );
     }
     if (debug_alloc) {
         const std::lock_guard<std::mutex> lock(sbuf_allocedM); // protect this function
@@ -149,7 +154,8 @@ sbuf_t::~sbuf_t()
         std::cerr << "sbuf_t::~sbuf_t() " << this << " " << *this << std::endl;
     }
     if (children != 0) {
-        std::runtime_error(Formatter() << "sbuf.cpp: error: sbuf children=" << children);
+        std::cerr << "sbuf.cpp: destroying sbuf with children=" << children << std::endl;
+        std::terminate();
     }
     {
         const std::lock_guard<std::mutex> lock(Mhistogram); // protect this function
@@ -159,11 +165,14 @@ sbuf_t::~sbuf_t()
         }
     }
     if (parent) parent->del_child(*this);
-    if (fd>0) {
+    if (fd != NO_FD) {
 #ifdef HAVE_MMAP
-        munmap((void*)buf, bufsize);
+        if (bufsize != 0 && munmap((void*)buf, bufsize) != 0) {
+            std::cerr << "sbuf.cpp: munmap failed: " << std::strerror(errno) << std::endl;
+            std::terminate();
+        }
 #else
-        std::runtime_error(Formatter() << "sbuf.cpp: fd>0 and HAVE_MMAP is not defined");
+        std::terminate();
 #endif
         ::close(fd);
     }
@@ -227,7 +236,9 @@ sbuf_t* sbuf_t::sbuf_new(pos0_t pos0_, const uint8_t* buf_, size_t bufsize_, siz
 sbuf_t* sbuf_t::sbuf_malloc(pos0_t pos0, const std::string &str)
 {
     sbuf_t *ret = sbuf_t::sbuf_malloc(pos0,  str.size(), str.size());
-    memcpy( ret->malloc_buf(), str.c_str(), str.size());
+    if (!str.empty()) {
+        memcpy(ret->malloc_buf(), str.c_str(), str.size());
+    }
     return ret;
 }
 
@@ -358,13 +369,70 @@ sbuf_t sbuf_t::slice(size_t off) const
  */
 
 sbuf_t* sbuf_t::map_file(const std::filesystem::path fname) {
-    int mfd = NO_FD;
-    std::uintmax_t bytes = std::filesystem::file_size( fname );
 #ifdef HAVE_MMAP
-    mfd = ::open(fname.c_str(), O_RDONLY);
-    uint8_t* mbuf = (uint8_t*)mmap(0, bytes, PROT_READ, MAP_FILE | MAP_SHARED, mfd, 0);
+    struct mapped_file {
+        int fd;
+        void* address {MAP_FAILED};
+        size_t bytes {0};
+
+        ~mapped_file() {
+            if (address != MAP_FAILED) {
+                munmap(address, bytes);
+            }
+            if (fd != NO_FD) {
+                ::close(fd);
+            }
+        }
+        void release() {
+            fd = NO_FD;
+            address = MAP_FAILED;
+        }
+    };
+
+    const int mfd = ::open(fname.c_str(), O_RDONLY | O_BINARY);
+    if (mfd == NO_FD) {
+        throw std::system_error(errno, std::generic_category(), "open " + fname.string());
+    }
+    mapped_file mapped_file{mfd};
+
+    struct stat st {};
+    if (fstat(mfd, &st) != 0) {
+        throw std::system_error(errno, std::generic_category(), "fstat " + fname.string());
+    }
+    if (!S_ISREG(st.st_mode)) {
+        throw std::runtime_error(Formatter() << "Not a regular file: " << fname);
+    }
+    if (st.st_size < 0 || static_cast<std::uintmax_t>(st.st_size) > std::numeric_limits<size_t>::max()) {
+        throw std::runtime_error(Formatter() << "Unsupported file size: " << fname);
+    }
+
+    const size_t bytes = static_cast<size_t>(st.st_size);
+    if (bytes == 0) {
+        return new sbuf_t(pos0_t(fname.string() + pos0_t::map_file_delimiter), nullptr,
+                          nullptr, 0, 0, NO_FD);
+    }
+
+    mapped_file.address = mmap(nullptr, bytes, PROT_READ, MAP_FILE | MAP_SHARED, mfd, 0);
+    mapped_file.bytes = bytes;
+    if (mapped_file.address == MAP_FAILED) {
+        throw std::system_error(errno, std::generic_category(), "mmap " + fname.string());
+    }
+    auto* ret = new sbuf_t(pos0_t(fname.string() + pos0_t::map_file_delimiter), nullptr,
+                           static_cast<uint8_t*>(mapped_file.address), bytes, bytes, mfd);
+    mapped_file.release();
+    return ret;
 #else
-    uint8_t *mbuf = static_cast<uint8_t*>(malloc(bytes));
+    const std::uintmax_t file_size = std::filesystem::file_size(fname);
+    if (file_size > std::numeric_limits<size_t>::max()) {
+        throw std::runtime_error(Formatter() << "Unsupported file size: " << fname);
+    }
+    const size_t bytes = static_cast<size_t>(file_size);
+    if (bytes == 0) {
+        return new sbuf_t(pos0_t(fname.string() + pos0_t::map_file_delimiter), nullptr,
+                          nullptr, 0, 0, NO_FD);
+    }
+    using owned_buffer = std::unique_ptr<uint8_t, decltype(&std::free)>;
+    owned_buffer mbuf(static_cast<uint8_t*>(malloc(bytes)), &std::free);
     if (mbuf == nullptr) {
         throw std::bad_alloc();
     }
@@ -372,24 +440,18 @@ sbuf_t* sbuf_t::map_file(const std::filesystem::path fname) {
     if (!infile.is_open()){
         throw std::runtime_error(Formatter() << "Cannot open " << fname);
     }
-    infile.read( reinterpret_cast<char *>(mbuf), bytes);
-    if (infile.rdstate() & std::ios::eofbit) {
-        free(mbuf); /* read failed */
-        throw std::runtime_error(Formatter() << "End of file: " << fname);
+    if (bytes > static_cast<size_t>(std::numeric_limits<std::streamsize>::max())) {
+        throw std::runtime_error(Formatter() << "Unsupported file size: " << fname);
     }
-    if (infile.rdstate() & std::ios::failbit) {
-        free(mbuf); /* read failed */
-        throw std::runtime_error(Formatter() << "Fail file: " << fname);
+    infile.read(reinterpret_cast<char *>(mbuf.get()), static_cast<std::streamsize>(bytes));
+    if (infile.gcount() != static_cast<std::streamsize>(bytes)) {
+        throw std::runtime_error(Formatter() << "Short read: " << fname);
     }
-    if (infile.rdstate() & std::ios::badbit) {
-        free(mbuf); /* read failed */
-        throw std::runtime_error(Formatter() << "Bad file: " << fname);
-    }
-    infile.close();
+    auto* ret = new sbuf_t(pos0_t(fname.string() + pos0_t::map_file_delimiter), nullptr,
+                           mbuf.get(), bytes, bytes, NO_FD);
+    ret->malloced = mbuf.release();
+    return ret;
 #endif
-    return new sbuf_t(pos0_t(fname.string() + pos0_t::map_file_delimiter), nullptr,
-                      mbuf, bytes, bytes,
-                      mfd);
 }
 
 
@@ -401,7 +463,10 @@ sbuf_t* sbuf_t::map_file(const std::filesystem::path fname) {
 sbuf_t* sbuf_t::sbuf_malloc(pos0_t pos0_, size_t bufsize_, size_t pagesize_)
 {
     assert( bufsize_ >= pagesize_ );
-    uint8_t *new_malloced = static_cast<uint8_t *>(malloc(bufsize_));
+    uint8_t *new_malloced = bufsize_ == 0 ? nullptr : static_cast<uint8_t *>(malloc(bufsize_));
+    if (bufsize_ != 0 && new_malloced == nullptr) {
+        throw std::bad_alloc();
+    }
     sbuf_t *ret = new sbuf_t(pos0_, nullptr,
                              new_malloced, bufsize_, pagesize_,
                              NO_FD);

--- a/src/be20_api/sbuf.h
+++ b/src/be20_api/sbuf.h
@@ -266,23 +266,19 @@ public:;
     public:
         size_t off {0};
         size_t len {0};
-        std::string message() const {
-            return Formatter() << "[sbuf_t::range_exception_t: Read past end of sbuf off=" << off << " len=" << len << "]";
-        }
-        range_exception_t(size_t off_, size_t len_):off(off_), len(len_){
+        range_exception_t(size_t off_, size_t len_)
+            : off(off_), len(len_), what_message(Formatter() << "[sbuf_t::range_exception_t: Read past end of sbuf off=" << off_ << " len=" << len_ << "]") {
             if (debug_range_exception){
                 std::cerr << __func__ ;
                 std::cerr << message() << " ";
                 std::cerr << "\n";
             }
         };
-        virtual const char* what() const throw() {
-            static char lbuf[80];        // big enough to hold a single error
-            std::string str = message();
-            strncpy(lbuf, str.c_str(), sizeof(lbuf)-1);
-            lbuf[sizeof(lbuf)-1] = '\000'; // safety
-            return lbuf;
-        }
+        std::string message() const { return what_message; }
+        const char* what() const noexcept override { return what_message.c_str(); }
+
+    private:
+        std::string what_message;
     };
 
     /****************************************************************
@@ -598,7 +594,7 @@ private:
                     int fd_);
 
     /* The private structures keep track of memory management */
-    int fd{0};                     // if fd>0, unmap(buf) and close(fd) when sbuf is deleted.
+    int fd{NO_FD};                 // if owned, unmap(buf) and close(fd) when sbuf is deleted.
     const sbuf_t        *parent {nullptr}; // parent sbuf references data in another.
     mutable std::mutex  Mhash{};    // mutext for hashing
     inline static std::string NO_HASH {""};
@@ -619,7 +615,7 @@ private:
     sbuf_t(const sbuf_t& that) = delete;            // default copy is not implemented
     sbuf_t& operator=(const sbuf_t& that) = delete; // default assignment not implemented
 
-    inline static const int NO_FD=0;
+    inline static const int NO_FD=-1;
     friend std::ostream& operator<<(std::ostream& os, const sbuf_t& t);
 };
 

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -32,6 +32,11 @@
 #include <random>
 #include <string>
 #include <csignal>
+#include <system_error>
+
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
 
 #include "stdlib.h"
 
@@ -78,6 +83,24 @@ std::filesystem::path get_tempdir() {
     }
     return tempdir;
 }
+
+#if defined(HAVE_MMAP) && !defined(_WIN32)
+class saved_file_descriptor {
+    int fd;
+public:
+    explicit saved_file_descriptor(int original) : fd(::dup(original)) {
+        if (fd < 0) {
+            throw std::system_error(errno, std::generic_category(), "dup");
+        }
+    }
+    ~saved_file_descriptor() {
+        if (fd >= 0) {
+            ::dup2(fd, STDIN_FILENO);
+            ::close(fd);
+        }
+    }
+};
+#endif
 
 #ifdef HAVE_MACH_O_DYLD_H
 #include <mach-o/dyld.h>
@@ -611,6 +634,11 @@ TEST_CASE("range_exception", "[sbuf]") {
     catch (const sbuf_t::range_exception_t &e) {
         REQUIRE( std::string("[sbuf_t::range_exception_t: Read past end of sbuf off=100 len=1]") == e.what());
     }
+
+    const sbuf_t::range_exception_t first(1, 2);
+    const sbuf_t::range_exception_t second(3, 4);
+    REQUIRE(std::string(first.what()) == "[sbuf_t::range_exception_t: Read past end of sbuf off=1 len=2]");
+    REQUIRE(std::string(second.what()) == "[sbuf_t::range_exception_t: Read past end of sbuf off=3 len=4]");
 }
 
 TEST_CASE("sbuf boundary contract", "[sbuf]") {
@@ -1132,6 +1160,35 @@ TEST_CASE("map_file", "[sbuf]") {
     REQUIRE(sb1[1000] == '\000');
     delete sb1p;
 }
+
+TEST_CASE("map_file empty", "[sbuf]") {
+    const auto fname = get_tempdir() / "empty.bin";
+    std::ofstream(fname).close();
+
+    std::unique_ptr<sbuf_t> sbuf(sbuf_t::map_file(fname));
+    REQUIRE(sbuf->bufsize == 0);
+    REQUIRE(sbuf->pagesize == 0);
+}
+
+TEST_CASE("map_file missing", "[sbuf]") {
+    REQUIRE_THROWS_AS(sbuf_t::map_file(get_tempdir() / "missing.bin"), std::exception);
+}
+
+#if defined(HAVE_MMAP) && !defined(_WIN32)
+TEST_CASE("map_file closes descriptor zero", "[sbuf]") {
+    const auto fname = get_tempdir() / "fd-zero.bin";
+    std::ofstream(fname) << "fd zero";
+
+    saved_file_descriptor saved_stdin(STDIN_FILENO);
+    REQUIRE(::close(STDIN_FILENO) == 0);
+    {
+        std::unique_ptr<sbuf_t> sbuf(sbuf_t::map_file(fname));
+        REQUIRE(sbuf->bufsize == 7);
+    }
+    REQUIRE(::fcntl(STDIN_FILENO, F_GETFD) == -1);
+    REQUIRE(errno == EBADF);
+}
+#endif
 
 /****************************************************************
  * scanner_config.h:


### PR DESCRIPTION
Codex-authored PR.

Closes #504.

## Summary

- make mapped-file ownership exception-safe, including descriptor zero, open/fstat/mmap failures, and empty files;
- retain and free fallback copied-file buffers when mmap is unavailable;
- enforce the live-child destructor invariant, restore non-owning debug tracking, and give each range exception its own thread-safe message; and
- add real regressions for empty/missing files, fd 0 ownership, and independent exception messages.

## Why

The old mapping path leaked fallback buffers, treated fd 0 as unowned, and could construct an sbuf from failed mmap results. Its diagnostic exceptions had no effect, and range exceptions shared mutable message storage across threads.

## Validation

- `bash bootstrap.sh && ./configure`
- `make -s -j4 check` — all three test programs pass (normal mmap configuration)
- `./configure ac_cv_func_mmap=no ac_cv_func_munmap=no && make -s -j4 check` — all three test programs pass (no-mmap fallback)
- restored the normal `./configure` configuration afterward.