### PR TITLE
Honor jpeg_carve_mode=0

### DIFF
--- a/src/be20_api/feature_recorder_set.cpp
+++ b/src/be20_api/feature_recorder_set.cpp
@@ -194,7 +194,7 @@ void feature_recorder_set::set_carve_defaults()
 {
     for (const auto &name : frm.keys()){
         int carve_mode = sc.get_carve_mode(name);
-        if (carve_mode>0) {
+        if (carve_mode>=0) {
             feature_recorder &fr = frm.get(name);
             std::cerr << "setting carve mode " << carve_mode << " for feature recorder " << name << "\n";
             fr.carve_mode = feature_recorder_def::carve_mode_t( carve_mode );

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -449,6 +449,18 @@ TEST_CASE("e2e-jpeg", "[end-to-end]") {
     REQUIRE( pos != lines.end());
 }
 
+TEST_CASE("e2e-jpeg-carving-disabled", "[end-to-end]") {
+    std::filesystem::path inpath = test_dir() / "len6192.jpg";
+    std::string inpath_string = inpath.string();
+    std::filesystem::path outdir = NamedTemporaryDirectory();
+    std::string outdir_string = outdir.string();
+    std::stringstream ss;
+    const char *argv[] = {"bulk_extractor", notify(), "-S", "jpeg_carve_mode=0", "-1q", "-o", outdir_string.c_str(), inpath_string.c_str(), nullptr};
+    int ret = run_be(ss, argv);
+    REQUIRE( ret == 0 );
+    REQUIRE_FALSE( std::filesystem::exists(outdir / "jpeg_carved") );
+}
+
 
 
 TEST_CASE("e2e-email_test", "[end-to-end]") {


### PR DESCRIPTION
Codex-generated fix.

Closes #480.

## What changed

- Apply explicitly requested carve mode zero instead of treating it as absent.
- Add an end-to-end regression test that runs bulk_extractor with `-S jpeg_carve_mode=0` and verifies no JPEG carve directory is created.

## Root cause

`feature_recorder_set::set_carve_defaults()` only applied values greater than zero. JPEG defaults to `CARVE_ENCODED`, so zero was ignored and carving continued.

## Validation

- `make -s -j4 check`