### PR TITLE
Cover explicit Outlook scanner selection

### DIFF
--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -289,6 +289,24 @@ TEST_CASE("select_scanners", "[end-to-end]") {
     REQUIRE( endpos != startpos + 1);
 }
 
+TEST_CASE("select_disabled_scanner", "[end-to-end]") {
+    std::filesystem::path inpath = test_dir() / "pdf_words2.pdf";
+    std::filesystem::path outdir = NamedTemporaryDirectory();
+    std::string inpath_string = inpath.string();
+    std::string outdir_string = outdir.string();
+    std::stringstream ss;
+    const char *argv[] = {"bulk_extractor", "-0q", "-x", "all", "-e", "outlook", "-o", outdir_string.c_str(), inpath_string.c_str(), nullptr};
+    REQUIRE( run_be(ss, std::cerr, argv) == 0 );
+
+    auto lines = getLines( outdir / "report.xml" );
+    auto startpos = std::find(lines.begin(), lines.end(), "    <scanners>");
+    auto endpos = std::find(lines.begin(), lines.end(), "    </scanners>");
+    REQUIRE( startpos != lines.end() );
+    REQUIRE( endpos != lines.end() );
+    REQUIRE( std::count(startpos, endpos, "      <scanner>outlook</scanner>") == 1 );
+    REQUIRE( std::count_if(startpos, endpos, [](const std::string& line) { return line.find("<scanner>") != std::string::npos; }) == 1 );
+}
+
 /* -f simsong
  */
 TEST_CASE("scan_find", "[end-to-end]") {


### PR DESCRIPTION
Codex-generated regression coverage.

Closes #412.

## What changed

- Add an end-to-end test for `-x all -e outlook`.
- Verify that the resulting report enables exactly the Outlook scanner.

## Assessment

The current command-processing implementation already applies disables before explicit enables, and Outlook is not excluded from explicit selection. The reported behavior no longer reproduces; this test prevents a regression.

## Validation

- `make -s -j4 check`