### PR TITLE
Bound fallback PCAP reads

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,11 +22,12 @@ libbe20_a_SOURCES = $(BE20_API_SRC) $(DFXML_READER) $(DFXML_WRITER)
 bulk_extractor_LDADD = libbe20.a @RE2_LIBS@
 test_be_LDADD = libbe20.a @RE2_LIBS@
 test_be20_api_LDADD = libbe20.a @RE2_LIBS@
+test_pcap_fake_CPPFLAGS = $(AM_CPPFLAGS) -DPCAP_FAKE_TEST
 
 AUTOMAKE_OPTIONS = subdir-objects
 
 bin_PROGRAMS   = bulk_extractor
-check_PROGRAMS = test_be test_be20_api test_dfxml
+check_PROGRAMS = test_be test_be20_api test_dfxml test_pcap_fake
 TESTS = $(check_PROGRAMS)
 
 CLEANFILES     = scan_accts.cpp scan_base16.cpp scan_email.cpp scan_gps.cpp scan_vehicle.cpp \
@@ -161,6 +162,10 @@ test_dfxml_SOURCES = \
 	$(BE20_API_DIR)/catch.hpp \
 	$(DFXML_READER) \
 	$(DFXML_WRITER)
+
+test_pcap_fake_SOURCES = \
+	$(BE20_API_DIR)/test_pcap_fake.cpp \
+	$(BE20_API_DIR)/pcap_fake.cpp
 
 runs.txt: test_be tests/run_each.sh
 	bash tests/run_each.sh > runs.txt 2>&1

--- a/src/be20_api/pcap_fake.cpp
+++ b/src/be20_api/pcap_fake.cpp
@@ -8,7 +8,7 @@
 // config.h is needed solely to find out if we need pcap_fake.h or not.
 #include "config.h"
 
-#ifndef HAVE_LIBPCAP
+#if !defined(HAVE_LIBPCAP) || defined(PCAP_FAKE_TEST)
 #include "pcap_fake.h"
 
 #include <fcntl.h>
@@ -34,10 +34,10 @@ struct pcap {
     bool must_close;
     char err_buf[128];
     uint8_t* pktbuf;
+    uint32_t snaplen;
 };
 
 char* pcap_geterr(pcap_t* p) {
-    snprintf(p->err_buf, sizeof(p->err_buf), "not implemented in pcap_fake");
     return p->err_buf;
 }
 
@@ -102,6 +102,10 @@ pcap_t* pcap_fopen_offline(FILE* fp, char* errbuf) {
                  header.version_minor);
         return 0;
     }
+    if (header.snaplen == 0 || header.snaplen > PCAP_MAX_SNAPLEN) {
+        snprintf(errbuf, PCAP_ERRBUF_SIZE, "Invalid pcap snaplen %u", header.snaplen);
+        return 0;
+    }
 
     pcap_t* ret = (pcap_t*)calloc(1, sizeof(pcap_t));
     if (ret == 0) {
@@ -125,6 +129,7 @@ pcap_t* pcap_fopen_offline(FILE* fp, char* errbuf) {
     ret->fp = fp;
     ret->swapped = swapped;
     ret->linktype = header.linktype;
+    ret->snaplen = header.snaplen;
     return ret;
 }
 
@@ -173,8 +178,18 @@ int pcap_loop(pcap_t* p, int cnt, pcap_handler callback, uint8_t* user) {
             hdr.len = swap4(hdr.len);
         }
 
+        if (hdr.caplen > p->snaplen) {
+            p->error = true;
+            snprintf(p->err_buf, sizeof(p->err_buf), "Packet caplen %u exceeds snaplen %u", hdr.caplen, p->snaplen);
+            return -1;
+        }
+
         /* Read the packet */
-        if (fread(p->pktbuf, hdr.caplen, 1, p->fp) != 1) break; // no more to read
+        if (fread(p->pktbuf, hdr.caplen, 1, p->fp) != 1) {
+            p->error = true;
+            snprintf(p->err_buf, sizeof(p->err_buf), "Truncated packet data");
+            return -1;
+        }
 
         // DEBUG(100) ("pcap_fake: read tv_sec.tv_usec=%d.%06d  caplen=%d  len=%d",
         // (int)hdr.ts.tv_sec,(int)hdr.ts.tv_usec,hdr.caplen,hdr.len);

--- a/src/be20_api/pcap_fake.h
+++ b/src/be20_api/pcap_fake.h
@@ -22,6 +22,8 @@ __BEGIN_DECLS
 #define PCAP_VERSION_MINOR 4
 #define PCAP_ERRBUF_SIZE 256
 
+constexpr uint32_t PCAP_MAX_SNAPLEN = 262144;
+
 struct pcap_file_header {
     uint32_t magic;         // d4 c3 b2 a1
     uint16_t version_major; // 02 00

--- a/src/be20_api/test_pcap_fake.cpp
+++ b/src/be20_api/test_pcap_fake.cpp
@@ -1,0 +1,77 @@
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include <cstdio>
+#include <cstring>
+
+#include "pcap_fake.h"
+
+namespace {
+FILE *pcap_file(uint32_t snaplen, uint32_t caplen = 0, size_t data_size = 0)
+{
+    FILE *fp = tmpfile();
+    REQUIRE(fp != nullptr);
+
+    pcap_file_header header {};
+    header.magic = 0xa1b2c3d4;
+    header.version_major = PCAP_VERSION_MAJOR;
+    header.version_minor = PCAP_VERSION_MINOR;
+    header.snaplen = snaplen;
+    REQUIRE(fwrite(&header, sizeof(header), 1, fp) == 1);
+
+    if (caplen != 0) {
+        uint32_t value = 0;
+        REQUIRE(fwrite(&value, sizeof(value), 1, fp) == 1);
+        REQUIRE(fwrite(&value, sizeof(value), 1, fp) == 1);
+        REQUIRE(fwrite(&caplen, sizeof(caplen), 1, fp) == 1);
+        REQUIRE(fwrite(&caplen, sizeof(caplen), 1, fp) == 1);
+        for (size_t i = 0; i < data_size; i++) { REQUIRE(fputc(0, fp) != EOF); }
+    }
+    rewind(fp);
+    return fp;
+}
+
+void count_packet(uint8_t *count, const pcap_pkthdr *, const uint8_t *)
+{
+    ++*count;
+}
+}
+
+TEST_CASE("pcap fallback rejects oversized snaplen", "[pcap_fake]")
+{
+    char errbuf[PCAP_ERRBUF_SIZE] {};
+    FILE *fp = pcap_file(PCAP_MAX_SNAPLEN + 1);
+    REQUIRE(pcap_fopen_offline(fp, errbuf) == nullptr);
+    REQUIRE(std::strstr(errbuf, "snaplen") != nullptr);
+    fclose(fp);
+}
+
+TEST_CASE("pcap fallback rejects a record larger than snaplen", "[pcap_fake]")
+{
+    char errbuf[PCAP_ERRBUF_SIZE] {};
+    FILE *fp = pcap_file(64, 65);
+    pcap_t *pcap = pcap_fopen_offline(fp, errbuf);
+    REQUIRE(pcap != nullptr);
+
+    uint8_t callbacks = 0;
+    REQUIRE(pcap_loop(pcap, 1, count_packet, &callbacks) == -1);
+    REQUIRE(callbacks == 0);
+    REQUIRE(std::strstr(pcap_geterr(pcap), "exceeds snaplen") != nullptr);
+    pcap_close(pcap);
+    fclose(fp);
+}
+
+TEST_CASE("pcap fallback rejects truncated packet data", "[pcap_fake]")
+{
+    char errbuf[PCAP_ERRBUF_SIZE] {};
+    FILE *fp = pcap_file(64, 64, 1);
+    pcap_t *pcap = pcap_fopen_offline(fp, errbuf);
+    REQUIRE(pcap != nullptr);
+
+    uint8_t callbacks = 0;
+    REQUIRE(pcap_loop(pcap, 1, count_packet, &callbacks) == -1);
+    REQUIRE(callbacks == 0);
+    REQUIRE(std::strstr(pcap_geterr(pcap), "Truncated") != nullptr);
+    pcap_close(pcap);
+    fclose(fp);
+}


### PR DESCRIPTION
Fixes #501.

The no-libpcap fallback previously allocated the file-header snaplen without a bound, then read each record caplen without confirming that it fit.

This change rejects zero or oversized snaplen values, rejects records whose caplen exceeds snaplen before reading, and reports truncated packet data as an error. A dedicated fallback-reader test binary runs even when libpcap is installed and covers each malformed input case.

Validation: `make check -j1`; `make distcheck -j1`.