### PR TITLE
Fix feature recorder histogram contract

### DIFF
--- a/src/TECH_DEBT.md
+++ b/src/TECH_DEBT.md
@@ -351,19 +351,6 @@ Packet dispatch is currently disabled in `scanner_set`, which limits immediate
 reachability but also means tests do not protect this code. Either repair and
 test the packet API using byte-wise parsing, or remove the dormant subsystem.
 
-#### Feature-recorder undefined behavior and incomplete low-memory path
-
-`feature_recorder_file::banner_stamp()` dereferences `line.end()` while trying
-to trim a line ending. Dereferencing the end iterator is undefined; `getline`
-already removes `\n`. Use `line.back()` after an emptiness check if `\r` must be
-removed.
-
-`histograms_write_largest()` is explicitly unimplemented even though the
-interface identifies it as the low-memory relief mechanism. The file-based
-histogram loop reaches EOF and then repeats up to ten times without clearing or
-rewinding the stream. Specify and test a bounded spill/merge algorithm or
-remove the nonfunctional fallback.
-
 ### P2: correctness and maintainability
 
 #### Phase-1 sampling and error semantics
@@ -748,10 +735,6 @@ appropriate validation.
 - [ ] Fix IPv6 packet address accessors that apply byte offsets as `ip6_addr` element offsets.
 - [ ] Replace potentially unaligned Ethernet/IP structure casts with checked byte-wise parsing.
 - [ ] Validate enough Ethernet bytes for the complete structure actually accessed.
-- [ ] Stop dereferencing `line.end()` in `feature_recorder_file::banner_stamp`.
-- [ ] Implement or remove the advertised `histograms_write_largest` low-memory mechanism.
-- [ ] Clear and rewind file-based histogram streams before retrying after EOF.
-
 ### P2: phase processing and scanner correctness
 
 - [ ] Make random sampling choose only valid block indexes below `max_blocks`.

--- a/src/be20_api/feature_recorder.h
+++ b/src/be20_api/feature_recorder.h
@@ -53,11 +53,8 @@
  * a second feature_recorder.
  *
  * Histogram - New in BE2.0, the histograms are built on-the-fly as features are recorded.
- * If memory runs below the LOW_MEMORY_THRESHOLD defined in the feature_recorder_sert,
- * the largest feature recorder is written to disk and a new feature_recorder histogram is started.
- *
- * When the feature_recorder_set shuts down, all remaining histograms are written to the disk.
- * Then, if there is any case where multiple histogram files were written, a merge-sort is performed.
+ * Histograms are written when the feature_recorder_set shuts down. When incremental
+ * histograms are disabled, they are generated from the feature files instead.
  */
 
 struct feature_recorder_def {
@@ -346,7 +343,6 @@ public:
     // set up the histogram
     virtual void histogram_add(const histogram_def &h) = 0;                // add a new histogram definition
     virtual size_t histogram_count() = 0;            // how many histograms this feature recorder has
-    virtual bool histograms_write_largest() = 0;      // flushes largest histogram. returns false if no histogram could be flushed. For low memory.
     virtual void histograms_write_all() = 0;
 
     // Called after each feature and context are processed, to support incremental histograms.

--- a/src/be20_api/feature_recorder_file.cpp
+++ b/src/be20_api/feature_recorder_file.cpp
@@ -144,9 +144,7 @@ void feature_recorder_file::banner_stamp(std::ostream& os, const std::string& he
         if (i.is_open()) {
             std::string line;
             while (getline(i, line)) {
-                if (line.size() > 0 && ((*line.end() == '\r') || (*line.end() == '\n'))) {
-                    line.erase(line.end()); /* remove the last character while it is a \n or \r */
-                }
+                if (!line.empty() && line.back() == '\r') { line.pop_back(); }
                 os << "# " << line << std::endl;
                 banner_lines++;
             }
@@ -268,12 +266,6 @@ size_t feature_recorder_file::histogram_count()
     return histograms.size();
 }
 
-bool feature_recorder_file::histograms_write_largest()
-{
-    std::cerr << "TODO: Implement histograms_write_largest\n";
-    return false;                       // need to implement
-}
-
 /* Write all of the histograms associated with this feature recorder. */
 void feature_recorder_file::histograms_write_all()
 {
@@ -332,26 +324,24 @@ void feature_recorder_file::histogram_write_from_file(AtomicUnicodeHistogram& h)
         std::cerr << "Cannot open histogram input file: " << ifname << std::endl;
         return;
     }
-    for (int histogram_counter = 0 ; histogram_counter<MAX_HISTOGRAM_FILES; histogram_counter++){
-        std::string line;
-        while(getline(f,line)){
-            if(line.size()==0) continue; // empty line
-            if(line[0]=='#') continue;   // comment line
-            truncate_at(line,'\r');      // truncate at a \r if there is one.
+    std::string line;
+    while(getline(f,line)){
+        if(line.size()==0) continue; // empty line
+        if(line[0]=='#') continue;   // comment line
+        truncate_at(line,'\r');      // truncate at a \r if there is one.
 
-            std::string feature;
-            std::string context;
-            if (extract_feature_context(line, feature, context)) {
-                /* if the feature is in the context, feature is in utf8, otherwise it was utf16 and converted */
-                bool found_utf16 = (context.find(feature) == std::string::npos);
-                try {
-                    h.add0( feature, context, found_utf16 );
-                }
-                catch (const std::bad_alloc &e) {
-                    std::cerr << "MEMORY OVERFLOW GENERATING HISTOGRAM  "
-                              << name << ". Dumping Histogram " << histogram_counter << std::endl;
-                    histogram_write_from_memory(h);
-                }
+        std::string feature;
+        std::string context;
+        if (extract_feature_context(line, feature, context)) {
+            /* if the feature is in the context, feature is in utf8, otherwise it was utf16 and converted */
+            bool found_utf16 = (context.find(feature) == std::string::npos);
+            try {
+                h.add0( feature, context, found_utf16 );
+            }
+            catch (const std::bad_alloc &e) {
+                std::cerr << "MEMORY OVERFLOW GENERATING HISTOGRAM  "
+                          << name << ". Dumping Histogram" << std::endl;
+                histogram_write_from_memory(h);
             }
         }
     }

--- a/src/be20_api/feature_recorder_file.h
+++ b/src/be20_api/feature_recorder_file.h
@@ -66,8 +66,6 @@ public:
     /* histogram support.
     * The file based feature recorder can store the histogram incrementally in memory or it can make it at the end in a second pass.
     */
-    static const inline int MAX_HISTOGRAM_FILES = 10; // don't make more than 10 files in low-memory conditions
-
     // the histograms are made in memory with the AtomicUnicodeHistogram object.
     // Each one contains the histogram_def.
     std::vector<std::unique_ptr<AtomicUnicodeHistogram>> histograms{};
@@ -81,7 +79,6 @@ public:
     virtual void histogram_write_from_file(AtomicUnicodeHistogram& h); // actually write this histogram
     virtual void histogram_write(AtomicUnicodeHistogram& h); // write this histogram
     virtual void histograms_incremental_add_feature_context(const std::string& feature, const std::string& context) override;
-    virtual bool histograms_write_largest() override;
     virtual void histograms_write_all() override;
 };
 

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -539,6 +539,48 @@ TEST_CASE("feature_recorder_tests", "[feature_recorder]") {
 
 }
 
+TEST_CASE("feature recorder banner removes CR from CRLF input", "[feature_recorder]") {
+    feature_recorder_set::flags_t flags;
+    flags.no_alert = true;
+    scanner_config sc;
+    sc.outdir = NamedTemporaryDirectory();
+    const auto banner = sc.outdir / "banner.txt";
+    {
+        std::ofstream out(banner);
+        out << "banner line\r\n";
+    }
+
+    feature_recorder_set frs(flags, sc);
+    frs.banner_filename = banner;
+    auto& fr = frs.create_feature_recorder("test");
+    fr.write_buf(sbuf_t("x"), 0, 1);
+    fr.flush();
+
+    const auto lines = getLines(sc.outdir / "test.txt");
+    REQUIRE(lines.at(0) == "# banner line");
+}
+
+TEST_CASE("file-backed histograms consume feature files once", "[feature_recorder]") {
+    feature_recorder_set::flags_t flags;
+    flags.no_alert = true;
+    scanner_config sc;
+    sc.outdir = NamedTemporaryDirectory();
+    feature_recorder_set frs(flags, sc);
+    auto& fr = frs.create_feature_recorder("test");
+    fr.disable_incremental_histograms = true;
+    frs.histogram_add(histogram_def("test", "test", "", "", "histogram", histogram_def::flags_t()));
+
+    fr.write(pos0_t(), "one", "one context");
+    fr.write(pos0_t("", 1), "one", "one context");
+    fr.write(pos0_t("", 2), "two", "two context");
+    fr.flush();
+    frs.histograms_generate();
+
+    const auto lines = getLines(sc.outdir / "test_histogram.txt");
+    REQUIRE(std::find(lines.begin(), lines.end(), "n=2\tone") != lines.end());
+    REQUIRE(std::find(lines.begin(), lines.end(), "n=1\ttwo") != lines.end());
+}
+
 /** feature_recorder_file functions */
 TEST_CASE("file_support","[feature_recorder_file]") {
     std::string line {"one\ttwo\tthree\\133"};


### PR DESCRIPTION
Fixes #510.

`banner_stamp()` no longer dereferences the one-past-end iterator while handling CRLF banner files. The unimplemented and uncalled low-memory histogram API, its misleading documentation, and the ineffective EOF loop are removed.

A real feature-recorder output test verifies that a CRLF banner produces a clean banner line.

Validation: `make check -j1`; `make distcheck -j1`.