### PR TITLE
Propagate banner files to feature recorders

### DIFF
--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -66,6 +66,7 @@ scanner_set::scanner_set(scanner_config& sc_, const feature_recorder_set::flags_
     debug_flags.debug_sbuf_gc              = getenv_debug("DEBUG_SBUF_GC");
     debug_flags.debug_sbuf_gc0             = getenv_debug("DEBUG_SBUF_GC0");
     fs.flags.pedantic                      = getenv_debug("DEBUG_FS_PEDANTIC");
+    fs.banner_filename                     = sc.banner_file;
     pool.debug                             = getenv_debug("DEBUG_THREAD_POOL");
 
     const char *dsi = std::getenv("DEBUG_SCANNERS_IGNORE");

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -249,6 +249,22 @@ TEST_CASE("e2e-0", "[end-to-end]") {
     grep( "debug:work_stop", xml_file);
 }
 
+TEST_CASE("e2e banner file", "[end-to-end]") {
+    const std::filesystem::path inpath = test_dir() / "nps-2010-emails.100k.raw";
+    const std::filesystem::path outdir = NamedTemporaryDirectory();
+    const std::filesystem::path banner = outdir / "banner.txt";
+    std::ofstream(banner) << "test banner\nsecond line\n";
+    const std::string inpath_string = inpath.string();
+    const std::string outdir_string = outdir.string();
+    const std::string banner_string = banner.string();
+    std::stringstream cout, cerr;
+    const char *argv[] = {"bulk_extractor", "-0q", "-b", banner_string.c_str(), "-o", outdir_string.c_str(), inpath_string.c_str(), nullptr};
+
+    REQUIRE(run_be(cout, cerr, argv) == 0);
+    grep("# test banner", outdir / "email.txt");
+    grep("# second line", outdir / "email.txt");
+}
+
 TEST_CASE("e2e-disk-write-error-stops-notifier", "[end-to-end]") {
 #if defined(HAVE_SYS_RESOURCE_H) && defined(HAVE_SIGNAL_H)
     std::filesystem::path inpath = test_dir() / "nps-2010-emails.100k.raw";


### PR DESCRIPTION
Fixes #370.

`-b FILE` was parsed into `scanner_config` but never copied into `feature_recorder_set`, so generated feature files omitted the requested banner. This propagates the configured file and adds an end-to-end CLI regression test verifying that banner lines prefix generated feature output.

Validation: `make check -j1`; `make distcheck -j1`.