### PR TITLE
Preserve features after histogram allocation failures

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -46,7 +46,7 @@ jobs:
           lcov --list linux-coverage.filtered.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           disable_search: true

--- a/src/be20_api/feature_recorder_file.cpp
+++ b/src/be20_api/feature_recorder_file.cpp
@@ -351,6 +351,7 @@ void feature_recorder_file::histogram_write_from_file(AtomicUnicodeHistogram& h)
                     std::cerr << "MEMORY OVERFLOW GENERATING HISTOGRAM  "
                               << name << ". Dumping Histogram " << histogram_counter << std::endl;
                     histogram_write_from_memory(h);
+                    h.add0(feature, context, found_utf16);
                 }
             }
         }

--- a/src/be20_api/feature_recorder_file.cpp
+++ b/src/be20_api/feature_recorder_file.cpp
@@ -330,20 +330,19 @@ void feature_recorder_file::histogram_write_from_file(AtomicUnicodeHistogram& h)
         if(line[0]=='#') continue;   // comment line
         truncate_at(line,'\r');      // truncate at a \r if there is one.
 
-            std::string feature;
-            std::string context;
-            if (extract_feature_context(line, feature, context)) {
-                /* if the feature is in the context, feature is in utf8, otherwise it was utf16 and converted */
-                bool found_utf16 = (context.find(feature) == std::string::npos);
-                try {
-                    h.add0( feature, context, found_utf16 );
-                }
-                catch (const std::bad_alloc &e) {
-                    std::cerr << "MEMORY OVERFLOW GENERATING HISTOGRAM  "
-                              << name << ". Dumping Histogram " << histogram_counter << std::endl;
-                    histogram_write_from_memory(h);
-                    h.add0(feature, context, found_utf16);
-                }
+        std::string feature;
+        std::string context;
+        if (extract_feature_context(line, feature, context)) {
+            /* if the feature is in the context, feature is in utf8, otherwise it was utf16 and converted */
+            bool found_utf16 = (context.find(feature) == std::string::npos);
+            try {
+                h.add0(feature, context, found_utf16);
+            }
+            catch (const std::bad_alloc &) {
+                std::cerr << "MEMORY OVERFLOW GENERATING HISTOGRAM "
+                          << name << ". Dumping Histogram" << std::endl;
+                histogram_write_from_memory(h);
+                h.add0(feature, context, found_utf16);
             }
         }
     }

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -552,6 +552,30 @@ TEST_CASE("file_support","[feature_recorder_file]") {
 
 }
 
+TEST_CASE("file-backed histograms preserve the feature that triggers a simulated allocation failure", "[feature_recorder]") {
+    feature_recorder_set::flags_t flags;
+    flags.no_alert = true;
+    scanner_config sc;
+    sc.outdir = NamedTemporaryDirectory();
+    feature_recorder_set frs(flags, sc);
+    auto& fr = frs.create_feature_recorder("test");
+    fr.disable_incremental_histograms = true;
+    frs.histogram_add(histogram_def("test", "test", "", "", "histogram", histogram_def::flags_t()));
+    fr.write(pos0_t(), "one", "one context");
+    fr.write(pos0_t("", 1), "two", "two context");
+    fr.flush();
+
+    AtomicUnicodeHistogram::debug_histogram_malloc_fail_frequency = 2;
+    frs.histograms_generate();
+    AtomicUnicodeHistogram::debug_histogram_malloc_fail_frequency = 0;
+
+    std::vector<std::string> lines = getLines(sc.outdir / "test_histogram.txt");
+    auto spilled = getLines(sc.outdir / "test_histogram_1.txt");
+    lines.insert(lines.end(), spilled.begin(), spilled.end());
+    REQUIRE(std::find(lines.begin(), lines.end(), "n=1\tone") != lines.end());
+    REQUIRE(std::find(lines.begin(), lines.end(), "n=1\ttwo") != lines.end());
+}
+
 
 /** test the path printer
  */


### PR DESCRIPTION
Fixes #534.

The histogram code already had a deterministic allocation-failure failpoint, but no test exercised it. When the failpoint threw while generating a file-backed histogram, the triggering feature was silently dropped after the partial histogram spill.

Retry that feature after spilling the partial histogram, and add a deterministic regression test that forces the failure without exhausting real memory and verifies both features are retained across spill files.

Validation: `make check -j1`; `make distcheck -j1`.