### PR TITLE
Fix code scanning alerts

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,6 +4,8 @@
 # COVERITY_SCAN_TOKEN, with the token from the Coverity project page (e.g., https://scan.coverity.com/projects/moshekaplan-duckdb?tab=project_settings )
 # Also, ensure that the 'github.repository' comparison and 'COVERITY_PROJECT_NAME' values below are accurate
 name: Coverity Scan
+permissions:
+  contents: read
 on:
   schedule:
   # Run once monthly, bulk_extractor is at ~175k LOC

--- a/src/scan_sqlite.cpp
+++ b/src/scan_sqlite.cpp
@@ -67,7 +67,7 @@ void scan_sqlite(scanner_params &sp)
                 (pagesize == 32768) || (pagesize == 65536)) {
 
                 uint32_t dbsize_in_pages = sbuf.get32uBE(begin+28);
-                size_t   dbsize = pagesize * dbsize_in_pages;
+                size_t   dbsize = static_cast<size_t>(pagesize) * dbsize_in_pages;
 
                 if (dbsize>0 && dbsize_in_pages>=1){
 

--- a/src/scan_sqlite.cpp
+++ b/src/scan_sqlite.cpp
@@ -72,7 +72,7 @@ void scan_sqlite(scanner_params &sp)
                 if (dbsize>0 && dbsize_in_pages>=1){
 
                     /* Write it out! */
-                    sqlite_recorder.carve(sbuf_t(sbuf,begin,begin+dbsize),".sqlite3");
+                    sqlite_recorder.carve(sbuf_t(sbuf,begin,dbsize),".sqlite3");
 
                     /* Worry about overflow */
                     if (( i+begin+dbsize-1) <= i) return; // would send us backwards or avoid movement

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -58,6 +58,8 @@
 
 #include "test_be.h"
 
+extern "C" void scan_sqlite(scanner_params& sp);
+
 #ifdef HAVE_EXIV2
 extern "C" void scan_exiv2(scanner_params& sp);
 #endif
@@ -503,6 +505,30 @@ TEST_CASE("scan_msxml","[scanners]") {
     REQUIRE( bufstr.find("http://maps.google.com/mapfiles/kml/pal3/icon19.png") != std::string::npos);
     REQUIRE( bufstr.find("A collection showing how easy it is to create 3-dimensional") != std::string::npos);
     delete sbufp;
+}
+
+TEST_CASE("scan_sqlite_carve_length", "[scanners]") {
+    constexpr size_t prefix_size = 64;
+    constexpr size_t page_size = 512;
+    constexpr size_t trailer_size = 64;
+    std::string data(prefix_size + page_size + trailer_size, '\x7f');
+    data.replace(prefix_size, 16, std::string("SQLite format 3\0", 16));
+    data[prefix_size + 16] = 0x02; // 512-byte page size, big-endian
+    data[prefix_size + 17] = 0x00;
+    data[prefix_size + 28] = 0x00; // one database page, big-endian
+    data[prefix_size + 29] = 0x00;
+    data[prefix_size + 30] = 0x00;
+    data[prefix_size + 31] = 0x01;
+
+    auto outdir = test_scanner(scan_sqlite, sbuf_t::sbuf_malloc(pos0_t(), data));
+    std::vector<std::filesystem::path> carved_files;
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(outdir / "sqlite_carved")) {
+        if (entry.is_regular_file()) {
+            carved_files.push_back(entry.path());
+        }
+    }
+    REQUIRE(carved_files.size() == 1);
+    REQUIRE(std::filesystem::file_size(carved_files.front()) == page_size);
 }
 
 TEST_CASE("scan_json1", "[scanners]") {


### PR DESCRIPTION
## Summary

- Widen SQLite page-size multiplication before calculating the database size.
- Restrict the scheduled Coverity workflow token to read-only repository contents.

## Security impact

The SQLite calculation can no longer overflow in `unsigned int` before being stored in `size_t`; the Coverity job no longer inherits broader repository-default `GITHUB_TOKEN` permissions.

## Validation

- `make -C src check TESTS=test_be`