### PR TITLE
Limit ZIP carved filenames

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -118,7 +118,7 @@ scanners_builtin = \
 	scan_winprefetch.cpp \
 	scan_wordlist.cpp scan_wordlist.h \
 	scan_xor.cpp \
-	scan_zip.cpp \
+	scan_zip.cpp scan_zip.h \
 	pcap_writer.cpp \
 	pcap_writer.h
 

--- a/src/scan_zip.cpp
+++ b/src/scan_zip.cpp
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include "sbuf_decompress.h"
+#include "scan_zip.h"
 #include "be20_api/scanner_params.h"
 #include "dfxml_cpp/src/dfxml_writer.h"
 #include "utf8.h"
@@ -18,6 +19,17 @@ static const std::string  ZIP_RECORDER_NAME {"zip"};
 static uint32_t  zip_max_uncompr_size = 256*1024*1024; // don't decompress objects larger than this
 static uint32_t  zip_min_uncompr_size = 6;	// don't bother with objects smaller than this
 static uint32_t  zip_name_len_max = 1024;
+static const size_t ZIP_CARVE_FILENAME_MAX = 64;
+
+std::string zip_carve_filename(const std::string &name)
+{
+    std::string carve_name("_");
+    for (const auto ch : name) {
+        if (carve_name.size() == ZIP_CARVE_FILENAME_MAX) break;
+        carve_name.push_back((ch == '/' || ch == '\\') ? '_' : ch);
+    }
+    return carve_name;
+}
 
 /* These are to eliminate compiler warnings */
 #define ZLIB_CONST
@@ -137,11 +149,7 @@ inline void scan_zip_component(scanner_params &sp, feature_recorder &zip_recorde
             xmlstream << "<disposition bytes='" << decomp->bufsize << "'>decompressed</disposition></zipinfo>";
             zip_recorder.write(pos0+pos,name,xmlstream.str());
 
-            std::string carve_name("_"); // begin with a _
-            for(auto const &it : name ){
-                carve_name.push_back((it=='/' || it=='\\') ? '_' : it);
-            }
-            zip_recorder.carve(*decomp, carve_name, mtime);
+            zip_recorder.carve(*decomp, zip_carve_filename(name), mtime);
 
             // recurse. Remember that recurse will free the sbuf
             sp.recurse( decomp );

--- a/src/scan_zip.h
+++ b/src/scan_zip.h
@@ -1,0 +1,8 @@
+#ifndef SCAN_ZIP_H
+#define SCAN_ZIP_H
+
+#include <string>
+
+std::string zip_carve_filename(const std::string &name);
+
+#endif

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -52,6 +52,7 @@
 #include "scan_msxml.h"
 #include "scan_net.h"
 #include "scan_pdf.h"
+#include "scan_zip.h"
 #include "scan_vcard.h"
 #include "scan_vin.h"
 #include "scan_wordlist.h"
@@ -1074,4 +1075,12 @@ TEST_CASE("scan_zip", "[scanners]") {
     REQUIRE( std::filesystem::exists( outdir / "zip/000/testfilex.docx____-0-ZIP-0__Content_Types_.xml") == true);
     REQUIRE( requireFeature(email_txt,"1771-ZIP-402\tuser_docx@microsoftword.com"));
     REQUIRE( requireFeature(email_txt,"2396-ZIP-1012\tuser_docx@microsoftword.com"));
+}
+
+TEST_CASE("zip_carve_filename_limit", "[scanners]") {
+    const std::string name(100, 'a');
+    const auto carved = zip_carve_filename(name);
+    REQUIRE(carved.size() == 64);
+    REQUIRE(carved.front() == '_');
+    REQUIRE(zip_carve_filename("dir\\file") == "_dir_file");
 }


### PR DESCRIPTION
## Summary

- Preserve long ZIP entry names for parsing and metadata.
- Limit only the derived carved filename to 64 bytes and normalize path separators.
- Add a regression test for the length limit and separator handling.

## Root cause

The ZIP scanner used the entry name directly when constructing the carved-file suffix. Long component names could push the operating-system filename beyond its limit after bulk_extractor added its path metadata.

## Validation

- `make -C src check TESTS=test_be`