### PR TITLE
Honor --max_minute_wait

### DIFF
--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -231,6 +231,11 @@ void scanner_set::join()
     }
 }
 
+bool scanner_set::join(std::chrono::seconds maximum_wait)
+{
+    return !threading || pool.join(maximum_wait);
+}
+
 /****************************************************************
  *** cpu benchmark thread
  ****************************************************************/

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -214,6 +214,7 @@ public:
     void update_queue_stats(const sbuf_t *sbufp, int dir);   // either +1 increment or -1 decrement
     void thread_set_status(const std::string &status); // designed to be overridden
     void join();                                       // join the threads
+    bool join(std::chrono::seconds maximum_wait);      // false if the threads do not finish in time
     void add_scanner_stat(scanner_t *, const struct stats &st);
     void debug_pool(std::ostream &os) const { pool.debug_pool(os);}
 

--- a/src/be20_api/test_be20_threadpool.cpp
+++ b/src/be20_api/test_be20_threadpool.cpp
@@ -11,12 +11,36 @@
 #include "config.h"
 #include "catch.hpp"
 
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
+#include <mutex>
 
 #include "scanner_set.h"
 #include "scan_sha1_test.h"
 
 std::filesystem::path get_tempdir();
+
+namespace {
+std::mutex blocking_scanner_mutex;
+std::condition_variable blocking_scanner_cv;
+bool blocking_scanner_started {false};
+bool release_blocking_scanner {false};
+
+void scan_blocking_test(scanner_params& sp) {
+    if (sp.phase == scanner_params::PHASE_INIT) {
+        sp.info->set_name("blocking_test");
+        sp.info->min_sbuf_size = 1;
+        return;
+    }
+    if (sp.phase == scanner_params::PHASE_SCAN) {
+        std::unique_lock<std::mutex> lock(blocking_scanner_mutex);
+        blocking_scanner_started = true;
+        blocking_scanner_cv.notify_all();
+        blocking_scanner_cv.wait(lock, [] { return release_blocking_scanner; });
+    }
+}
+}
 
 TEST_CASE("scanner_set_mt", "[thread_pool]") {
     scanner_config sc;
@@ -54,6 +78,48 @@ TEST_CASE("idle_workers_shutdown", "[thread_pool]") {
     ss.launch_workers(32);
     ss.join();
 
+    REQUIRE(ss.get_worker_count() == 0);
+    REQUIRE(ss.get_tasks_queued() == 0);
+    ss.shutdown();
+}
+
+TEST_CASE("timed_join_reports_timeout", "[thread_pool]") {
+    scanner_config sc;
+    sc.outdir = get_tempdir() / "timed_join_reports_timeout";
+    std::filesystem::create_directory(sc.outdir);
+
+    feature_recorder_set::flags_t f;
+    scanner_set ss(sc, f, nullptr);
+    ss.add_scanner(scan_blocking_test);
+    ss.apply_scanner_commands();
+    ss.phase_scan();
+    ss.launch_workers(1);
+
+    {
+        std::lock_guard<std::mutex> lock(blocking_scanner_mutex);
+        blocking_scanner_started = false;
+        release_blocking_scanner = false;
+    }
+    ss.schedule_sbuf(new sbuf_t("blocked"));
+
+    bool scanner_started;
+    {
+        std::unique_lock<std::mutex> lock(blocking_scanner_mutex);
+        scanner_started = blocking_scanner_cv.wait_for(
+            lock, std::chrono::seconds(5), [] { return blocking_scanner_started; });
+    }
+    const bool joined_before_deadline = ss.join(std::chrono::seconds(0));
+
+    {
+        std::lock_guard<std::mutex> lock(blocking_scanner_mutex);
+        release_blocking_scanner = true;
+    }
+    blocking_scanner_cv.notify_all();
+    const bool joined_after_release = ss.join(std::chrono::seconds(5));
+
+    REQUIRE(scanner_started);
+    REQUIRE_FALSE(joined_before_deadline);
+    REQUIRE(joined_after_release);
     REQUIRE(ss.get_worker_count() == 0);
     REQUIRE(ss.get_tasks_queued() == 0);
     ss.shutdown();

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -57,6 +57,21 @@ void thread_pool::join()
     TO_MAIN.wait(lock, [this] { return workers.empty(); });
 }
 
+bool thread_pool::join(std::chrono::seconds maximum_wait)
+{
+    const auto deadline = std::chrono::steady_clock::now() + maximum_wait;
+    std::unique_lock<std::mutex> lock(M);
+    while (work_queue.size() > 0 || working_workers > 0) {
+        TO_WORKER.notify_one();
+        if (TO_MAIN.wait_until(lock, deadline) == std::cv_status::timeout) {
+            return work_queue.empty() && working_workers == 0;
+        }
+    }
+    mode = 2;
+    TO_WORKER.notify_all();
+    return TO_MAIN.wait_until(lock, deadline, [this] { return workers.empty(); });
+}
+
 void thread_pool::main_thread_wait()
 {
     std::unique_lock<std::mutex> lock(M);

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -64,7 +64,7 @@ bool thread_pool::join(std::chrono::seconds maximum_wait)
     while (work_queue.size() > 0 || working_workers > 0) {
         TO_WORKER.notify_one();
         if (TO_MAIN.wait_until(lock, deadline) == std::cv_status::timeout) {
-            return work_queue.empty() && working_workers == 0;
+            return false;
         }
     }
     mode = 2;

--- a/src/be20_api/threadpool.h
+++ b/src/be20_api/threadpool.h
@@ -51,6 +51,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <atomic>
+#include <chrono>
 #include <future>      // std::future, std::promise
 
 #include "aftimer.h"
@@ -95,6 +96,7 @@ public:
     void launch_workers(size_t num_workers);
     void wait_for_tasks();              // wait until there are no tasks in work queue
     void join();                        // wait_for_tasks() and kill the workers
+    bool join(std::chrono::seconds maximum_wait); // false if workers do not finish in time
     void main_thread_wait();
     void push_task(const sbuf_t *sbuf, scanner_t *scanner);
     void push_task(const sbuf_t *sbuf);

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -269,6 +269,11 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     sc.offset_add  = result["offset_add"].as<int64_t>();
     sc.context_window_default = result["context_window"].as<int>();
     cfg.debug = result["debug"].as<int>();
+    const int max_minute_wait = result["max_minute_wait"].as<int>();
+    if (max_minute_wait <= 0) {
+        throw std::runtime_error("--max_minute_wait must be positive");
+    }
+    cfg.max_wait_time = static_cast<time_t>(max_minute_wait) * 60;
 
     try {
         sc.banner_file = result["banner_file"].as<std::string>();
@@ -621,6 +626,20 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
              << "Remove extra files and restart bulk_extractor with the exact same command line to continue." << std::endl;
         // do not call ss.shutdown() to avoid writing out histograms
         return 6;
+    }
+    catch (const Phase1::ThreadWaitTimeout &e) {
+        notify.stop();
+        try {
+            xreport->xmlout("debug:exception", e.what(),
+                            Formatter() << "name='thread_wait_timeout' maximum_wait_seconds='"
+                                        << e.maximum_wait << "'", true);
+        }
+        catch (const std::exception &) {
+        }
+        cerr << "Timed out after " << e.maximum_wait / 60
+             << " minute(s) waiting for scanner threads; terminating." << std::endl;
+        cerr.flush();
+        std::_Exit(8);
     }
 
 #ifdef USE_SQLITE3

--- a/src/phase1.cpp
+++ b/src/phase1.cpp
@@ -289,7 +289,9 @@ void Phase1::phase1_run()
     read_process_sbufs();
 
     if (!config.opt_quiet) cout << "All data read; waiting for threads to finish..." << std::endl;
-    ss.join();
+    if (!ss.join(std::chrono::seconds(config.max_wait_time))) {
+        throw ThreadWaitTimeout(config.max_wait_time);
+    }
     if (ss.disk_write_errors > 0) {
         throw feature_recorder::DiskWriteError("while scanning input");
     }

--- a/src/phase1.h
+++ b/src/phase1.h
@@ -39,6 +39,13 @@ class Phase1 {
     }
 
 public:
+    class ThreadWaitTimeout : public std::runtime_error {
+    public:
+        explicit ThreadWaitTimeout(time_t maximum_wait):
+            std::runtime_error("timed out waiting for scanner threads"), maximum_wait(maximum_wait) {}
+        const time_t maximum_wait;
+    };
+
     // because seen_page_ids are added in order, we want to use an unordered set.
     typedef std::unordered_set<std::string> seen_page_ids_t;
     static inline std::string REPORT_FILENAME {"report.xml"};

--- a/src/phase1.h
+++ b/src/phase1.h
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <memory>
 #include <ostream>
+#include <stdexcept>
 
 #include "be20_api/scanner_set.h"
 #include "be20_api/dfxml_cpp/src/dfxml_writer.h"


### PR DESCRIPTION
Fixes #404.

`--max_minute_wait` is now applied to Phase 1's wait for queued scanner work and worker shutdown. On timeout, bulk_extractor records and reports the failure, then terminates directly so cleanup cannot block on the same stuck worker.

Validation: `make -C src -s check TESTS=test_be`.