### PR TITLE
Document Codex GitHub identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AI contributor instructions
 
+GitHub activity authored by Codex must use `@${USER}-codex` when that account exists. For this workspace, use `@simsong-codex`; do not use the personal `@simsong` identity for GitHub writes, pushes, issues, pull requests, reviews, or comments.
+
 Before changing a scanner or writing a scanner plug-in, read
 [doc/scanner_api.md](doc/scanner_api.md). Start new loadable scanners from
 [doc/scanner_template.cpp](doc/scanner_template.cpp), and preserve its phase


### PR DESCRIPTION
Codex-authored GitHub activity must use @${USER}-codex when available; in this workspace that is @simsong-codex. The personal @simsong identity must not be used for GitHub writes.