### PR TITLE
Add Ubuntu MinGW Windows artifact build

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -1,0 +1,86 @@
+name: Windows MinGW build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  VCPKG_COMMIT: 40f3c709db80acf154ac4b17a1f83c564ebd022e
+  VCPKG_ROOT: ${{ github.workspace }}/.vcpkg
+
+jobs:
+  mingw:
+    name: Ubuntu MinGW executable
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Ubuntu cross-build tools and libraries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            autoconf automake binutils-mingw-w64-x86-64 cmake curl file flex g++ \
+            g++-mingw-w64-x86-64-posix gcc-mingw-w64-x86-64-posix \
+            git libgcrypt-mingw-w64-dev libgpg-error-mingw-w64-dev \
+            libtool libz-mingw-w64-dev make ninja-build pkg-config python3 \
+            unzip zip
+          sudo update-alternatives --set x86_64-w64-mingw32-gcc \
+            /usr/bin/x86_64-w64-mingw32-gcc-posix
+          sudo update-alternatives --set x86_64-w64-mingw32-g++ \
+            /usr/bin/x86_64-w64-mingw32-g++-posix
+
+      - name: Build static RE2, Abseil, and Expat
+        run: |
+          git init "$VCPKG_ROOT"
+          git -C "$VCPKG_ROOT" remote add origin https://github.com/microsoft/vcpkg.git
+          git -C "$VCPKG_ROOT" fetch --depth 1 origin "$VCPKG_COMMIT"
+          git -C "$VCPKG_ROOT" checkout --detach FETCH_HEAD
+          "$VCPKG_ROOT/bootstrap-vcpkg.sh" -disableMetrics
+          "$VCPKG_ROOT/vcpkg" install \
+            expat:x64-mingw-static \
+            re2:x64-mingw-static \
+            --host-triplet=x64-linux \
+            --clean-after-build
+
+      - name: Cross-compile bulk_extractor
+        run: |
+          bash bootstrap.sh
+          mkdir build-mingw
+          cd build-mingw
+          target_root="$VCPKG_ROOT/installed/x64-mingw-static"
+          PKG_CONFIG="pkg-config --static" \
+          PKG_CONFIG_LIBDIR="$target_root/lib/pkgconfig" \
+          CPPFLAGS="-I$target_root/include" \
+          LDFLAGS="-L$target_root/lib" \
+            ../configure --host=x86_64-w64-mingw32 --disable-libewf --quiet
+          make -j2
+
+      - name: Verify standalone Windows executable
+        run: |
+          exe=build-mingw/src/bulk_extractor.exe
+          test -s "$exe"
+          file "$exe" | grep -q 'PE32+ executable'
+          x86_64-w64-mingw32-objdump -p "$exe" \
+            | sed -n 's/^[[:space:]]*DLL Name: //p' \
+            | sort -u | tee dll-imports.txt
+          if grep -Eivq \
+            '^(ADVAPI32|DBGHELP|GDI32|KERNEL32|msvcrt|PSAPI|SHELL32|USER32|WS2_32)\.dll$' \
+            dll-imports.txt; then
+            echo "The executable imports a DLL outside the Windows system allowlist." >&2
+            exit 1
+          fi
+          cp "$exe" bulk_extractor64.exe
+
+      - name: Upload Windows executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: bulk_extractor-windows-x86_64
+          path: bulk_extractor64.exe
+          if-no-files-found: error

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -79,7 +79,7 @@ jobs:
           cp "$exe" bulk_extractor64.exe
 
       - name: Upload Windows executable
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bulk_extractor-windows-x86_64
           path: bulk_extractor64.exe

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -74,10 +74,12 @@ jobs:
           x86_64-w64-mingw32-objdump -p "$exe" \
             | sed -n 's/^[[:space:]]*DLL Name: //p' \
             | sort -u | tee dll-imports.txt
-          if grep -Eivq \
+          grep -Eiv \
             '^(ADVAPI32|DBGHELP|GDI32|KERNEL32|msvcrt|PSAPI|SHELL32|USER32|WS2_32)\.dll$' \
-            dll-imports.txt; then
-            echo "The executable imports a DLL outside the Windows system allowlist." >&2
+            dll-imports.txt > non-system-dll-imports.txt || true
+          if [[ -s non-system-dll-imports.txt ]]; then
+            echo "DLLs outside the Windows system allowlist:" >&2
+            sed 's/^/  /' non-system-dll-imports.txt >&2
             exit 1
           fi
           cp "$exe" bulk_extractor64.exe

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Verify standalone Windows executable
         run: |
           exe=build-mingw/src/.libs/bulk_extractor.exe
+          if [[ ! -s "$exe" ]]; then
+            exe=build-mingw/src/bulk_extractor.exe
+          fi
           test -s "$exe"
           test "$(stat -c %s "$exe")" -gt 1000000
           file "$exe" | grep -q 'PE32+ executable'

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -64,8 +64,9 @@ jobs:
 
       - name: Verify standalone Windows executable
         run: |
-          exe=build-mingw/src/bulk_extractor.exe
+          exe=build-mingw/src/.libs/bulk_extractor.exe
           test -s "$exe"
+          test "$(stat -c %s "$exe")" -gt 1000000
           file "$exe" | grep -q 'PE32+ executable'
           x86_64-w64-mingw32-objdump -p "$exe" \
             | sed -n 's/^[[:space:]]*DLL Name: //p' \

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -60,7 +60,7 @@ jobs:
           CPPFLAGS="-I$target_root/include" \
           LDFLAGS="-L$target_root/lib" \
             ../configure --host=x86_64-w64-mingw32 --disable-libewf --quiet
-          make -j2
+          make -j2 LDFLAGS="-L$target_root/lib -all-static"
 
       - name: Verify standalone Windows executable
         run: |

--- a/README.md
+++ b/README.md
@@ -114,11 +114,18 @@ cleanup completes.
 
 BUILDING ON WINDOWS
 ===================
-Native Windows builds of bulk_extractor 2.1 are not currently supported.
+Native Windows builds of bulk_extractor are not currently supported.
 
-Windows is not currently validated by a required parent CI job. The maintained
-repository path is cross-compilation from Fedora; start with a clean VM and use
-these commands:
+The `Windows MinGW build` GitHub Actions workflow cross-compiles the executable
+on Ubuntu for every pull request and uploads `bulk_extractor64.exe` in the
+`bulk_extractor-windows-x86_64` artifact. The workflow verifies that the PE
+executable does not import the MinGW, RE2, Abseil, Expat, zlib, or GNU crypto
+runtime DLLs. It does not use Wine or run the resulting Windows executable.
+The CI artifact is currently built without libewf, so it does not include E01
+support.
+
+The traditional repository path is cross-compilation from Fedora; start with a
+clean VM and use these commands:
 
 ```
 $ git clone https://github.com/simsong/bulk_extractor.git

--- a/src/be20_api/feature_recorder_file.cpp
+++ b/src/be20_api/feature_recorder_file.cpp
@@ -139,8 +139,8 @@ feature_recorder_file::~feature_recorder_file()
 
 void feature_recorder_file::banner_stamp(std::ostream& os, const std::string& header) const {
     int banner_lines = 0;
-    if (fs.banner_filename.size() > 0) {
-        std::ifstream i(fs.banner_filename.c_str());
+    if (!fs.banner_filename.empty()) {
+        std::ifstream i(fs.banner_filename);
         if (i.is_open()) {
             std::string line;
             while (getline(i, line)) {

--- a/src/be20_api/feature_recorder_set.h
+++ b/src/be20_api/feature_recorder_set.h
@@ -138,8 +138,8 @@ public:
     /* feature_recorder_set flags */
     /* Flags are now implemented as booleans per stroustrup 2013 */
 
-    int64_t offset_add{0};         // added to every reported offset, for use with hadoop
-    std::string banner_filename{}; // banner for top of every file
+    int64_t offset_add{0};                    // added to every reported offset, for use with hadoop
+    std::filesystem::path banner_filename{}; // banner for top of every file
 
     /* histogram support */
     void histogram_add(const histogram_def& def); // adds it to a local set or to the specific feature recorder


### PR DESCRIPTION
## Summary

- add a dedicated Ubuntu 24.04 MinGW workflow that runs for every pull request
- build RE2, Abseil, and Expat statically from a pinned vcpkg revision
- use Ubuntu's MinGW packages for zlib, libgcrypt, and libgpg-error
- upload `bulk_extractor64.exe` as the `bulk_extractor-windows-x86_64` artifact
- reject executables that import DLLs outside an explicit Windows-system allowlist
- fix `banner_filename` to use `std::filesystem::path`, as required by the Windows filesystem API
- document that this is an Ubuntu cross-build and does not use Wine

## Validation

- passed the complete `Windows MinGW build` workflow on GitHub
- downloaded the resulting 66 MB artifact and confirmed it is an x86-64 Windows PE
- confirmed it imports only Windows system DLLs: `ADVAPI32.dll`, `KERNEL32.dll`,
  `PSAPI.DLL`, `SHELL32.dll`, `USER32.dll`, `WS2_32.dll`, `dbghelp.dll`, and
  `msvcrt.dll`
- artifact SHA-256: `63d62b820729bcf86d6be713fa5ed07e43ab39dd7c13eb66d9687fbfb77978fa`
- passed `make -C src -j2 test_be && make -C src check TESTS=test_be` on macOS

## Current limitation

Ubuntu does not provide a MinGW libewf package and vcpkg does not provide a libewf port. This first CI artifact therefore uses `--disable-libewf` and does not support E01 input. The existing Fedora cross-build instructions remain documented.

Authored by Codex using `@simsong-codex`.
