### PR TITLE
Test recursive Unicode filenames on Windows

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -90,3 +90,42 @@ jobs:
           name: bulk_extractor-windows-x86_64
           path: bulk_extractor64.exe
           if-no-files-found: error
+
+  windows-unicode:
+    name: Windows Unicode filename test
+    needs: mingw
+    runs-on: windows-latest
+
+    steps:
+      - name: Download Windows executable
+        uses: actions/download-artifact@v8
+        with:
+          name: bulk_extractor-windows-x86_64
+          path: dist
+
+      - name: Scan a directory containing a Unicode filename
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Path input | Out-Null
+          $filename = Join-Path $PWD "input\©_test.txt"
+          [IO.File]::WriteAllText(
+            $filename,
+            "unicode-path@example.com`n",
+            [Text.UTF8Encoding]::new($false))
+
+          & "$PWD\dist\bulk_extractor64.exe" -R -o output input 2>&1 |
+            Tee-Object -FilePath run.log
+          if ($LASTEXITCODE -ne 0) {
+            throw "bulk_extractor exited with status $LASTEXITCODE"
+          }
+          if (Select-String -Path run.log -SimpleMatch "read error" -Quiet) {
+            throw "bulk_extractor reported a read error for the Unicode filename"
+          }
+          if (-not (Test-Path output\email.txt)) {
+            throw "bulk_extractor did not create email.txt"
+          }
+          if (-not (Select-String -Path output\email.txt `
+                -SimpleMatch "unicode-path@example.com" -Quiet)) {
+            throw "bulk_extractor did not scan the Unicode-named file"
+          }

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -86,6 +86,23 @@ TEST_CASE("directory_scan_skips_symlinks", "[image_process]")
     std::filesystem::remove_all(root);
 }
 
+TEST_CASE("directory_scan_reads_unicode_filename", "[image_process]")
+{
+    const auto root = NamedTemporaryDirectory();
+    const auto path = root / std::filesystem::u8path(u8"\u00a9_test.txt");
+    const std::string contents = "unicode-path@example.com\n";
+    std::ofstream(path, std::ios::binary) << contents;
+
+    const auto image = image_process::open(root, true, 0, 0);
+    REQUIRE(image->image_size() == 1);
+    auto it = image->begin();
+    std::unique_ptr<sbuf_t> sbuf(image->sbuf_alloc(it));
+    REQUIRE(sbuf->asString() == contents);
+    REQUIRE(image->get_pos0(it).path == path.string());
+
+    std::filesystem::remove_all(root);
+}
+
 bool has(std::string line, std::string substr)
 {
     return line.find(substr) != std::string::npos;


### PR DESCRIPTION
## Summary

- add a focused directory-reader test using the original `©_test.txt` filename
- run the distributable Ubuntu/MinGW executable on a GitHub Windows runner
- verify the Unicode-named file is read and its known email is extracted
- fail the Windows check on the original `read error` symptom

Current code already keeps the enumerated `std::filesystem::path` through file
opening. This PR adds the missing platform proof around that behavior instead
of introducing a second Windows path implementation.

Closes #91.

## Validation

- `make -C src check TESTS=test_be` — pass
- full `make -j4 check` — `test_be`, `test_dfxml`, and `test_pcap_fake` pass;
  the unrelated `machine_stats` test fails locally because this sandbox denies
  `/bin/ps`, yielding `NaN`
- `git diff --check`

The new `Windows Unicode filename test` job is the decisive Windows validation
and consumes the exact executable uploaded by the MinGW build.

Authored and published by @simsong-codex.
