### PR TITLE
Add community contribution guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Report reproducible incorrect behavior, a crash, or a build failure.
+title: "bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please do not attach forensic images, personal data, credentials, or other material you cannot publish. Use a minimized synthetic reproducer or arrange private contact with a maintainer.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: State the observed result and the result you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Include the complete command line and the smallest safe input or steps needed to reproduce it.
+      placeholder: |
+        1. ...
+        2. ...
+        Command: bulk_extractor ...
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include bulk_extractor version or commit, OS, architecture, compiler, and relevant dependency versions.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Safe diagnostic output
+      description: Paste relevant logs, configure output, stack traces, hashes, or redacted output. Explain how expected forensic results were independently verified, if applicable.
+      render: text
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and Discussions.
+          required: true
+        - label: I removed or replaced sensitive evidence with a safe reproducer or redacted diagnostics.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and early design discussion
+    url: https://github.com/simsong/bulk_extractor/discussions
+    about: Use Discussions for support, usage questions, and ideas not yet ready for an actionable issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature or enhancement
+description: Propose a bounded improvement to bulk_extractor.
+title: "proposal: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or forensic use case
+      description: Describe the concrete workflow or limitation this would address. Do not include sensitive case data.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the user-visible behavior, constraints, and acceptance criteria.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include existing tools, command-line options, or approaches that do not meet the need.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation approach
+      description: Explain how correctness, false positives/negatives, portability, and performance could be evaluated.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and Discussions.
+          required: true
+        - label: I am willing to help test or implement this change if requested.
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+Describe the change and why it is needed. Link the related issue or Discussion.
+
+## Forensic impact
+
+State the expected effect on extraction, feature output, offsets, recursion,
+false positives/negatives, compatibility, or performance. Write `None` when it
+does not affect those areas.
+
+## Validation
+
+List the commands run through the Makefile and their results. Include focused
+fixtures, platform/compiler coverage, or benchmark comparisons when relevant.
+
+```
+make check
+```
+
+## Checklist
+
+- [ ] I kept this pull request focused and updated documentation where needed.
+- [ ] I added or updated a meaningful test for changed behavior, or explained why one is not appropriate.
+- [ ] I used only redistributable, non-sensitive test data.
+- [ ] I read `doc/scanner_api.md` and used `doc/scanner_template.cpp` if this changes or adds a scanner.
+- [ ] I confirm I may contribute this work under the repository license.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Contributor Code of Conduct
+
+## Project norms
+
+bulk_extractor values rough consensus and running code. Discussion should focus
+on the technology: evidence, reproducible behavior, design tradeoffs, tests,
+and results. Avoid discussion of individuals. In particular, do not question a
+person's motives, competence, or abilities; address the technical claim instead.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people.
+* Giving and gracefully accepting constructive feedback.
+* Focusing on evidence, reproducible results, and the project rather than on
+  people.
+* Respecting differing opinions, viewpoints, and experiences.
+* Respecting the privacy, safety, and legal constraints surrounding digital
+  evidence.
+
+Examples of unacceptable behavior include:
+
+* Sexualized language or imagery, and sexual attention or advances of any kind.
+* Trolling, insulting or derogatory comments, and personal or political attacks.
+* Public or private harassment.
+* Publishing another person's private information, including evidence data,
+  without explicit permission.
+* Other conduct that could reasonably be considered inappropriate in a
+  professional setting.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing this Code of
+Conduct. They may remove, edit, or reject comments, commits, code, wiki edits,
+issues, pull requests, and other contributions that are not aligned with it.
+
+To report unacceptable behavior, contact the repository owner privately through
+their [GitHub profile](https://github.com/simsong). Reports will be reviewed
+promptly and fairly. The reporter's identity will be kept confidential unless
+disclosure is required to investigate the report or by law.
+
+Maintainers who violate this Code of Conduct may be subject to action by the
+project owner.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to bulk_extractor
+
+Thank you for helping improve bulk_extractor. Contributions that improve
+forensic correctness, reproducibility, portability, performance, documentation,
+or test coverage are especially useful.
+
+## Before opening an issue
+
+Search existing issues and Discussions first. Use an issue for a reproducible
+defect or a bounded, actionable proposal. Use a
+[Discussion](https://github.com/simsong/bulk_extractor/discussions) for support,
+usage questions, or early design exploration.
+
+Do not upload forensic images, extracted evidence, credentials, personal data,
+or other material you are not authorized to disclose. A minimized synthetic
+fixture, a redacted excerpt, a cryptographic hash, and exact reproduction steps
+are usually enough to begin investigating.
+
+For a bug report, include the version or commit, operating system and compiler,
+the complete command line, relevant configuration output, expected and actual
+results, and the smallest safe reproducer. Reports about format recognition or
+carving should also state how the expected result was independently verified.
+
+## Development workflow
+
+1. Start from current `main` and create a focused branch.
+2. Discuss substantial changes in an issue or Discussion before investing in a
+   large implementation.
+3. Keep each pull request focused, with documentation updated when behavior,
+   build requirements, or output changes.
+4. Use C++20 and follow the style of the code you change. Avoid unrelated
+   formatting churn.
+5. Run the relevant checks through the Makefile. For normal source changes,
+   run `make check`; use `make distcheck` when changing build or distribution
+   files. State the exact validation and its result in the pull request.
+
+Before changing a scanner or adding a scanner plug-in, read
+[the scanner API](doc/scanner_api.md). Start loadable scanners from
+[the scanner template](doc/scanner_template.cpp), preserve its phase and
+concurrency rules, and add focused tests that exercise the changed behavior.
+
+## Tests and fixtures
+
+Tests must assert a meaningful forensic or program behavior. Do not add tests
+solely to raise coverage. Keep fixtures small, deterministic, redistributable,
+and free of sensitive data. When a change fixes a false positive, false
+negative, offset, recursion, or format-handling bug, include a fixture that
+would fail before the fix when practical.
+
+## Pull requests and review
+
+By submitting a contribution, you confirm that you have the right to submit it
+under the repository's license. Do not include copied code or test data unless
+its license and provenance allow distribution here.
+
+Maintainers may ask for narrower scope, tests, documentation, benchmarks, or
+changes before merging. Review focuses on correctness, safety, forensic
+reproducibility, portability, maintainability, and performance. Please keep
+discussion technical and follow the [Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary

Adds the repository community-health files:

- a code of conduct centered on rough consensus, running code, and technical discussion;
- contribution guidance for C++20, focused validation, safe forensic fixtures, and scanner changes;
- structured bug and enhancement issue forms, with Discussions for questions and early design;
- a pull-request template that records forensic impact and Makefile-based validation.

## Validation

- `ruby -e 'require "yaml"; ...' .github/ISSUE_TEMPLATE/*.yml`
- `git diff --check`
- `make check`

Drafted by Codex at the repository owner's request.