### PR TITLE
Restore alert-list processing

### DIFF
--- a/doc/latex_manuals/BEUsersManual.tex
+++ b/doc/latex_manuals/BEUsersManual.tex
@@ -753,7 +753,7 @@ SilentFury2012
 www.maliciousintent.com
 \end{verbatim}
 
-While this list does not appear to help in any particular investigation, it demonstrates that you can specify distinct words that are important to their analysis. Results containing the alert list information are found in the file \texttt{alert.txt} in the \bulk output directory.
+While this list does not appear to help in any particular investigation, it demonstrates that you can specify distinct words that are important to their analysis. Results containing the alert list information are found in the file \texttt{ALERTS\_found.txt} in the \bulk output directory.
 
 \subsection{The Importance of Compressed Data Processing}
 \label{compressedProcessing}

--- a/src/be20_api/feature_recorder.cpp
+++ b/src/be20_api/feature_recorder.cpp
@@ -169,21 +169,13 @@ void feature_recorder::write(const pos0_t& pos0, const std::string &original_fea
         return;
     }
 
-    /* The alert list is a special features that are called out.
-     * If we have one of those, write it to the redlist.
-     */
-#if 0
-    if (flags.no_alertlist==false
+    /* Alert-list matches are recorded separately and remain in their normal feature file. */
+    if (def.flags.no_alertlist == false
         && fs.alert_list
-        && fs.alert_list->check_feature_context(*feature_utf8,context)) {
-        std::filesystem::path alert_fn = fs.get_outdir() + "/ALERTS_found.txt";
-        const std::lock_guard<std::mutex> lock(Mr);                // notice we are locking the alert list
-        std::ofstream rf(alert_fn.c_str(),std::ios_base::app);
-        if(rf.is_open()){
-            rf << pos0.shift(fs.offset_add).str() << '\t' << feature << '\t' << "\n";
-        }
+        && fs.alert_list->check_feature_context(feature_utf8, context)) {
+        fs.named_feature_recorder(feature_recorder_set::ALERT_LIST_RECORDER_NAME)
+            .write(pos0, feature_utf8, context);
     }
-#endif
 
     /* Write out the feature and the context */
     this->write0(pos0, feature_utf8, context);

--- a/src/be20_api/feature_recorder.cpp
+++ b/src/be20_api/feature_recorder.cpp
@@ -172,9 +172,10 @@ void feature_recorder::write(const pos0_t& pos0, const std::string &original_fea
     /* Alert-list matches are recorded separately and remain in their normal feature file. */
     if (def.flags.no_alertlist == false
         && fs.alert_list
+        && fs.alert_list->size() > 0
         && fs.alert_list->check_feature_context(feature_utf8, context)) {
         fs.named_feature_recorder(feature_recorder_set::ALERT_LIST_RECORDER_NAME)
-            .write(pos0, feature_utf8, context);
+            .write0(pos0, feature_utf8, context);
     }
 
     /* Write out the feature and the context */

--- a/src/be20_api/feature_recorder_set.cpp
+++ b/src/be20_api/feature_recorder_set.cpp
@@ -25,6 +25,7 @@
  */
 
 const std::string feature_recorder_set::ALERT_RECORDER_NAME = "alerts";
+const std::string feature_recorder_set::ALERT_LIST_RECORDER_NAME = "ALERTS_found";
 // const std::string feature_recorder_set::DISABLED_RECORDER_NAME = "disabled";
 
 /* be_hash. Currently this just returns the MD5 of the sbuf,
@@ -120,6 +121,18 @@ void feature_recorder_set::create_alert_recorder() {
     if (!flags.no_alert) {
         create_feature_recorder(feature_recorder_set::ALERT_RECORDER_NAME); // make the alert recorder
     }
+}
+
+void feature_recorder_set::create_alert_list_recorder()
+{
+    if (alert_list == nullptr || alert_list->size() == 0) {
+        return;
+    }
+
+    feature_recorder_def::flags_t flags;
+    flags.no_stoplist = true;
+    flags.no_alertlist = true;
+    create_feature_recorder(feature_recorder_def(ALERT_LIST_RECORDER_NAME, flags));
 }
 
 void feature_recorder_set::create_stop_list_recorders()

--- a/src/be20_api/feature_recorder_set.cpp
+++ b/src/be20_api/feature_recorder_set.cpp
@@ -129,10 +129,10 @@ void feature_recorder_set::create_alert_list_recorder()
         return;
     }
 
-    feature_recorder_def::flags_t flags;
-    flags.no_stoplist = true;
-    flags.no_alertlist = true;
-    create_feature_recorder(feature_recorder_def(ALERT_LIST_RECORDER_NAME, flags));
+    feature_recorder_def::flags_t recorder_flags;
+    recorder_flags.no_stoplist = true;
+    recorder_flags.no_alertlist = true;
+    create_feature_recorder(feature_recorder_def(ALERT_LIST_RECORDER_NAME, recorder_flags));
 }
 
 void feature_recorder_set::create_stop_list_recorders()

--- a/src/be20_api/feature_recorder_set.h
+++ b/src/be20_api/feature_recorder_set.h
@@ -121,10 +121,12 @@ public:
     const hash_def hasher; // name and function that perform hashing; set by allocator
 
     static const std::string ALERT_RECORDER_NAME; // the name of the alert recorder
+    static const std::string ALERT_LIST_RECORDER_NAME; // features matched by the user alert list
     // static const std::string   DISABLED_RECORDER_NAME; // the fake disabled feature recorder
 
     void set_stop_list(const word_and_context_list* alist) { stop_list = alist; }
     void set_alert_list(const word_and_context_list* alist) { alert_list = alist; }
+    void create_alert_list_recorder();
     void create_stop_list_recorders();
 
     /** Initialize a feature_recorder_set. Previously this was a constructor, but it turns out that

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -555,6 +555,7 @@ void scanner_set::apply_scanner_commands() {
     scanner_params sp(sc, this, nullptr, scanner_params::PHASE_INIT2, nullptr);
     for (const auto &it : enabled_scanners) { (*it)(sp); }
 
+    fs.create_alert_list_recorder();
     fs.create_stop_list_recorders();
 
     /* set the carve defaults from the command line (-S jpeg_carve_mode=...) or the scanner definitions if one is not provided*/

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -150,6 +150,7 @@ public:
     class dfxml_writer* writer {nullptr};          // if provided, a dfxml writer. Mutext locking done by dfxml_writer.h
     void set_dfxml_writer(class dfxml_writer *writer_);
     class dfxml_writer *get_dfxml_writer() const;
+    void set_alert_list(const word_and_context_list *list) { fs.set_alert_list(list); }
     void set_stop_list(const word_and_context_list *list) { fs.set_stop_list(list); }
 
     // timing info

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -476,7 +476,9 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
     struct feature_recorder_set::flags_t f;
     scanner_set ss( sc, f, nullptr);     // make a scanner_set but with no XML writer. We will create it below
-    ss.set_alert_list(&alert_list);
+    if (alert_list.size() > 0) {
+        ss.set_alert_list(&alert_list);
+    }
     ss.set_stop_list(&stop_list);
     ss.add_scanners( scanners_builtin );
     for (const auto &scanner_dir : scanner_dirs) ss.add_scanner_directory(scanner_dir);

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -476,6 +476,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
     struct feature_recorder_set::flags_t f;
     scanner_set ss( sc, f, nullptr);     // make a scanner_set but with no XML writer. We will create it below
+    ss.set_alert_list(&alert_list);
     ss.set_stop_list(&stop_list);
     ss.add_scanners( scanners_builtin );
     for (const auto &scanner_dir : scanner_dirs) ss.add_scanner_directory(scanner_dir);

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -128,6 +128,34 @@ TEST_CASE("e2e-stop-list", "[end-to-end]")
     std::filesystem::remove_all(root);
 }
 
+TEST_CASE("e2e-alert-list", "[end-to-end]")
+{
+    const auto root = NamedTemporaryDirectory();
+    const auto input = root / "input.raw";
+    const auto alert_list = root / "alert-list.txt";
+    const auto outdir = root / "output";
+    std::ofstream(input) << "ordinary@example.com alert@example.com\n";
+    std::ofstream(alert_list) << "alert@example.com\n";
+
+    const std::string input_string = input.string();
+    const std::string alert_list_string = alert_list.string();
+    const std::string outdir_string = outdir.string();
+    const char *argv[] = {
+        "bulk_extractor", "-0q", "-Eemail", "-r", alert_list_string.c_str(),
+        "-o", outdir_string.c_str(), input_string.c_str(), nullptr
+    };
+    std::stringstream output;
+    REQUIRE(run_be(output, argv) == 0);
+
+    const auto email = getLines(outdir / "email.txt");
+    REQUIRE(requireFeature(email, "ordinary@example.com"));
+    REQUIRE(requireFeature(email, "alert@example.com"));
+    const auto alerts = getLines(outdir / "ALERTS_found.txt");
+    REQUIRE(requireFeature(alerts, "alert@example.com"));
+
+    std::filesystem::remove_all(root);
+}
+
 #if defined(HAVE_SYS_RESOURCE_H) && defined(HAVE_SIGNAL_H)
 class file_size_limit {
     struct rlimit old_limit {};

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -134,7 +134,7 @@ TEST_CASE("e2e-alert-list", "[end-to-end]")
     const auto input = root / "input.raw";
     const auto alert_list = root / "alert-list.txt";
     const auto outdir = root / "output";
-    std::ofstream(input) << "ordinary@example.com alert@example.com\n";
+    std::ofstream(input) << "ordinary@example.com C:\\temp alert@example.com\n";
     std::ofstream(alert_list) << "alert@example.com\n";
 
     const std::string input_string = input.string();
@@ -152,6 +152,15 @@ TEST_CASE("e2e-alert-list", "[end-to-end]")
     REQUIRE(requireFeature(email, "alert@example.com"));
     const auto alerts = getLines(outdir / "ALERTS_found.txt");
     REQUIRE(requireFeature(alerts, "alert@example.com"));
+    const auto email_match = std::find_if(email.begin(), email.end(), [](const auto &line) {
+        return line.find("alert@example.com") != std::string::npos;
+    });
+    const auto alert_match = std::find_if(alerts.begin(), alerts.end(), [](const auto &line) {
+        return line.find("alert@example.com") != std::string::npos;
+    });
+    REQUIRE(email_match != email.end());
+    REQUIRE(alert_match != alerts.end());
+    REQUIRE(*alert_match == *email_match);
 
     std::filesystem::remove_all(root);
 }


### PR DESCRIPTION
Fixes #357.

This is stacked on #552 because alert-list and stop-list restoration share the same initialization path. It should be reviewed as the eight-file diff against `codex/issue-356-stop-lists`; after #552 merges, this PR can be retargeted to `main`.

The CLI parsed `-r`, but never attached the resulting alert list to the scanner set. The matching block in `feature_recorder::write()` was also disabled and bypassed the thread-safe feature-recorder infrastructure.

This change:

- attaches the parsed alert list before scanner initialization;
- creates a dedicated `ALERTS_found` recorder only when a nonempty alert list is supplied;
- writes matches to `ALERTS_found.txt` through the normal mutex-protected recorder;
- retains matches in their original feature files;
- prevents recursive stop/alert processing on the special recorder;
- updates the user manual with the actual artifact name; and
- adds a CLI-level regression test for both the normal and alert outputs.

Validation:

- `make -C src -j4 check TESTS=test_be` — PASS
- `git diff --check` — PASS

Authored and signed by Codex using the project Codex identity.
