### PR TITLE
Add RawTherapee Image8 thumbnail carver

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -108,6 +108,7 @@ scanners_builtin = \
 	scan_outlook.cpp scan_outlook.h \
 	scan_pdf.cpp scan_pdf.h \
 	scan_rar.cpp \
+	scan_rtti.cpp \
 	scan_sqlite.cpp \
 	scan_utmp.cpp \
 	scan_vcard.cpp scan_vcard.h \

--- a/src/bulk_extractor_scanners.h
+++ b/src/bulk_extractor_scanners.h
@@ -52,6 +52,7 @@ SCANNER(ntfsusn)
 SCANNER(outlook)
 SCANNER(pdf)
 SCANNER(rar)
+SCANNER(rtti)
 SCANNER(sqlite)
 SCANNER(utmp)        // scanner provided by 4n6ist:
 SCANNER(vcard)

--- a/src/scan_rtti.cpp
+++ b/src/scan_rtti.cpp
@@ -1,0 +1,84 @@
+/**
+ * Carves 8-bit RawTherapee thumbnail images.
+ *
+ * RTTI Image8 records contain "Image8\n", native little-endian width and
+ * height values, and contiguous RGB bytes. A PPM header makes the pixels
+ * directly viewable without copying or transforming the image data.
+ */
+
+#include "config.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "be20_api/scanner_params.h"
+
+namespace {
+
+constexpr char IMAGE8_SIGNATURE[] = "Image8\n";
+constexpr size_t SIGNATURE_SIZE = sizeof(IMAGE8_SIGNATURE) - 1;
+constexpr size_t IMAGE8_HEADER_SIZE = SIGNATURE_SIZE + sizeof(uint32_t) * 2;
+constexpr size_t RGB_CHANNELS = 3;
+constexpr size_t MAX_PIXEL_BYTES = 16 * 1024 * 1024;
+
+void carve_image8(const sbuf_t &sbuf, feature_recorder &recorder)
+{
+    size_t search_offset = 0;
+    while (search_offset < sbuf.pagesize) {
+        const ssize_t found = sbuf.find(IMAGE8_SIGNATURE, search_offset);
+        if (found < 0 || static_cast<size_t>(found) >= sbuf.pagesize) {
+            return;
+        }
+
+        const size_t start = static_cast<size_t>(found);
+        search_offset = start + SIGNATURE_SIZE;
+        if (sbuf.left(start) < IMAGE8_HEADER_SIZE) {
+            return;
+        }
+
+        const uint32_t width = sbuf.get32u(start + SIGNATURE_SIZE);
+        const uint32_t height = sbuf.get32u(start + SIGNATURE_SIZE + sizeof(width));
+        if (width == 0 || height == 0 ||
+            height > MAX_PIXEL_BYTES / RGB_CHANNELS / width) {
+            continue;
+        }
+
+        const size_t pixel_bytes = static_cast<size_t>(width) * height * RGB_CHANNELS;
+        const size_t pixel_offset = start + IMAGE8_HEADER_SIZE;
+        if (pixel_bytes > sbuf.left(pixel_offset)) {
+            continue;
+        }
+
+        const std::string ppm_header = "P6\n" + std::to_string(width) + " " +
+                                       std::to_string(height) + "\n255\n";
+        const sbuf_t header(ppm_header.c_str());
+        std::unique_ptr<sbuf_t> pixels(
+            sbuf.new_slice(sbuf.pos0 + start, pixel_offset, pixel_bytes));
+        recorder.carve(header, *pixels, ".ppm");
+        search_offset = pixel_offset + pixel_bytes;
+    }
+}
+
+} // namespace
+
+extern "C"
+void scan_rtti(scanner_params &sp)
+{
+    sp.check_version();
+    if (sp.phase == scanner_params::PHASE_INIT) {
+        sp.info->set_name("rtti");
+        sp.info->author = "Simson Garfinkel and Rannek";
+        sp.info->description = "Carves 8-bit RawTherapee thumbnail images";
+        sp.info->scanner_version = "1.0";
+        sp.info->min_sbuf_size = IMAGE8_HEADER_SIZE;
+
+        feature_recorder_def::flags_t flags;
+        flags.carve = true;
+        sp.info->feature_defs.emplace_back("rtti", flags);
+        return;
+    }
+    if (sp.phase == scanner_params::PHASE_SCAN) {
+        carve_image8(*sp.sbuf, sp.named_feature_recorder("rtti"));
+    }
+}

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -20,11 +20,13 @@
 #include <memory>
 #include <filesystem>
 #include <cstdio>
+#include <iterator>
 #include <stdexcept>
 #include <unistd.h>
 #include <string>
 #include <string_view>
 #include <sstream>
+#include <vector>
 
 #include "be20_api/catch.hpp"
 
@@ -957,6 +959,44 @@ TEST_CASE("scan_pdf", "[scanners]") {
     delete sbufp;
 }
 
+TEST_CASE("scan_rtti_image8", "[scanners]")
+{
+    const std::vector<uint8_t> image = {
+        'x', 'I', 'm', 'a', 'g', 'e', '8', '\n',
+        2, 0, 0, 0, 1, 0, 0, 0,
+        255, 0, 0, 0, 255, 0
+    };
+    auto outdir = test_scanner(
+        scan_rtti, new sbuf_t(pos0_t(), image.data(), image.size()));
+
+    std::vector<std::filesystem::path> carved;
+    for (const auto &entry :
+         std::filesystem::recursive_directory_iterator(outdir / "rtti")) {
+        if (entry.is_regular_file()) {
+            carved.push_back(entry.path());
+        }
+    }
+    REQUIRE(carved.size() == 1);
+
+    std::ifstream input(carved.front(), std::ios::binary);
+    const std::string actual((std::istreambuf_iterator<char>(input)),
+                             std::istreambuf_iterator<char>());
+    std::string expected = "P6\n2 1\n255\n";
+    expected.append("\xff\x00\x00\x00\xff\x00", 6);
+    REQUIRE(actual == expected);
+}
+
+TEST_CASE("scan_rtti_rejects_truncated_image8", "[scanners]")
+{
+    const std::vector<uint8_t> truncated = {
+        'I', 'm', 'a', 'g', 'e', '8', '\n',
+        2, 0, 0, 0, 2, 0, 0, 0,
+        255, 0, 0
+    };
+    auto outdir = test_scanner(
+        scan_rtti, new sbuf_t(pos0_t(), truncated.data(), truncated.size()));
+    REQUIRE_FALSE(std::filesystem::exists(outdir / "rtti"));
+}
 
 TEST_CASE("scan_vcard", "[scanners]") {
     auto *sbufp = map_file( "john_jakes.vcf" );


### PR DESCRIPTION
## Summary

- add a small built-in `rtti` scanner for RawTherapee `Image8` thumbnail records
- validate dimensions, overflow, size limits, and complete RGB payloads before carving
- prepend a P6 PPM header while writing the original RGB bytes directly, avoiding an image-sized copy
- add exact-output and truncated-input scanner tests

## Scope

This intentionally handles only `Image8`, the contiguous 8-bit RGB format used by the supplied RTTI exemplars. `Image16` and `Imagefloat` require pixel conversion and remain out of scope.

Fixes #460.

## Validation

- `bash bootstrap.sh`
- `./configure`
- `make -C src -j4 check TESTS=test_be` (PASS: 1/1 test program)
- `git diff --check`

Authored by Codex using `@simsong-codex`.