### PR TITLE
Warn when built without O3 optimization

### DIFF
--- a/m4/slg_noopt.m4
+++ b/m4/slg_noopt.m4
@@ -25,5 +25,7 @@ else
 
       CXXFLAGS=`echo -g "$CXXFLAGS" | sed 's/-O[123]//'`
       CXXFLAGS="$CXXFLAGS -O3"
+      AC_DEFINE([HAVE_OPTIMIZATION_O3], [1],
+                [Define to 1 when bulk_extractor is built with -O3])
   fi
 fi

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -574,6 +574,9 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     /* provide documentation to the user; the DFXML information comes from elsewhere */
     if ( !cfg.opt_quiet){
         cout << "bulk_extractor version: " << PACKAGE_VERSION << std::endl ;
+#ifndef HAVE_OPTIMIZATION_O3
+        cout << "WARNING: built without -O3 optimization; performance may be reduced." << std::endl;
+#endif
         cout << "Input file: " << sc.input_fname << std::endl ;
         cout << "Output directory: " << sc.outdir << std::endl ;
         cout << "Disk Size: " << p->image_size() << std::endl ;


### PR DESCRIPTION
## Summary

- record whether the build used the project’s forced `-O3` optimization
- print a concise startup warning for builds configured with `--disable-o3` or
  `--disable-opt`
- preserve quiet-mode output suppression

Closes #349.

## Validation

- `../configure --disable-o3` — confirmed `HAVE_OPTIMIZATION_O3` is absent
- normal `./configure` — confirmed `HAVE_OPTIMIZATION_O3` is defined
- `make -C src check-TESTS` — 4 passed
- `make distcheck`
