### PR TITLE
Exclude HTML quote entities from URLs

### DIFF
--- a/src/scan_email.flex
+++ b/src/scan_email.flex
@@ -301,6 +301,11 @@ Host:[ \t]?([a-zA-Z0-9._]{1,64}) {
     for (unsigned int i=0;i<(unsigned int)yyleng;i++){
         if (SBUF[POS+i]=='/') slash_count++;
     }
+    const std::string html_quote = "&quot;";
+    if (feature_len >= static_cast<int>(html_quote.size()) &&
+        std::string(reinterpret_cast<const char *>(SBUF.get_buf() + POS + feature_len - html_quote.size()), html_quote.size()) == html_quote) {
+        feature_len -= html_quote.size();
+    }
     if (slash_count==2){
        while(feature_len>0 && !isalpha(SBUF[POS+feature_len-1])){
          feature_len--;

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -396,6 +396,27 @@ TEST_CASE("scan_email16", "[scanners]") {
     }
 }
 
+TEST_CASE("scan_email_excludes_html_quote_entity", "[scanners]") {
+    const auto has_url_feature = [](const std::vector<std::string> &lines, const std::string &feature) {
+        for (const auto &line : lines) {
+            if (has(line, "\t" + feature + "\t")) return true;
+        }
+        return false;
+    };
+
+    auto *sbufp = new sbuf_t("http://www.icra.org/ratingsv02.html&quot;");
+    auto outdir = test_scanner(scan_email, sbufp);
+    auto url_txt = getLines(outdir / "url.txt");
+    REQUIRE( requireFeature(url_txt, "0\thttp://www.icra.org/ratingsv02.html\t") );
+    REQUIRE_FALSE( has_url_feature(url_txt, "http://www.icra.org/ratingsv02.html&quot;") );
+
+    auto *host_sbufp = new sbuf_t("http://www.msn.com&quot;");
+    auto host_outdir = test_scanner(scan_email, host_sbufp);
+    auto host_url_txt = getLines(host_outdir / "url.txt");
+    REQUIRE( requireFeature(host_url_txt, "0\thttp://www.msn.com\t") );
+    REQUIRE_FALSE( has_url_feature(host_url_txt, "http://www.msn.com&quot;") );
+}
+
 TEST_CASE("scan_exif0", "[scanners]") {
     auto *sbufp = map_file("1.jpg");
     REQUIRE( sbufp->bufsize == 7323 );


### PR DESCRIPTION
## Summary

- remove a terminal HTML `&quot;` entity from URL features
- retain the entity only as surrounding markup, not URL content
- add a focused regression test for a path-bearing URL

Closes #69.

## Validation

- `make -C src check-TESTS` (4 passed)