### PR TITLE
Clean up C++ initialization warnings

### DIFF
--- a/src/notify_thread.h
+++ b/src/notify_thread.h
@@ -20,7 +20,8 @@ class notify_thread {
     void *run();
 public:
     notify_thread(std::ostream &os_, scanner_set &ss_, const Phase1::Config &cfg_, aftimer &master_timer_, std::atomic<double> *fraction_done_):
-        os(os_), ss(ss_), cfg(cfg_), master_timer(master_timer_),fraction_done(fraction_done_) {};
+        the_notify_thread(), os(os_), ss(ss_), cfg(cfg_), master_timer(master_timer_), fraction_done(fraction_done_),
+        phase_changed() {};
     ~notify_thread();
     static int terminal_width( int default_width );
     std::ostream &os;

--- a/src/pcap_writer.cpp
+++ b/src/pcap_writer.cpp
@@ -13,7 +13,7 @@
  **/
 
 pcap_writer::pcap_writer(const scanner_params &sp):
-    outdir(sp.sc.outdir)
+    outdir(sp.sc.outdir), streams()
 {
 }
 

--- a/src/pcap_writer.h
+++ b/src/pcap_writer.h
@@ -50,6 +50,7 @@ class pcap_writer {
     pcap_writer(const pcap_writer &pc) = delete;
     pcap_writer &operator=(const pcap_writer &that) = delete;
     struct stream_t {
+        stream_t() : outpath(), fcap() {}
         std::filesystem::path outpath;
         std::unique_ptr<std::ofstream> fcap;
     };

--- a/src/phase1.cpp
+++ b/src/phase1.cpp
@@ -29,7 +29,7 @@
 using namespace std::chrono_literals;
 
 Phase1::Phase1(Config &config_, image_process &p_, scanner_set &ss_, std::ostream &cout_):
-    config(config_), p(p_), ss(ss_), cout(cout_), xreport(*ss_.get_dfxml_writer())
+    config(config_), p(p_), ss(ss_), cout(cout_), sha1g(), xreport(*ss_.get_dfxml_writer())
 {
 }
 

--- a/src/phase1.h
+++ b/src/phase1.h
@@ -42,8 +42,8 @@ class Phase1 {
 public:
     class ThreadWaitTimeout : public std::runtime_error {
     public:
-        explicit ThreadWaitTimeout(time_t maximum_wait):
-            std::runtime_error("timed out waiting for scanner threads"), maximum_wait(maximum_wait) {}
+        explicit ThreadWaitTimeout(time_t wait_timeout):
+            std::runtime_error("timed out waiting for scanner threads"), maximum_wait(wait_timeout) {}
         const time_t maximum_wait;
     };
 

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -63,8 +63,6 @@
 
 #include "test_be.h"
 
-extern "C" void scan_sqlite(scanner_params& sp);
-
 #ifdef HAVE_EXIV2
 extern "C" void scan_exiv2(scanner_params& sp);
 #endif


### PR DESCRIPTION
## Summary

- initialize members called out by `-Weffc++`
- remove a redundant scanner declaration
- preserve the current compile-only Debian CI scope

This carries forward the valid source-only portion of #566. The optional-dependency test repair is already covered by #567.

## Validation

- `./configure --disable-libewf --enable-silent-rules --quiet`
- `make -j2`
