### PR TITLE
Document Debian CI scope

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Bootstrap and build in Debian
         run: |
+          # This is a compile-only compatibility job.  The full test suite runs
+          # in the platform build jobs below, so do not add `make check` here.
           docker run --rm \
             --mount type=bind,source="$GITHUB_WORKSPACE",target=/src \
             --workdir /src \


### PR DESCRIPTION
## Summary

- document that the Debian Bookworm job is a compile-only compatibility check
- document that `make check` belongs in the platform build jobs

## Validation

- `git diff --check`
