### PR TITLE
Tighten Windows IP regression assertion

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -146,6 +146,6 @@ jobs:
           if (-not (Test-Path $ipFile)) {
             throw "bulk_extractor did not create ip.txt"
           }
-          if (-not (Select-String -Path $ipFile -SimpleMatch "192.168.0.91" -Quiet)) {
+          if (-not (Select-String -Path $ipFile -Pattern '(^|\s)192\.168\.0\.91(\s|$)' -Quiet)) {
             throw "bulk_extractor did not report the fixture's IPv4 address"
           }


### PR DESCRIPTION
Follow-up to #573: require the expected IPv4 address to be a complete whitespace-delimited feature value, rather than a substring.

Validation: `git diff --check`.