### PR TITLE
Send O3 warning to diagnostic stream

### DIFF
--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -575,7 +575,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     if ( !cfg.opt_quiet){
         cout << "bulk_extractor version: " << PACKAGE_VERSION << std::endl ;
 #ifndef HAVE_OPTIMIZATION_O3
-        cout << "WARNING: built without -O3 optimization; performance may be reduced." << std::endl;
+        cerr << "WARNING: built without -O3 optimization; performance may be reduced." << std::endl;
 #endif
         cout << "Input file: " << sc.input_fname << std::endl ;
         cout << "Output directory: " << sc.outdir << std::endl ;


### PR DESCRIPTION
Fixes the actionable Copilot feedback from #564: write the non-O3 startup warning to the caller-provided diagnostic stream (`cerr`) instead of normal output (`cout`). Quiet mode remains unchanged.\n\nValidation: `make check`.