### PR TITLE
Bypass duplicate sbuf scanner fan-out

### DIFF
--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -529,6 +529,13 @@ void scanner_set::apply_scanner_commands() {
             }
         }
     }
+    scan_seen_before_enabled = false;
+    for (const auto &scanner : enabled_scanners) {
+        if (scanner_info_db[scanner]->scanner_flags.scan_seen_before) {
+            scan_seen_before_enabled = true;
+            break;
+        }
+    }
 
     /* Create feature recorders for each enabled scanner.
      * Multiple scanners may request the same feature recorder without generating an error.
@@ -975,6 +982,18 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp)
     sbufp->seen_before = previously_processed_count(sbuf) > 0; // abstraction violation
     if (sbufp->seen_before) {
         dup_bytes_encountered += sbuf.bufsize;
+        if (!scan_seen_before_enabled) {
+            duplicate_sbufs_bypassed++;
+            if (debug_flags.debug_benchmark && writer) {
+                writer->xmlout("debug:bypass", "",
+                               Formatter()
+                               << "sbuf='" << sbuf.pos0.str() << "' "
+                               << "bufsize='" << sbuf.bufsize << "' "
+                               << "scanner='all' reason='seen_before'", true);
+            }
+            thread_set_status("IDLE");
+            return;
+        }
     }
 
     /*

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -110,6 +110,7 @@ class scanner_set {
     std::map<scanner_t*, struct scanner_params::scanner_info *> scanner_info_db {}; // scanner to info db; master list of scanners
     std::map<std::string, scanner_t *> scanner_names {}; // scanner name to scanner
     std::set<scanner_t*> enabled_scanners {};            //
+    bool scan_seen_before_enabled {false};
     std::vector<void *> plugin_handles {};
 
     class thread_pool pool;
@@ -126,6 +127,7 @@ class scanner_set {
     bool record_call_stats {true};     // by default, record the call stats
     std::atomic<uint64_t> sbuf_seen {0}; // number of seen sbufs.
     std::atomic<uint64_t> dup_bytes_encountered{0}; // amount of dup data encountered
+    std::atomic<uint64_t> duplicate_sbufs_bypassed{0};
     std::map<scanner_t* , struct stats> scanner_stats{}; // maps scanner name to performance stats
     mutable std::mutex Mscanner_stats {};                        // mutex for scanner_stats
 
@@ -221,6 +223,7 @@ public:
     void debug_pool(std::ostream &os) const { pool.debug_pool(os);}
 
     uint64_t get_dup_bytes_encountered()  const  { return dup_bytes_encountered; }
+    uint64_t get_duplicate_sbufs_bypassed() const { return duplicate_sbufs_bypassed; }
     uint32_t get_max_depth_seen() const          { return max_depth_seen;} ; // max seen during scan
 
     // Feature recorders. Functions below are virtual so they can be called by loaded scanners.

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1312,6 +1312,30 @@ TEST_CASE("scanner", "[scanner]") {
 #include "scanner_set.h"
 #include "machine_stats.h"
 
+namespace {
+uint64_t duplicate_bypass_scans {0};
+uint64_t duplicate_opt_in_scans {0};
+
+void scan_duplicate_bypass_test(scanner_params& sp) {
+    if (sp.phase == scanner_params::PHASE_INIT) {
+        sp.info->set_name("duplicate_bypass_test");
+        sp.info->min_sbuf_size = 1;
+    } else if (sp.phase == scanner_params::PHASE_SCAN) {
+        duplicate_bypass_scans++;
+    }
+}
+
+void scan_duplicate_opt_in_test(scanner_params& sp) {
+    if (sp.phase == scanner_params::PHASE_INIT) {
+        sp.info->set_name("duplicate_opt_in_test");
+        sp.info->min_sbuf_size = 1;
+        sp.info->scanner_flags.scan_seen_before = true;
+    } else if (sp.phase == scanner_params::PHASE_SCAN) {
+        duplicate_opt_in_scans++;
+    }
+}
+}
+
 #ifdef _WIN32
 TEST_CASE("machine_stats", "[!mayfail][machine_stats]") {
     WARN("machine_stats not implemented on Windows (ps and /proc/ don't exist)");
@@ -1352,6 +1376,42 @@ TEST_CASE("previously_processed", "[scanner_set]") {
     REQUIRE(ss.previously_processed_count(slg) == 0);
     REQUIRE(ss.previously_processed_count(slg) == 1);
     REQUIRE(ss.previously_processed_count(slg) == 2);
+}
+
+TEST_CASE("duplicate sbufs bypass scanner fan-out unless requested", "[scanner_set]") {
+    scanner_config sc;
+    sc.outdir = get_tempdir();
+    sc.enable_all_scanners();
+    duplicate_bypass_scans = 0;
+    scanner_set ss(sc, feature_recorder_set::flags_t(), nullptr);
+    ss.add_scanner(scan_duplicate_bypass_test);
+    ss.apply_scanner_commands();
+    ss.phase_scan();
+    ss.schedule_sbuf(new sbuf_t("duplicate"));
+    ss.schedule_sbuf(new sbuf_t("duplicate"));
+    REQUIRE(duplicate_bypass_scans == 1);
+    REQUIRE(ss.get_dup_bytes_encountered() == 9);
+    REQUIRE(ss.get_duplicate_sbufs_bypassed() == 1);
+    ss.shutdown();
+}
+
+TEST_CASE("duplicate sbufs reach scanners that opt in", "[scanner_set]") {
+    scanner_config sc;
+    sc.outdir = get_tempdir();
+    sc.enable_all_scanners();
+    duplicate_bypass_scans = 0;
+    duplicate_opt_in_scans = 0;
+    scanner_set ss(sc, feature_recorder_set::flags_t(), nullptr);
+    ss.add_scanner(scan_duplicate_bypass_test);
+    ss.add_scanner(scan_duplicate_opt_in_test);
+    ss.apply_scanner_commands();
+    ss.phase_scan();
+    ss.schedule_sbuf(new sbuf_t("duplicate"));
+    ss.schedule_sbuf(new sbuf_t("duplicate"));
+    REQUIRE(duplicate_bypass_scans == 1);
+    REQUIRE(duplicate_opt_in_scans == 2);
+    REQUIRE(ss.get_duplicate_sbufs_bypassed() == 0);
+    ss.shutdown();
 }
 
 #if 0

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -692,6 +692,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     xreport->xmlout( "elapsed_seconds",master_timer.elapsed_seconds());
     xreport->xmlout( "max_depth_seen",ss.get_max_depth_seen());
     xreport->xmlout( "dup_bytes_encountered",ss.get_dup_bytes_encountered());
+    xreport->xmlout( "duplicate_sbufs_bypassed",ss.get_duplicate_sbufs_bypassed());
     xreport->xmlout( "sbufs_created", sbuf_t::sbuf_total);
     xreport->xmlout( "sbufs_unaccounted", sbuf_t::sbuf_count);
     xreport->xmlout( "producer_timer_ns", ss.producer_wait_ns() );


### PR DESCRIPTION
## Summary

- Bypass per-scanner task fan-out for duplicate sbufs when no enabled scanner requests duplicate buffers.
- Preserve `scan_seen_before` semantics: if any enabled scanner opts in, duplicates continue through the normal dispatch path.
- Report `duplicate_sbufs_bypassed` in final DFXML and cover both paths with scanner-set regression tests.

## Rationale

The duplicate digest/accounting decision already happens once per sbuf. Previously, a duplicate still created one task per enabled scanner only to have each scanner return immediately. This removes that avoidable work without changing behavior for scanners that explicitly need duplicate data.

Closes #310.

## Validation

- `make -C src test_be20_api`
- `./src/test_be20_api "*duplicate*" --reporter compact`
- `make -C src check-TESTS TESTS=test_be20_api` reaches the full suite but fails only at the existing sandbox-blocked `machine_stats` check (`/bin/ps: Operation not permitted`, CPU percentage `NaN`). The two new focused tests pass.
