### PR TITLE
Remove disabled scanner-set test

### DIFF
--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1354,19 +1354,6 @@ TEST_CASE("previously_processed", "[scanner_set]") {
     REQUIRE(ss.previously_processed_count(slg) == 2);
 }
 
-#if 0
-TEST_CASE("mt_previously_processed", "[scanner_set]") {
-    scanner_config sc;
-    feature_recorder_set::flags_t f;
-    scanner_set ss(sc, f, nullptr);
-    sbuf_t slg("Simson");
-    ss.info();
-    REQUIRE(ss.previously_processed_count(slg) == 0);
-    REQUIRE(ss.previously_processed_count(slg) == 1);
-    REQUIRE(ss.previously_processed_count(slg) == 2);
-}
-#endif
-
 TEST_CASE("enable/disable", "[scanner_set]") {
     scanner_config sc;
     sc.outdir = get_tempdir();


### PR DESCRIPTION
## Summary

Removes the disabled `mt_previously_processed` test from `test_be20_api.cpp`.

The block was permanently compiled out with `#if 0`, duplicated the active
single-threaded `previously_processed` test, and did not exercise
multithreaded behavior.

## Validation

- `make -C src check-TESTS TESTS=test_be20_api V=0`
