### PR TITLE
Remove nested output directories with -Z

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -68,6 +68,8 @@ through the project's normal pull-request and CI process.
 - Fixed notifier and disk-write error shutdown so worker failures are reported
   and cleaned up instead of hanging or terminating incorrectly
   ([PR #513](https://github.com/simsong/bulk_extractor/pull/513)).
+- `-Z` now removes stale nested output directories as well as files before a
+  new run ([#239](https://github.com/simsong/bulk_extractor/issues/239)).
 - Fixed scanner controls: `jpeg_carve_mode=0` now disables JPEG carving, and
   `-x all -e outlook` enables Outlook as requested
   ([PR #525](https://github.com/simsong/bulk_extractor/pull/525),

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -454,11 +454,9 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
         /* The zap option wipes the contents of a directory, useful for debugging */
         if ( result.count( "zap" ) && std::filesystem::is_directory( sc.outdir )) {
-            for ( const auto &entry : std::filesystem::recursive_directory_iterator( sc.outdir ) ) {
-                if ( ! std::filesystem::is_directory( entry.path())){
-                    cout << "erasing " << entry.path().string() << std::endl ;
-                    std::filesystem::remove( entry );
-                }
+            for (const auto &entry : std::filesystem::directory_iterator(sc.outdir)) {
+                cout << "erasing " << entry.path().string() << std::endl;
+                std::filesystem::remove_all(entry.path());
             }
         }
 	if (std::filesystem::exists( sc.outdir ) == false ){

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -184,6 +184,33 @@ TEST_CASE("e2e-alert-list", "[end-to-end]")
     std::filesystem::remove_all(root);
 }
 
+TEST_CASE("e2e-zap-removes-nested-output", "[end-to-end]")
+{
+    const auto root = NamedTemporaryDirectory();
+    const auto input = root / "input.raw";
+    const auto outdir = root / "output";
+    const auto nested = outdir / "nested" / "deeper";
+    std::ofstream(input) << "input\n";
+    std::filesystem::create_directories(nested);
+    std::ofstream(outdir / "stale.txt") << "stale\n";
+    std::ofstream(nested / "stale.txt") << "stale\n";
+
+    const std::string input_string = input.string();
+    const std::string outdir_string = outdir.string();
+    const char *argv[] = {
+        "bulk_extractor", "-0q", "-x", "all", "-Z", "-o", outdir_string.c_str(),
+        input_string.c_str(), nullptr
+    };
+    std::stringstream output;
+    REQUIRE(run_be(output, argv) == 0);
+    REQUIRE(std::filesystem::is_directory(outdir));
+    REQUIRE_FALSE(std::filesystem::exists(outdir / "stale.txt"));
+    REQUIRE_FALSE(std::filesystem::exists(nested));
+    REQUIRE(std::filesystem::exists(outdir / "report.xml"));
+
+    std::filesystem::remove_all(root);
+}
+
 #if defined(HAVE_SYS_RESOURCE_H) && defined(HAVE_SIGNAL_H)
 class file_size_limit {
     struct rlimit old_limit {};


### PR DESCRIPTION
## Summary

Fixes #239: `-Z` now removes every child of an existing output directory,
including nested directories, while retaining the output-directory root for
the new report.

The previous recursive iterator removed only non-directory entries, leaving
the directory tree behind.

## Validation

- `make -C src check-TESTS TESTS=test_be V=0`

The new end-to-end regression creates stale files at the output root and in a
nested directory, runs `bulk_extractor -Z`, and verifies that both are gone
while the fresh `report.xml` is produced.
