### PR TITLE
Use zip_carved output directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,8 @@ Before changing a scanner or writing a scanner plug-in, read
 [doc/scanner_template.cpp](doc/scanner_template.cpp), and preserve its phase
 and concurrency rules unless the API documentation is updated in the same
 change.
+
+Update [doc/RELEASE_NOTES.md](doc/RELEASE_NOTES.md) in the same pull request
+for every user-visible behavior, build or platform-support, packaging, or
+documentation change. Do not add release-note entries for test-only or purely
+internal refactors.

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -79,7 +79,7 @@ through the project's normal pull-request and CI process.
   [PR #535](https://github.com/simsong/bulk_extractor/pull/535)).
 - Bounded and normalized derived ZIP-carving filenames while retaining source
   metadata ([PR #539](https://github.com/simsong/bulk_extractor/pull/539)).
-- ZIP component carvings now use the `zip_carved/` output directory, matching
+- ZIP component carvings now use the `zip_carved/` output directory and `zip_carved.txt` feature file, matching
   the convention used by other carvers ([#336](https://github.com/simsong/bulk_extractor/issues/336)).
 - Prevented empty MSXML extraction from causing recursion and changed residual
   `sbuf` diagnostics from an abort to a DFXML warning

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -79,6 +79,8 @@ through the project's normal pull-request and CI process.
   [PR #535](https://github.com/simsong/bulk_extractor/pull/535)).
 - Bounded and normalized derived ZIP-carving filenames while retaining source
   metadata ([PR #539](https://github.com/simsong/bulk_extractor/pull/539)).
+- ZIP component carvings now use the `zip_carved/` output directory, matching
+  the convention used by other carvers ([#336](https://github.com/simsong/bulk_extractor/issues/336)).
 - Prevented empty MSXML extraction from causing recursion and changed residual
   `sbuf` diagnostics from an abort to a DFXML warning
   ([PR #537](https://github.com/simsong/bulk_extractor/pull/537)).

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -134,7 +134,7 @@ through the project's normal pull-request and CI process.
   [PR #567](https://github.com/simsong/bulk_extractor/pull/567),
   [PR #572](https://github.com/simsong/bulk_extractor/pull/572),
   [PR #577](https://github.com/simsong/bulk_extractor/pull/577)).
-- Builds configured without the project O3 optimization now say so at startup
+- Builds configured without the project `-O3` optimization now say so at startup
   ([PR #564](https://github.com/simsong/bulk_extractor/pull/564)).
 
 ### Documentation and project maintenance

--- a/src/scan_zip.cpp
+++ b/src/scan_zip.cpp
@@ -13,7 +13,7 @@
 #include "utf8.h"
 
 
-static const std::string  ZIP_RECORDER_NAME {"zip"};
+static const std::string  ZIP_RECORDER_NAME {"zip_carved"};
 
 // these are not tunable
 static uint32_t  zip_max_uncompr_size = 256*1024*1024; // don't decompress objects larger than this

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -1115,7 +1115,7 @@ TEST_CASE("scan_zip", "[scanners]") {
     auto *sbufp = map_file( "testfilex.docx" );
     auto outdir = test_scanners( scanners, sbufp); // deletes sbuf2
     auto email_txt = getLines( outdir / "email.txt" );
-    REQUIRE( std::filesystem::exists( outdir / "zip/000/testfilex.docx____-0-ZIP-0__Content_Types_.xml") == true);
+    REQUIRE( std::filesystem::exists( outdir / "zip_carved/000/testfilex.docx____-0-ZIP-0__Content_Types_.xml") == true);
     REQUIRE( requireFeature(email_txt,"1771-ZIP-402\tuser_docx@microsoftword.com"));
     REQUIRE( requireFeature(email_txt,"2396-ZIP-1012\tuser_docx@microsoftword.com"));
 }


### PR DESCRIPTION
## Summary

- change the ZIP feature recorder to `zip_carved`, so ZIP components are carved
  beneath `zip_carved/` like other carvers;
- update the existing DOCX ZIP regression to assert the new output path;
- document the output-directory correction in the 2.2.0 release notes.

## Root cause

The earlier #336 fix corrected KML, but the ZIP scanner still registered its
carving feature recorder as `zip`, causing its carved files to land in `zip/`.

## Validation

- `make -j1 -C src check TESTS=test_be V=0`

Fixes #336.
