### PR TITLE
Add case-sensitive find option

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -109,6 +109,9 @@ through the project's normal pull-request and CI process.
   is exercised against the NTLM PCAP fixture in the Windows runtime workflow
   ([PR #573](https://github.com/simsong/bulk_extractor/pull/573),
   [PR #574](https://github.com/simsong/bulk_extractor/pull/574)).
+- `--find-case-sensitive` makes `-f` and `-F` RE2 patterns case-sensitive;
+  their historical case-insensitive matching remains the default
+  ([#483](https://github.com/simsong/bulk_extractor/issues/483)).
 - Fixed a SQLite-size arithmetic overflow and reduced the scheduled Coverity
   workflow token to read-only repository contents
   ([PR #538](https://github.com/simsong/bulk_extractor/pull/538)).

--- a/src/be20_api/regex_vector.cpp
+++ b/src/be20_api/regex_vector.cpp
@@ -32,7 +32,7 @@ bool regex_vector::has_metachars(const std::string& str) {
 
 void regex_vector::push_back(const std::string& val) {
     RE2::Options options;
-    options.set_case_sensitive(false);
+    options.set_case_sensitive(case_sensitive);
     if (engine_enabled("RE2")){
         regex_strings.push_back(val);
         RE2 *re = new RE2(std::string("(") + val + std::string(")"), options);

--- a/src/be20_api/regex_vector.h
+++ b/src/be20_api/regex_vector.h
@@ -17,6 +17,7 @@
 #include <fstream>
 #include <iostream>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <cstdlib>
@@ -34,6 +35,7 @@
 class regex_vector {
     std::vector<std::string> regex_strings; // the original regex strings
     std::vector<RE2 *> re2_regex_comps;     // the compiled regular expressions
+    bool case_sensitive {false};
     regex_vector(const regex_vector&) = delete;
     regex_vector& operator=(const regex_vector&) = delete;
     static const std::string RE_ENGINE;
@@ -44,7 +46,7 @@ public:
         return std::getenv(RE_ENGINE.c_str()) == nullptr ||
             std::getenv(RE_ENGINE.c_str())==engine;
     }
-    regex_vector() : regex_strings() , re2_regex_comps() {};
+    explicit regex_vector(bool case_sensitive_ = false) : case_sensitive(case_sensitive_) {};
     ~regex_vector();
 
     // is this a regular expression with meta characters?
@@ -53,6 +55,10 @@ public:
 
     /* Add a string */
     void push_back(const std::string& val);
+    void set_case_sensitive(bool value) {
+        if (!re2_regex_comps.empty()) throw std::logic_error("cannot change regex case mode after compilation");
+        case_sensitive = value;
+    }
     // Empty the vectors. For the compiled, be sure to delete them
     void clear();
     size_t size() const;        // the number of regular expressions in the vector

--- a/src/be20_api/scanner_config.h
+++ b/src/be20_api/scanner_config.h
@@ -85,6 +85,7 @@ public:
     struct {
         std::vector<std::filesystem::path> files {};     // accumulates pattern files
         std::vector<std::string> patterns {};            // accumulates cmdline patterns
+        bool case_sensitive {false};
     } FindOpts {};
 
     bool find_opts_empty() const {
@@ -94,8 +95,10 @@ public:
     // Find interface
     const std::vector<std::string> &find_patterns() const        { return FindOpts.patterns; }
     const std::vector<std::filesystem::path> &find_files() const { return FindOpts.files; }
+    bool find_case_sensitive() const                             { return FindOpts.case_sensitive; }
     void add_find_pattern(std::string pattern)                   { FindOpts.patterns.push_back(pattern);}
     void add_find_path(std::filesystem::path path)               { FindOpts.files.push_back(path);}
+    void set_find_case_sensitive(bool value)                     { FindOpts.case_sensitive = value; }
 
 
     size_t context_window_default{16}; // global option

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -247,6 +247,7 @@ public:
     // Find interface
     const std::vector<std::string> &find_patterns() const           { return sc.find_patterns(); }
     const std::vector<std::filesystem::path> &find_files()    const { return sc.find_files(); }
+    bool find_case_sensitive() const                                { return sc.find_case_sensitive(); }
 
     // Scanning
     scanner_params::phase_t get_current_phase() const { return current_phase; };

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -999,6 +999,12 @@ TEST_CASE("test regex_vector", "[regex]") {
     REQUIRE(regex_vector::has_metachars("this[1234].*foo") == true);
     REQUIRE(regex_vector::has_metachars("this1234foo") == false);
 
+    regex_vector case_sensitive(true);
+    case_sensitive.push_back("CaseSensitive");
+    std::string found;
+    REQUIRE_FALSE(case_sensitive.search_all("casesensitive", &found));
+    REQUIRE(case_sensitive.search_all("CaseSensitive", &found));
+
     for(int pass=0;pass<1;pass++){
         if (pass==0) {
             strncpy(disable,"RE_ENGINE=RE2",sizeof(disable));

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -237,6 +237,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         ("x,disable",  "disable a scanner (can be repeated)", cxxopts::value<std::vector<std::string>>())
         ("f,find",     "search for a pattern (can be repeated)", cxxopts::value<std::vector<std::string>>())
         ("F,find_file", "read patterns to search from a file (can be repeated)", cxxopts::value<std::vector<std::string>>())
+        ("find-case-sensitive", "make -f and -F patterns case-sensitive")
         ("G,pagesize",   "page size in bytes", cxxopts::value<std::string>()->default_value(std::to_string(cfg.opt_pagesize )))
         ("g,marginsize", "margin size in bytes", cxxopts::value<std::string>()->default_value(std::to_string(cfg.opt_marginsize )))
         ("j,threads",    "number of threads", cxxopts::value<int>()->default_value(std::to_string(cfg.num_threads)))
@@ -291,6 +292,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     try {
         sc.banner_file = result["banner_file"].as<std::string>();
     } catch ( cxxopts::option_has_no_value_exception &e ) { }
+    sc.set_find_case_sensitive(result.count("find-case-sensitive") != 0);
 
     try {
         for ( const auto &name : result["disable"].as<std::vector<std::string>>() ) {

--- a/src/scan_find.cpp
+++ b/src/scan_find.cpp
@@ -98,6 +98,8 @@ void scan_find(scanner_params &sp)
         return;
     }
     if (sp.phase == scanner_params::PHASE_INIT2 ) {
+        find_list.clear();
+        find_list.set_case_sensitive(sp.ss->find_case_sensitive());
         for (const auto &it : sp.ss->find_patterns()) {
             add_find_pattern(it);
             if (sp.ss->writer) { sp.ss->writer->xmlout("find_pattern", it); }

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -624,6 +624,28 @@ TEST_CASE("scan_find", "[end-to-end]") {
     grep( Feature(pos0_t("70-PDF-366"), "simsong", ""), outdir / "find.txt" );
 }
 
+TEST_CASE("scan_find case-sensitive option", "[end-to-end]") {
+    const auto root = NamedTemporaryDirectory();
+    const auto input = root / "input.raw";
+    std::ofstream(input) << "CaseSensitive\n" << std::string(65536, 'x');
+    const std::string input_string = input.string();
+
+    const auto default_outdir = root / "default";
+    const std::string default_outdir_string = default_outdir.string();
+    const char *default_argv[] = {"bulk_extractor", "-0q", "-f", "casesensitive",
+                                  "-o", default_outdir_string.c_str(), input_string.c_str(), nullptr};
+    std::stringstream output;
+    REQUIRE(run_be(output, default_argv) == 0);
+    REQUIRE(requireFeature(getLines(default_outdir / "find.txt"), "CaseSensitive"));
+
+    const auto sensitive_outdir = root / "sensitive";
+    const std::string sensitive_outdir_string = sensitive_outdir.string();
+    const char *sensitive_argv[] = {"bulk_extractor", "-0q", "--find-case-sensitive", "-f", "casesensitive",
+                                    "-o", sensitive_outdir_string.c_str(), input_string.c_str(), nullptr};
+    REQUIRE(run_be(output, sensitive_argv) == 0);
+    REQUIRE_FALSE(requireFeature(getLines(sensitive_outdir / "find.txt"), "CaseSensitive"));
+}
+
 /*
  * Test the 5gb flat file if it is present and if the DEBUG_5G environment variable is set.
  */


### PR DESCRIPTION
## Summary

- add `--find-case-sensitive` for `-f` and `-F` RE2 patterns
- preserve case-insensitive matching as the default
- rebuild the scanner-local pattern list during initialization so repeated in-process runs do not retain a prior configuration
- add focused RE2 and end-to-end regressions, and document the user-visible option in the draft 2.2.0 notes

## Validation

`make -j1 -C src check TESTS='test_be test_be20_api' V=0`

The test verifies that a mixed-case input matches a lower-case pattern by default, and does not match with `--find-case-sensitive`.
