### PR TITLE
Honor JPEG recorder carve limits

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -74,6 +74,9 @@ through the project's normal pull-request and CI process.
   `-x all -e outlook` enables Outlook as requested
   ([PR #525](https://github.com/simsong/bulk_extractor/pull/525),
   [PR #527](https://github.com/simsong/bulk_extractor/pull/527)).
+- JPEG carving now observes the recorder's configured minimum and maximum
+  carve sizes; `jpeg_min_carve_size` and `jpeg_max_carve_size` provide
+  scanner-specific overrides ([#242](https://github.com/simsong/bulk_extractor/issues/242)).
 - Preserved recorder banners and triggering features across CRLF input,
   histogram setup, and allocation-failure paths
   ([PR #531](https://github.com/simsong/bulk_extractor/pull/531),

--- a/src/be20_api/feature_recorder.cpp
+++ b/src/be20_api/feature_recorder.cpp
@@ -28,7 +28,8 @@
 
 /* These are all overridden in the subclass */
 feature_recorder::feature_recorder(class feature_recorder_set& fs_, const struct feature_recorder_def def_)
-    : fs(fs_), name(def_.name), def(def_)
+    : fs(fs_), name(def_.name), def(def_), min_carve_size(def_.min_carve_size),
+      max_carve_size(def_.max_carve_size)
 {
     debug_histograms               = getenv_debug(DEBUG_HISTOGRAMS_ENV);
     disable_incremental_histograms = getenv_debug(DEBUG_HISTOGRAMS_NO_INCREMENTAL_ENV);

--- a/src/scan_exif.cpp
+++ b/src/scan_exif.cpp
@@ -28,9 +28,6 @@
 #include "exif_reader.h"
 #include "unicode_escape.h"
 
-// these are tunable
-static size_t min_jpeg_size = 1000; // don't carve smaller than this
-
 /****************************************************************
  *** formatting code
  ****************************************************************/
@@ -365,7 +362,8 @@ size_t exif_scanner::process_possible_jpeg( const sbuf_t &sbuf, bool found_start
         if ( res.len <= 0 ) return 0;
 
         // Should we carve?
-        if ( res.how==jpeg_validator::COMPLETE || res.len > static_cast<ssize_t>( min_jpeg_size ) ) {
+        const size_t jpeg_size = static_cast<size_t>(res.len);
+        if (jpeg_size >= jpeg_recorder.min_carve_size && jpeg_size <= jpeg_recorder.max_carve_size) {
             if ( exif_scanner_debug ) fprintf( stderr,"CARVING1\n" );
             jpeg_recorder.carve( sbuf.slice( 0, res.len ), ".jpg", 0 );
             ret = res.len;
@@ -519,6 +517,15 @@ void scan_exif( scanner_params &sp )
         auto jpeg_def = feature_recorder_def("jpeg", carve_flag); // set carve mode with  -S jpeg_carve_mode=2
 
         jpeg_def.default_carve_mode = feature_recorder_def::carve_mode_t::CARVE_ENCODED;
+
+        uint64_t min_carve_size = jpeg_def.min_carve_size;
+        uint64_t max_carve_size = jpeg_def.max_carve_size;
+        sp.get_scanner_config("jpeg_min_carve_size", &min_carve_size,
+                              "Minimum JPEG size to carve");
+        sp.get_scanner_config("jpeg_max_carve_size", &max_carve_size,
+                              "Maximum JPEG size to carve");
+        jpeg_def.min_carve_size = static_cast<size_t>(min_carve_size);
+        jpeg_def.max_carve_size = static_cast<size_t>(max_carve_size);
 	sp.info->feature_defs.push_back( jpeg_def );
         sp.get_scanner_config( "exif_debug",&exif_debug,"debug exif decoder" );
 	return;

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -780,6 +780,21 @@ TEST_CASE("e2e-jpeg-carving-disabled", "[end-to-end]") {
     REQUIRE_FALSE( std::filesystem::exists(outdir / "jpeg_carved") );
 }
 
+TEST_CASE("e2e-jpeg-carving-respects-recorder-size-limits", "[end-to-end]") {
+    const std::filesystem::path inpath = test_dir() / "len6192.jpg";
+    const std::string inpath_string = inpath.string();
+
+    for (const char* limit : {"jpeg_min_carve_size=7000", "jpeg_max_carve_size=6000"}) {
+        const std::filesystem::path outdir = NamedTemporaryDirectory();
+        const std::string outdir_string = outdir.string();
+        std::stringstream output;
+        const char* argv[] = {"bulk_extractor", notify(), "-S", "jpeg_carve_mode=2", "-S", limit,
+                              "-1q", "-o", outdir_string.c_str(), inpath_string.c_str(), nullptr};
+        REQUIRE(run_be(output, argv) == 0);
+        REQUIRE_FALSE(std::filesystem::exists(outdir / "jpeg_carved"));
+    }
+}
+
 
 
 TEST_CASE("e2e-email_test", "[end-to-end]") {


### PR DESCRIPTION
## Summary

- make the JPEG scanner honor the minimum and maximum sizes configured on its `jpeg` feature recorder
- add `jpeg_min_carve_size` and `jpeg_max_carve_size` scanner options for explicit JPEG-carving limits
- initialize each feature recorder's limits from its definition, so scanner definitions are applied consistently
- add an end-to-end regression test using a real JPEG fixture and document the user-visible controls

## Root cause

The JPEG scanner kept a private 1,000-byte minimum and never consulted the recorder maximum. That bypassed the common feature-recorder carve-limit policy.

## Validation

- `make -j1 -C src check TESTS=test_be V=0`

Closes neither the issue nor any related issue; issue closure remains for the project owner.
