### PR TITLE
Test scanner configuration find-option isolation

### DIFF
--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1290,6 +1290,15 @@ TEST_CASE("scanner_config", "[scanner]") {
     sc.push_scanner_command("scanner1", scanner_config::scanner_command::ENABLE);
     sc.push_scanner_command("scanner2", scanner_config::scanner_command::DISABLE);
     REQUIRE(sc.get_scanner_commands().size() == 2);
+
+    sc.add_find_pattern("first-pattern");
+    sc.add_find_path("first-patterns.txt");
+    scanner_config other;
+    other.add_find_pattern("second-pattern");
+    REQUIRE(sc.find_patterns() == std::vector<std::string>{"first-pattern"});
+    REQUIRE(sc.find_files() == std::vector<std::filesystem::path>{"first-patterns.txt"});
+    REQUIRE(other.find_patterns() == std::vector<std::string>{"second-pattern"});
+    REQUIRE(other.find_files().empty());
 }
 
 /****************************************************************


### PR DESCRIPTION
Fixes #249.\n\nAdds a focused regression test proving that separate `scanner_config` instances keep independent find patterns and find-file paths. The current production path already uses per-instance configuration; this locks in that behavior.\n\nValidation: `make -C src check TESTS=test_be20_api`.