### PR TITLE
Bound extracted email local parts and domains independently

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -47,6 +47,9 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
+- Email extraction now enforces independent 64-octet local-part and 253-octet
+  domain limits for ASCII and UTF-16 input, avoiding truncated suffix features
+  from overlong addresses ([#585](https://github.com/simsong/bulk_extractor/issues/585)).
 - Hardened `sbuf` bounds, arithmetic, and ownership behavior, including
   zero-length and one-past-end cases
   ([PR #511](https://github.com/simsong/bulk_extractor/pull/511)).

--- a/src/scan_email.flex
+++ b/src/scan_email.flex
@@ -67,7 +67,39 @@ inline class email_scanner *get_extra(yyscan_t yyscanner) {return yyemail_get_ex
 bool extra_validate_email(const char *email)
 {
     if (strstr(email,"..")) return false;
-    return true;
+    const char *at = strchr(email, '@');
+    if (at == nullptr || strchr(at + 1, '@') != nullptr) return false;
+    const size_t local_length = static_cast<size_t>(at - email);
+    const size_t domain_length = strlen(at + 1);
+    return local_length <= 64 && domain_length <= 253;
+}
+
+bool extra_validate_email_utf16(const char *email, size_t length)
+{
+    if (length % 2 != 0) return false;
+    std::string ascii;
+    ascii.reserve(length / 2);
+    for (size_t i = 0; i < length; i += 2) {
+        if (email[i + 1] != '\0') return false;
+        ascii.push_back(email[i]);
+    }
+    return extra_validate_email(ascii.c_str());
+}
+
+bool email_has_left_boundary(const sbuf_t &sbuf, size_t pos)
+{
+    if (pos == 0) return true;
+    const unsigned char previous = sbuf[pos - 1];
+    return !std::isalnum(previous) && previous != '.' && previous != '_' &&
+           previous != '%' && previous != '+' && previous != '-';
+}
+
+bool email_has_left_boundary_utf16(const sbuf_t &sbuf, size_t pos)
+{
+    if (pos < 2) return true;
+    const unsigned char previous = sbuf[pos - 2];
+    return !std::isalnum(previous) && previous != '.' && previous != '_' &&
+           previous != '%' && previous != '+' && previous != '-';
 }
 
 
@@ -134,7 +166,7 @@ LOCALPART	{WORD}([.]{WORD})*
 ADDRSPEC	{LOCALPART}@{DOMAIN}
 MAILBOX		{ADDRSPEC}
 
-EMAIL	{ALNUM}[a-zA-Z0-9._%\-+]{1,128}{ALNUM}@{ALNUM}[a-zA-Z0-9._%\-]{1,128}\.{TLD}
+EMAIL	{ALNUM}[a-zA-Z0-9._%\-+]{1,62}{ALNUM}@{ALNUM}[a-zA-Z0-9._%\-]{1,250}\.{TLD}
 YEAR		((19[6-9][0-9])|(20[0-1][0-9]))
 DAYOFWEEK	(Mon|Tue|Wed|Thu|Fri|Sat|Sun)
 MONTH		(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)
@@ -191,10 +223,10 @@ Host:[ \t]?([a-zA-Z0-9._]{1,64}) {
     s.pos += yyleng;
 }
 
-{EMAIL}/[^a-zA-Z]	{
+{EMAIL}/[^a-zA-Z0-9._%\-]	{
     email_scanner &s = * yyemail_get_extra(yyscanner);
     s.check_margin();
-    if (extra_validate_email(yytext)){
+    if (email_has_left_boundary(SBUF, POS) && extra_validate_email(yytext)){
         s.email_recorder.write_buf(SBUF,POS,yyleng);
 	ssize_t domain_start = find_host_in_email(SBUF.slice(POS,yyleng));
         if (domain_start>0){
@@ -320,11 +352,11 @@ Host:[ \t]?([a-zA-Z0-9._]{1,64}) {
     s.pos += yyleng;
 }
 
-[a-zA-Z0-9]\0([a-zA-Z0-9._%\-+]\0){1,128}@\0([a-zA-Z0-9._%\-]\0){1,128}\.\0({U_TLD1}|{U_TLD2}|{U_TLD3}|{U_TLD4})/[^a-zA-Z]|([^][^\0])	{
+[a-zA-Z0-9]\0([a-zA-Z0-9._%\-+]\0){1,62}[a-zA-Z0-9]\0@\0([a-zA-Z0-9._%\-]\0){1,250}\.\0({U_TLD1}|{U_TLD2}|{U_TLD3}|{U_TLD4})/[^a-zA-Z0-9._%\-]\0	{
     /* UTF-16 URL scanner */
     email_scanner &s = * yyemail_get_extra(yyscanner);
     s.check_margin();
-    if (extra_validate_email(yytext)){
+    if (email_has_left_boundary_utf16(SBUF, POS) && extra_validate_email_utf16(yytext, yyleng)){
         s.email_recorder.write_buf(SBUF,POS,yyleng);
         ssize_t domain_start = find_host_in_email(SBUF.slice(POS,yyleng)) + 1;
         if (domain_start >= 0){

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -15,6 +15,7 @@
 #include "config.h"
 
 #include <cstdint>
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -355,6 +356,70 @@ TEST_CASE("scan_email3", "[support]") {
     auto outdir = test_scanner(scan_email, sbufp);
     auto email_txt = getLines( outdir / "email.txt" );
     REQUIRE( requireFeature(email_txt,"0\tplain_text_pdf@textedit.com"));
+}
+
+static std::string valid_email_domain(size_t length)
+{
+    REQUIRE(length >= 5);
+    std::string domain;
+    size_t remaining = length - 4; // the final ".com"
+    while (remaining > 0) {
+        const size_t label_length = std::min<size_t>(63, remaining);
+        domain.append(label_length, 'd');
+        remaining -= label_length;
+        if (remaining == 0) break;
+        domain.push_back('.');
+        --remaining;
+    }
+    return domain + ".com";
+}
+
+static std::vector<uint8_t> utf16le(const std::string &text)
+{
+    std::vector<uint8_t> bytes;
+    bytes.reserve(text.size() * 2);
+    for (const unsigned char ch : text) {
+        bytes.push_back(ch);
+        bytes.push_back(0);
+    }
+    return bytes;
+}
+
+TEST_CASE("scan_email_length_limits", "[support]") {
+    const auto scan = [](const std::string &email) {
+        const std::string input = email + " ";
+        auto outdir = test_scanner(scan_email, new sbuf_t(input.c_str()));
+        return getLines(outdir / "email.txt");
+    };
+
+    for (const size_t length : {63U, 64U}) {
+        const std::string email(length, 'l');
+        const auto lines = scan(email + "@example.com");
+        REQUIRE(requireFeature(lines, "0\t" + email + "@example.com"));
+    }
+    REQUIRE(scan(std::string(65, 'l') + "@example.com").empty());
+
+    const std::string local = "loc";
+    for (const size_t length : {252U, 253U}) {
+        const std::string email = local + "@" + valid_email_domain(length);
+        const auto lines = scan(email);
+        REQUIRE(requireFeature(lines, "0\t" + email));
+    }
+    REQUIRE(scan(local + "@" + valid_email_domain(254)).empty());
+}
+
+TEST_CASE("scan_email_utf16_length_limits", "[support]") {
+    const auto scan = [](const std::string &email) {
+        const auto bytes = utf16le(email + " ");
+        auto outdir = test_scanner(scan_email, new sbuf_t(pos0_t(), bytes.data(), bytes.size()));
+        return getLines(outdir / "email.txt");
+    };
+
+    const std::string local(64, 'l');
+    REQUIRE_FALSE(scan(local + "@example.com").empty());
+    REQUIRE(scan(std::string(65, 'l') + "@example.com").empty());
+    REQUIRE_FALSE(scan("loc@" + valid_email_domain(253)).empty());
+    REQUIRE(scan("loc@" + valid_email_domain(254)).empty());
 }
 
 TEST_CASE("scan_email4", "[support]") {


### PR DESCRIPTION
Fixes #585.\n\nEnforces the 64-octet local-part and 253-octet domain limits independently in both ASCII and UTF-16 Flex paths. A left-boundary guard prevents overlong addresses from being emitted as truncated suffixes.\n\nAdds scanner-level boundary tests for local lengths 63/64/65 and domain lengths 252/253/254, including UTF-16 coverage, and documents the behavior in the 2.2.0 release notes.\n\nValidation: `make -C src check TESTS=test_be`.