### PR TITLE
Recover all members from RAR archives

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -47,6 +47,8 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
+- RAR extraction now preserves full seek offsets and bounded in-memory writes,
+  recovering every member of a multi-file RAR fixture ([#212](https://github.com/simsong/bulk_extractor/issues/212)).
 - Hardened `sbuf` bounds, arithmetic, and ownership behavior, including
   zero-length and one-past-end cases
   ([PR #511](https://github.com/simsong/bulk_extractor/pull/511)).

--- a/src/rar/file.cpp
+++ b/src/rar/file.cpp
@@ -614,7 +614,12 @@ bool File::RawSeek(int64 Offset,int Method)
 	}
 	else if(Method == SEEK_CUR)
 	{
-		return RawSeek(Tell() + Offset, SEEK_SET);
+        const int64 position = Tell();
+        if ((Offset > 0 && position > ptrlength - Offset) ||
+            (Offset < 0 && Offset < -position)) {
+            return false;
+        }
+        return RawSeek(position + Offset, SEEK_SET);
 	}
 
 	else

--- a/src/rar/file.cpp
+++ b/src/rar/file.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <climits>
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -510,7 +511,7 @@ int File::DirectRead(void *Data,size_t Size)
 Read data from memory of size <code>Size</code>. Calls the <code>DirectRead(Data,Size)</code> function.
 @param Data - a pointer to the memory location of the RAR file to be extracted
 @param Size - the length, in bytes, of the <code>Data</code> variable
-@return the size that was read from the memory location. If a '-1' is returned, an error has occurred.
+@return the size read from memory, or zero if the requested range is invalid.
 */
 int File::DirectRead(byte *Data,size_t Size)
 { //Reads from memory the size as spcified by 'Size'
@@ -520,26 +521,14 @@ int File::DirectRead(byte *Data,size_t Size)
 	//send off results
 
 	//int result = -1;
-	int result = 0;
-	if(Tell(ptrlocation + Size) <= ptrlength)
-	{ //verifies that we will be in bounds
-		result = Size;
-		memcpy(Data, ptrlocation, Size);
-
-
-		ptrlocation += Size; //adjust the pointer location
-
-		//Tell(); //for debugging purposes
-		/*for(int i = 0; i < result; i++)
-		{
-			Data = ptrlocation;
-			Data++;
-			ptrlocation++;
-		}*/
+	const int64 position = Tell();
+	if (position < 0 || position > ptrlength || Size > INT_MAX ||
+	    Size > static_cast<size_t>(ptrlength - position)) {
+		return 0;
 	}
-
-
-	return result;
+	memcpy(Data, ptrlocation, Size);
+	ptrlocation += Size;
+	return static_cast<int>(Size);
 
 	/*
 #ifdef _WIN_ALL
@@ -587,8 +576,8 @@ Moves the pointer in the file to a specified location. Calls the <code>RawSeek</
 @param Offset - the length from the current position
 @param Method - the method to move the pointer.
 If <code>SEEK_SET</code>, move the pointer <code>Offset</code> number of bytes to the new location in memory.
-If <code>SEEK_END</code>, move the pointer to the end of the file (NOT IMPLEMENTED)
-If <code>SEEK_CUR</code>, move the pointer (NOT IMPLEMENTED).
+If <code>SEEK_END</code>, move the pointer relative to the end of the file.
+If <code>SEEK_CUR</code>, move the pointer relative to the current position.
 */
 void File::Seek(int64 Offset,int Method)
 { //Calls RawSeek function
@@ -611,68 +600,21 @@ bool File::RawSeek(int64 Offset,int Method)
     return(true);*/  //we will assume all is well if we have gone this far.
 
 
-	if(Method == SEEK_SET)
-	{
-		/*if(&ptrlocation + Offset > &initptrlocation + ptrlength)
-			return(false); //we have overun the bounds
-
-		if(&ptrlocation + Offset < &initptrlocation)
-			return(false); //we have overrun the bounds*/
-
-		//ptrlocation = (byte*)Offset;
-
-		bool result = true;
-		byte * tempptrlocation = ptrlocation;
-
-		if(Offset > Tell())
-		{
-			byte newdiff = (byte)Offset - Tell();
-			tempptrlocation += newdiff;
-			//int64 telldebugging = Tell();
-			//int64 telldebugging2 = Tell(tempptrlocation);
-			//ptrlocation += newdiff;
-			if(Tell(tempptrlocation)  > ptrlength )
-			{//the new pointer length is farther than the length of the RAR file
-				result = false;
-			}
-			else
-			{// the new pointer length is within range of the length of the RAR file
-				ptrlocation += newdiff;
-				result = true;
-			}
-		}
-		else if(Offset < Tell())
-		{
-			byte newdiff = Tell() - (byte)Offset;
-			tempptrlocation -= newdiff;
-
-			//ptrlocation -= newdiff;
-			if(Tell(tempptrlocation)  < Tell(initptrlocation))
-			{//the new pointer length is before the range of the RAR file
-				result = false;
-			}
-			else{//the new pointer is within range of the length of the file
-				ptrlocation -= newdiff;
-				result = true;
-			}
-
-		}
-
-		//Tell(); //debugging function
-		return(result);
+	if (Method == SEEK_SET) {
+		if (Offset < 0 || Offset > ptrlength) return false;
+		ptrlocation = initptrlocation + Offset;
+		return true;
 	}
 
 	else if(Method == SEEK_END)
 	{
-		//we should go to the end of the file
-		ptrlocation = initptrlocation; 	//reset the pointer location to the beginning of the RAR file
-		ptrlocation += ptrlength;	//set the pointer to the end of the RAR file
+		if (Offset < -ptrlength || Offset > 0) return false;
+		ptrlocation = initptrlocation + ptrlength + Offset;
 		return true;
 	}
 	else if(Method == SEEK_CUR)
 	{
-		//we should do something else
-		return false;
+		return RawSeek(Tell() + Offset, SEEK_SET);
 	}
 
 	else

--- a/src/rar/rdwrfn.cpp
+++ b/src/rar/rdwrfn.cpp
@@ -151,12 +151,10 @@ void ComprDataIO::UnpWrite(byte *Addr,size_t Count)
   UnpWrSize=Count;
   if (UnpackToMemory)
   {
-    if (Count <= UnpackToMemorySize)
-    {
-      memcpy(UnpackToMemoryAddr,Addr,Count);
-      UnpackToMemoryAddr+=Count;
-      UnpackToMemorySize-=Count;
-    }
+    const size_t write_size=Min(Count,UnpackToMemorySize);
+    memcpy(UnpackToMemoryAddr,Addr,write_size);
+    UnpackToMemoryAddr+=write_size;
+    UnpackToMemorySize-=write_size;
   }
   else
     if (!TestMode)
@@ -266,5 +264,3 @@ void ComprDataIO::SetUnpackToMemory(byte *Addr,uint Size)
     UnpackFromMemorySize  = Size;
     UnpackFromMemoryAddr = (byte*)Addr;
 }*/
-
-

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -465,6 +465,18 @@ TEST_CASE("test_json", "[phase1]") {
 
 TEST_CASE("test_jpeg_rar", "[phase1]") {
     std::vector<Check> ex2 {
+        Check("unrar_carved.txt",
+              Feature("20-RAR-0", "unrar_carved/000/20-RAR-0_jpegs_1.jpg",
+                      "<fileobject><filename>unrar_carved/000/20-RAR-0_jpegs_1.jpg</filename><filesize>7323</filesize><hashdigest type='sha1'>0be21db1315246d1617092e8ed92530c85a66e9c</hashdigest></fileobject>")),
+        Check("unrar_carved.txt",
+              Feature("4340-RAR-0", "unrar_carved/000/4340-RAR-0_jpegs_2.jpg",
+                      "<fileobject><filename>unrar_carved/000/4340-RAR-0_jpegs_2.jpg</filename><filesize>7331</filesize><hashdigest type='sha1'>e8beb3c26d976fc30200d52d526c88553e09feac</hashdigest></fileobject>")),
+        Check("unrar_carved.txt",
+              Feature("8708-RAR-0", "unrar_carved/000/8708-RAR-0_jpegs_3.jpg",
+                      "<fileobject><filename>unrar_carved/000/8708-RAR-0_jpegs_3.jpg</filename><filesize>7509</filesize><hashdigest type='sha1'>d77611b716c9bb5f17ffa35b294ed775724b6839</hashdigest></fileobject>")),
+        Check("unrar_carved.txt",
+              Feature("13259-RAR-0", "unrar_carved/000/13259-RAR-0_jpegs_4.jpg",
+                      "<fileobject><filename>unrar_carved/000/13259-RAR-0_jpegs_4.jpg</filename><filesize>7599</filesize><hashdigest type='sha1'>65a1b15956227d3968d5b460c9512c54c46d80bb</hashdigest></fileobject>")),
         Check("jpeg.txt",
               Feature( "13259-RAR-0", "jpeg/000/13259-RAR-0.jpg"))
 

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <memory>
 #include <filesystem>
 #include <cstdio>
@@ -50,6 +51,7 @@
 #include "scan_pdf.h"
 #include "scan_vcard.h"
 #include "scan_wordlist.h"
+#include "rar/rar.hpp"
 
 #include "test_be.h"
 
@@ -482,6 +484,20 @@ TEST_CASE("test_jpeg_rar", "[phase1]") {
 
     };
     validate("jpegs.rar", ex2);
+}
+
+TEST_CASE("RAR in-memory relative seeks are bounded", "[rar]") {
+    std::array<unsigned char, 8> data{};
+    File file;
+    file.InitFile(data.data(), static_cast<int64>(data.size()));
+
+    REQUIRE(file.RawSeek(4, SEEK_SET));
+    REQUIRE_FALSE(file.RawSeek(std::numeric_limits<int64>::max(), SEEK_CUR));
+    REQUIRE(file.Tell() == 4);
+    REQUIRE_FALSE(file.RawSeek(std::numeric_limits<int64>::min(), SEEK_CUR));
+    REQUIRE(file.Tell() == 4);
+    REQUIRE(file.RawSeek(-4, SEEK_CUR));
+    REQUIRE(file.Tell() == 0);
 }
 
 /****************************************************************


### PR DESCRIPTION
Addresses #212.

Repairs RAR in-memory seeking: offsets are no longer truncated to a byte, `SEEK_SET`, `SEEK_CUR`, and `SEEK_END` perform bounded positioning, and in-memory unpack writes are bounded rather than silently discarded.

The regression checks all four carved JPEG members of `jpegs.rar` with exact offsets, filenames, sizes, and SHA-1 values. The 2.2.0 release notes record the recovery fix.

Validation: `make -C src check TESTS=test_be`.