### PR TITLE
Adapt progress display to Windows resize

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -51,6 +51,9 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
+- Progress displays now adapt to Windows console-width changes, matching the
+  periodic terminal-width refresh already used on Unix-like systems
+  ([#311](https://github.com/simsong/bulk_extractor/issues/311)).
 - Email extraction now enforces independent 64-octet local-part and 253-octet
   domain limits for ASCII and UTF-16 input, avoiding truncated suffix features
   from overlong addresses ([#585](https://github.com/simsong/bulk_extractor/issues/585)).

--- a/src/notify_thread.cpp
+++ b/src/notify_thread.cpp
@@ -2,6 +2,10 @@
 #include "bulk_extractor.h"
 #include "notify_thread.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif
@@ -19,6 +23,12 @@
 
 int notify_thread::terminal_width( int default_width )
 {
+#ifdef _WIN32
+    CONSOLE_SCREEN_BUFFER_INFO info;
+    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &info)) {
+        return info.srWindow.Right - info.srWindow.Left + 1;
+    }
+#endif
 #if defined(HAVE_IOCTL) && defined(HAVE_STRUCT_WINSIZE_WS_COL)
     struct winsize ws;
     if ( ioctl( STDIN_FILENO, TIOCGWINSZ, &ws)==0){


### PR DESCRIPTION
Addresses #311.

Use `GetConsoleScreenBufferInfo` to obtain the active Windows console width each progress refresh. Unix-like builds already refresh terminal width with `ioctl(TIOCGWINSZ)` on each notification interval; the existing cursor-home and clear-to-end-of-screen output redraws the resized display.

Validation: `make -C src check TESTS=test_be`.