### PR TITLE
Document carving mode behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,9 @@ shutdown defects found by full-image testing and AddressSanitizer.
 ## Release 2.1.1 (April 26, 2024)
 Renamed jpeg_carved feature recorder to jpeg, so that the jpeg carve mode can be set with -S jpeg_carve_mode=2, rather than -S jpeg_carved_carve_mode=2, which was confusing.
 
+See [Carving](doc/carving.md) for the current per-recorder carve-mode settings
+and their effects.
+
 
 ## Release 2.0
 `bulk_extractor` 2.0 (BE2) is now operational. Although it works with the Java-based viewer, we do not currently have an installer that runs under Windows.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,7 +2,7 @@
 AM_CPPFLAGS = -I${top_srcdir}/src/be20_api
 AUTOMAKE_OPTIONS = subdir-objects
 
-EXTRA_DIST = logging.md scanner_api.md scanner_template.cpp \
+EXTRA_DIST = carving.md logging.md scanner_api.md scanner_template.cpp \
     programmer_manual/BEProgrammersManual.tex \
     programmer_manual/Makefile.am \
     programmer_manual/extractinformationreprocess.pdf \

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -48,6 +48,8 @@ through the project's normal pull-request and CI process.
 - Network captures now preserve IEEE 802.11 records with their correct PCAP
   link type and report WiFi frame metadata in `wifi.txt`
   ([PR #559](https://github.com/simsong/bulk_extractor/pull/559)).
+- The carving guide documents recorder-specific `-S <recorder>_carve_mode=`
+  settings, defaults, and feature-file behavior ([#264](https://github.com/simsong/bulk_extractor/issues/264)).
 
 ### Reliability and correctness
 

--- a/doc/carving.md
+++ b/doc/carving.md
@@ -1,0 +1,36 @@
+# Carving
+
+Carving writes a recognized object to a file below the report directory. The
+corresponding carving feature file records its forensic path, carved filename,
+size, and hash.
+
+Carving is configured per feature recorder, not globally. Run
+`bulk_extractor -h` to list the available recorder names, then pass:
+
+```
+-S <recorder>_carve_mode=<mode>
+```
+
+For example, `-S jpeg_carve_mode=2` writes every JPEG accepted by the JPEG
+validator. Carving recorders include `jpeg`, `zip`, `rar`, `unrar`, and
+`sqlite` when their scanners are enabled in the build.
+
+| Mode | Effect |
+| --- | --- |
+| `0` | Do not write carved files or entries in the carving feature file. |
+| `1` | Write only objects reached through an encoded or derived input path, such as decompressed or Base64-decoded data. A bare object found directly in the input is not carved. |
+| `2` | Write every object passed to that recorder's carver, subject to validation, deduplication, and its minimum and maximum carve sizes. |
+
+Mode `1` is the usual default for JPEG, ZIP, and RAR recorders. It focuses on
+objects that ordinary file carvers are less likely to recover while avoiding a
+second copy of bare objects from the original image. `sqlite` defaults to mode
+`2`.
+
+The carving feature file records files actually carved (or a cached duplicate),
+not every object that a different mode could have carved. Some scanners also
+emit separate metadata feature records regardless of carve mode; for example,
+`zip.txt` describes recognized ZIP components. Use mode `2` when an inventory
+of every validated object for a carving recorder is required.
+
+There is currently no one-option global carve-mode override. Supply one `-S`
+setting for each carving recorder whose default you want to change.

--- a/doc/carving.md
+++ b/doc/carving.md
@@ -12,8 +12,9 @@ Carving is configured per feature recorder, not globally. Run
 ```
 
 For example, `-S jpeg_carve_mode=2` writes every JPEG accepted by the JPEG
-validator. Carving recorders include `jpeg`, `zip`, `rar`, `unrar`, and
-`sqlite` when their scanners are enabled in the build.
+validator. Carving recorders include `jpeg`, `zip_carved`, `rar`,
+`unrar_carved`, and `sqlite_carved` when their scanners are enabled in the
+build.
 
 | Mode | Effect |
 | --- | --- |
@@ -21,10 +22,10 @@ validator. Carving recorders include `jpeg`, `zip`, `rar`, `unrar`, and
 | `1` | Write only objects reached through an encoded or derived input path, such as decompressed or Base64-decoded data. A bare object found directly in the input is not carved. |
 | `2` | Write every object passed to that recorder's carver, subject to validation, deduplication, and its minimum and maximum carve sizes. |
 
-Mode `1` is the usual default for JPEG, ZIP, and RAR recorders. It focuses on
-objects that ordinary file carvers are less likely to recover while avoiding a
-second copy of bare objects from the original image. `sqlite` defaults to mode
-`2`.
+Mode `1` is the default for JPEG and RAR recorders (`rar` and
+`unrar_carved`). It focuses on objects that ordinary file carvers are less
+likely to recover while avoiding a second copy of bare objects from the
+original image. `zip_carved` and `sqlite_carved` default to mode `2`.
 
 The carving feature file records files actually carved (or a cached duplicate),
 not every object that a different mode could have carved. Some scanners also


### PR DESCRIPTION
Addresses #264.

Add a concise user-facing carving guide that documents each per-recorder `-S <recorder>_carve_mode=<0|1|2>` setting, defaults, encoded-path semantics, size limits, deduplication, and feature-file behavior.

The issue comment records the validated limitation: mode-suppressed candidates are not currently entered in the carving feature file, so an inventory-only record requires separate implementation.

Validation: `git diff --check`. Documentation-only change.