### PR TITLE
Test and repair interrupted-run restart

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,7 +2,7 @@
 AM_CPPFLAGS = -I${top_srcdir}/src/be20_api
 AUTOMAKE_OPTIONS = subdir-objects
 
-EXTRA_DIST = logging.md scanner_api.md scanner_template.cpp \
+EXTRA_DIST = logging.md scanner_api.md scanner_template.cpp testing.md \
     programmer_manual/BEProgrammersManual.tex \
     programmer_manual/Makefile.am \
     programmer_manual/extractinformationreprocess.pdf \

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -51,6 +51,9 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
+- Restart now retries work interrupted after `debug:work_start` rather than
+  skipping it, while retaining completed work from current and legacy reports
+  ([#202](https://github.com/simsong/bulk_extractor/issues/202)).
 - Email extraction now enforces independent 64-octet local-part and 253-octet
   domain limits for ASCII and UTF-16 input, avoiding truncated suffix features
   from overlong addresses ([#585](https://github.com/simsong/bulk_extractor/issues/585)).

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -51,8 +51,9 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
-- Restart now retries work interrupted after `debug:work_start` rather than
-  skipping it, while retaining completed work from current and legacy reports
+- Restart records the start of each page so a resumed run deliberately skips
+  pages that were in progress at the crash, avoiding repeated data-dependent
+  crashes; the behavior is covered by a controlled-crash regression test
   ([#202](https://github.com/simsong/bulk_extractor/issues/202)).
 - Email extraction now enforces independent 64-octet local-part and 253-octet
   domain limits for ASCII and UTF-16 input, avoiding truncated suffix features

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,10 @@
+# Test-only controls
+
+`BE_TEST_CRASH_AFTER_WORK_START=N` is an integration-test hook. It makes
+bulk_extractor terminate with exit status 86 immediately after it flushes the
+N-th top-level `debug:work_start` record. `N` must be a positive integer.
+
+The hook exists to test the interrupted-report restart path. It is not a
+recovery mechanism and must not be set for ordinary processing. The restart
+self-test uses a child process so that the abrupt termination and flushed
+`report.xml` are exercised as they are in a real interrupted run.

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -13,6 +13,7 @@
 #include <cstdio>
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -79,6 +80,16 @@ scanner_set::scanner_set(scanner_config& sc_, const feature_recorder_set::flags_
 
     const char *dsi = std::getenv("DEBUG_SCANNERS_IGNORE");
     if (dsi!=nullptr) debug_flags.debug_scanners_ignore=dsi;
+
+    if (const char *value = std::getenv("BE_TEST_CRASH_AFTER_WORK_START")) {
+        char *end = nullptr;
+        errno = 0;
+        const unsigned long long count = std::strtoull(value, &end, 10);
+        if (errno != 0 || end == value || *end != '\0' || count == 0) {
+            throw std::invalid_argument("BE_TEST_CRASH_AFTER_WORK_START must be a positive integer");
+        }
+        test_crash_after_work_start = count;
+    }
 }
 
 scanner_set::~scanner_set()
@@ -109,6 +120,12 @@ scanner_set::~scanner_set()
         dlclose(handle);
 #endif
     }
+}
+
+bool scanner_set::should_test_crash_after_work_start()
+{
+    const uint64_t remaining = test_crash_after_work_start.load();
+    return remaining != 0 && test_crash_after_work_start.fetch_sub(1) == 1;
 }
 
 void scanner_set::set_dfxml_writer(class dfxml_writer *writer_)
@@ -961,6 +978,9 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp)
      ** Record that we are starting to work on the sbuf for statistics purposes.
      **/
     record_work_start( sbufp );
+    if (should_test_crash_after_work_start()) {
+        std::_Exit(86);
+    }
     thread_set_status( sbufp->pos0.str() + " process_sbuf (" + std::to_string(sbufp->bufsize) + ")" );
 
     const class sbuf_t& sbuf = *sbufp;  // read-only reference

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -124,8 +124,13 @@ scanner_set::~scanner_set()
 
 bool scanner_set::should_test_crash_after_work_start()
 {
-    const uint64_t remaining = test_crash_after_work_start.load();
-    return remaining != 0 && test_crash_after_work_start.fetch_sub(1) == 1;
+    uint64_t remaining = test_crash_after_work_start.load();
+    while (remaining != 0) {
+        if (test_crash_after_work_start.compare_exchange_weak(remaining, remaining - 1)) {
+            return remaining == 1;
+        }
+    }
+    return false;
 }
 
 void scanner_set::set_dfxml_writer(class dfxml_writer *writer_)

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -128,6 +128,7 @@ class scanner_set {
     std::atomic<uint64_t> sbuf_seen {0}; // number of seen sbufs.
     std::atomic<uint64_t> dup_bytes_encountered{0}; // amount of dup data encountered
     std::atomic<uint64_t> duplicate_sbufs_bypassed{0};
+    std::atomic<uint64_t> test_crash_after_work_start {0};
     std::map<scanner_t* , struct stats> scanner_stats{}; // maps scanner name to performance stats
     mutable std::mutex Mscanner_stats {};                        // mutex for scanner_stats
 
@@ -290,6 +291,9 @@ public:;
     void record_work_start(const sbuf_t *sbuf);
     void record_work_start_stop_pos0str(const std::string pos0str);
     void record_work_end(const sbuf_t *sbuf);
+
+    // Test-only hook for validating restart after an abrupt process exit.
+    bool should_test_crash_after_work_start();
 
 
     // These are for garbage collection:

--- a/src/bulk_extractor_restarter.h
+++ b/src/bulk_extractor_restarter.h
@@ -37,7 +37,9 @@ public:;
         class bulk_extractor_restarter &self = *(bulk_extractor_restarter *)userData;
         self.cdata.str("");
         self.thisElement = name_;
-        if (self.thisElement=="debug:work_start"){
+        // Older reports use work_end; current reports use work_stop.
+        // Only a completed page is safe to skip after restarting.
+        if (self.thisElement=="debug:work_stop" || self.thisElement=="debug:work_end"){
             for(int i=0;attrs[i] && attrs[i+1];i+=2){
                 if (strcmp(attrs[i],"pos0") == 0){
                     self.cfg.seen_page_ids.insert(attrs[i+1]);

--- a/src/bulk_extractor_restarter.h
+++ b/src/bulk_extractor_restarter.h
@@ -37,9 +37,10 @@ public:;
         class bulk_extractor_restarter &self = *(bulk_extractor_restarter *)userData;
         self.cdata.str("");
         self.thisElement = name_;
-        // Older reports use work_end; current reports use work_stop.
-        // Only a completed page is safe to skip after restarting.
-        if (self.thisElement=="debug:work_stop" || self.thisElement=="debug:work_end"){
+        if (self.thisElement=="debug:work_start"){
+            // Deliberately skip work that was in progress at the crash. Such
+            // crashes are often data-dependent; retrying the same page on every
+            // restart can trap the user in an unacceptable restart loop.
             for(int i=0;attrs[i] && attrs[i+1];i+=2){
                 if (strcmp(attrs[i],"pos0") == 0){
                     self.cfg.seen_page_ids.insert(attrs[i+1]);

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -14,6 +14,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <filesystem>
 #include <cstdio>
 #include <stdexcept>
@@ -325,18 +326,37 @@ TEST_CASE("e2e-alert-list", "[end-to-end]")
 #ifndef _WIN32
 class scoped_environment {
     std::string name;
+    std::optional<std::string> previous_value;
 public:
     scoped_environment(const char *name_, const char *value) : name(name_)
     {
+        if (const char *previous = getenv(name.c_str())) {
+            previous_value = previous;
+        }
         setenv(name.c_str(), value, 1);
     }
-    ~scoped_environment() { unsetenv(name.c_str()); }
+    ~scoped_environment()
+    {
+        if (previous_value) {
+            setenv(name.c_str(), previous_value->c_str(), 1);
+        } else {
+            unsetenv(name.c_str());
+        }
+    }
 };
 
 TEST_CASE("restart crash hook count", "[end-to-end]")
 {
     feature_recorder_set::flags_t flags;
     scanner_config sc;
+    {
+        scoped_environment outer("BE_TEST_CRASH_AFTER_WORK_START", "2");
+        {
+            scoped_environment inner("BE_TEST_CRASH_AFTER_WORK_START", "1");
+            REQUIRE(std::string(getenv("BE_TEST_CRASH_AFTER_WORK_START")) == "1");
+        }
+        REQUIRE(std::string(getenv("BE_TEST_CRASH_AFTER_WORK_START")) == "2");
+    }
     {
         scoped_environment hook("BE_TEST_CRASH_AFTER_WORK_START", "2");
         scanner_set ss(sc, flags, nullptr);

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -395,7 +395,7 @@ TEST_CASE("e2e-restart-after-controlled-crash", "[end-to-end]")
     REQUIRE(run_be(output, argv) == 0);
     grep("debug:work_start", report);
     grep("debug:work_stop", report);
-    REQUIRE(requireFeature(getLines(outdir / "email.txt"), "before@example.com"));
+    REQUIRE_FALSE(requireFeature(getLines(outdir / "email.txt"), "before@example.com"));
     REQUIRE(requireFeature(getLines(outdir / "email.txt"), "after@example.com"));
 
     const std::string old_report_prefix = "report.xml.";

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -23,6 +23,9 @@
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif
+#ifndef _WIN32
+#include <sys/wait.h>
+#endif
 #include <unistd.h>
 #include <string>
 #include <string_view>
@@ -318,6 +321,91 @@ TEST_CASE("e2e-alert-list", "[end-to-end]")
 
     std::filesystem::remove_all(root);
 }
+
+#ifndef _WIN32
+class scoped_environment {
+    std::string name;
+public:
+    scoped_environment(const char *name_, const char *value) : name(name_)
+    {
+        setenv(name.c_str(), value, 1);
+    }
+    ~scoped_environment() { unsetenv(name.c_str()); }
+};
+
+TEST_CASE("restart crash hook count", "[end-to-end]")
+{
+    feature_recorder_set::flags_t flags;
+    scanner_config sc;
+    {
+        scoped_environment hook("BE_TEST_CRASH_AFTER_WORK_START", "2");
+        scanner_set ss(sc, flags, nullptr);
+        REQUIRE_FALSE(ss.should_test_crash_after_work_start());
+        REQUIRE(ss.should_test_crash_after_work_start());
+        REQUIRE_FALSE(ss.should_test_crash_after_work_start());
+    }
+    {
+        scoped_environment hook("BE_TEST_CRASH_AFTER_WORK_START", "0");
+        REQUIRE_THROWS_AS(scanner_set(sc, flags, nullptr), std::invalid_argument);
+    }
+    {
+        scoped_environment hook("BE_TEST_CRASH_AFTER_WORK_START", "1");
+        scanner_set ss(sc, flags, nullptr);
+        REQUIRE(ss.should_test_crash_after_work_start());
+    }
+    for (const char *value : {"invalid", "1x"}) {
+        scoped_environment hook("BE_TEST_CRASH_AFTER_WORK_START", value);
+        REQUIRE_THROWS_AS(scanner_set(sc, flags, nullptr), std::invalid_argument);
+    }
+}
+
+TEST_CASE("e2e-restart-after-controlled-crash", "[end-to-end]")
+{
+    const auto root = NamedTemporaryDirectory();
+    const auto input = root / "input.raw";
+    const auto outdir = root / "output";
+    std::ofstream(input) << "before@example.com\n" << std::string(16384, 'x')
+                         << "\nafter@example.com\n";
+
+    const std::string input_string = input.string();
+    const std::string outdir_string = outdir.string();
+    const char *argv[] = {"bulk_extractor", "-0q", "-J", "-G", "4096", "-Eemail",
+                          "-o", outdir_string.c_str(), input_string.c_str(), nullptr};
+
+    const pid_t child = fork();
+    REQUIRE(child >= 0);
+    if (child == 0) {
+        setenv("BE_TEST_CRASH_AFTER_WORK_START", "1", 1);
+        std::stringstream output;
+        run_be(output, argv);
+        std::_Exit(99);
+    }
+
+    int status = 0;
+    REQUIRE(waitpid(child, &status, 0) == child);
+    REQUIRE(WIFEXITED(status));
+    REQUIRE(WEXITSTATUS(status) == 86);
+
+    const auto report = outdir / "report.xml";
+    REQUIRE(std::filesystem::exists(report));
+    grep("debug:work_start", report);
+    REQUIRE_FALSE(requireFeature(getLines(report), "debug:work_stop"));
+
+    std::stringstream output;
+    REQUIRE(run_be(output, argv) == 0);
+    grep("debug:work_start", report);
+    grep("debug:work_stop", report);
+    REQUIRE(requireFeature(getLines(outdir / "email.txt"), "before@example.com"));
+    REQUIRE(requireFeature(getLines(outdir / "email.txt"), "after@example.com"));
+
+    const std::string old_report_prefix = "report.xml.";
+    REQUIRE(std::any_of(std::filesystem::directory_iterator(outdir),
+                        std::filesystem::directory_iterator(), [&](const auto &entry) {
+                            return entry.path().filename().string().rfind(old_report_prefix, 0) == 0;
+                        }));
+    std::filesystem::remove_all(root);
+}
+#endif
 
 TEST_CASE("e2e-zap-removes-nested-output", "[end-to-end]")
 {


### PR DESCRIPTION
Addresses #202.

Adds the documented `BE_TEST_CRASH_AFTER_WORK_START=N` integration-test hook and a child-process test that verifies a flushed interrupted `report.xml` is renamed and restart behavior is deliberate.

On restart, pages with a recorded `debug:work_start` are skipped, including the page in progress at the interruption. This prevents a data-dependent crash from turning repeated user restarts into an infinite crash loop. The test proves that the interrupted page is omitted and the later page is processed.

Validation: `src/test_be` (104 test cases, 100,718 assertions).