### PR TITLE
Retire obsolete numeric debug mask

### DIFF
--- a/doc/Diagnostic_Notes/be_crash_diagnostics.md
+++ b/doc/Diagnostic_Notes/be_crash_diagnostics.md
@@ -87,4 +87,7 @@ STEP FOUR: CAPTURE A TRACE
 
 bulk_extractor is multi-threaded, which means that multiple threads of execution run at the same time within the program. In standard use bulk_extractor creates one thread to read all of the pages from the disk. Between 1 and NN threads are then created to process the pages. Pages are not processed roughly in order, although different different pages take different amounts of time to process, so it is likely that some pages will start processing before other pages finish.
 
-You can have bulk_extractor print every time it starts and exits a scanner with the “-d1″ option. It’s not clear that this will actually help you debug the problem you encounter, but it might.
+Use `-d` to enable debug-level diagnostic logging. The log is written to
+`<outdir>/bulk_extractor.log` by default; use `--log-file PATH` to select a
+different location. Scanner selection is independent of logging: use `-x all`
+followed by `-e NAME` to run only selected scanners.

--- a/doc/Diagnostic_Notes/crash_diagnosis1.txt
+++ b/doc/Diagnostic_Notes/crash_diagnosis1.txt
@@ -89,6 +89,8 @@ STEP FIVE: CAPTURE A TRACE
 
 bulk_extractor is multi-threaded, which means that multiple threads of execution run at the same time within the program. In standard use bulk_extractor creates one thread to read all of the pages from the disk. Between 1 and NN threads are then created to process the pages. Pages are not processed roughly in order, although different different pages take different amounts of time to process, so it is likely that some pages will start processing before other pages finish.
 
-You can have bulk_extractor print every time it starts and exits a scanner with the "-d1" option. It's not clear that this will actually help you debug the problem you encounter, but it might.
+Use -d to enable debug-level diagnostic logging. The log is written to
+<outdir>/bulk_extractor.log by default; use --log-file PATH to select a
+different location. Scanner selection is independent of logging: use -x all
+followed by -e NAME to run only selected scanners.
 
- 

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -51,6 +51,11 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
+- Removed the obsolete numeric debug mask and its misleading scanner-control
+  documentation. `-d`/`--debug` now explicitly enables debug-level diagnostic
+  logging; scanner selection remains controlled by `-x` and `-e`
+  ([#403](https://github.com/simsong/bulk_extractor/issues/403)).
+
 - Email extraction now enforces independent 64-octet local-part and 253-octet
   domain limits for ASCII and UTF-16 input, avoiding truncated suffix features
   from overlong addresses ([#585](https://github.com/simsong/bulk_extractor/issues/585)).

--- a/src/DEBUG.md
+++ b/src/DEBUG.md
@@ -5,11 +5,16 @@
 `DEBUG_DISABLE_TIMERS` | Do not run any aftimer (for determining overhead of running the timers.)
 `DEBUG_PDF_DUMP_HEX`   | Hex dump all decompressed PDF runs to stderr
 `DEBUG_PDF_DUMP_TEXT`  | Dump all extracted PDF text to stderr
-`DEBUG_SCANNER_SET_PRINT_STEPS`| debug_flags.debug_print_steps = true;
-`DEBUG_SCANNER_SET_NO_SCANNERS`| debug_flags.debug_no_scanners = true;
-`DEBUG_SCANNER_SET_SCANNER`| debug_flags.debug_scanner = true;
-`DEBUG_SCANNER_SET_DUMP_DATA`| debug_flags.debug_dump_data = true;
-`DEBUG_SCANNER_SET_DECODING`| debug_flags.debug_decoding = true;
-`DEBUG_SCANNER_SET_INFO`| debug_flags.debug_info = true;
-`DEBUG_SCANNER_SET_EXIT_EARLY`| debug_flags.debug_exit_early = true;
-`DEBUG_SCANNER_SET_REGISTER`| debug_flags.debug_register = true;
+`DEBUG_PRINT_STEPS`| print each scanner as it starts
+`DEBUG_SCANNER`| dump feature writes to stderr
+`DEBUG_SCANNER_DUMP_DATA`| dump scanner input data
+`DEBUG_BENCHMARK`| collect scanner timing diagnostics
+`DEBUG_SCANNERS_SAME_THREAD`| run scanner callbacks in one thread
+`DEBUG_SBUF_GC`| log sbuf garbage-collection activity
+`DEBUG_SBUF_GC0`| log initial sbuf garbage-collection activity
+`DEBUG_FS_PEDANTIC`| enable feature-recorder consistency checks
+
+Use `-d` (or `--debug`) to set diagnostic logging to the `debug` level. Use
+`--log-level` to select another diagnostic level. Scanner selection is
+independent: use `-x all` to disable every scanner, followed by `-e NAME` to
+enable selected scanners.

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -270,7 +270,32 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
     options.positional_help( "image_name" );
     options.parse_positional( "image_name" );
-    auto result = options.parse( argc, argv);
+    const auto is_numeric_debug_mask = [](std::string_view argument) {
+        std::string_view value;
+        if (argument.rfind("-d", 0) == 0 && argument.size() > 2) {
+            value = argument.substr(2);
+        } else if (argument.rfind("--debug=", 0) == 0) {
+            value = argument.substr(std::string_view("--debug=").size());
+        }
+        return !value.empty() && value.find_first_not_of("0123456789") == std::string_view::npos;
+    };
+    for (int arg = 1; arg < argc; arg++) {
+        const std::string_view argument(argv[arg]);
+        if (is_numeric_debug_mask(argument) || argument == "-D") {
+            cerr << "error: numeric debug masks and -D have been retired; "
+                 << "use -d for debug logging and -x/-e for scanner selection.\n\n"
+                 << options.help() << std::endl;
+            return 1;
+        }
+    }
+
+    cxxopts::ParseResult result;
+    try {
+        result = options.parse( argc, argv);
+    } catch (const cxxopts::OptionException &e) {
+        cerr << "error: " << e.what() << "\n\n" << options.help() << std::endl;
+        return 1;
+    }
     const bool debug_requested = result.count("debug") != 0;
 
     sc.offset_add  = result["offset_add"].as<int64_t>();

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -52,25 +52,6 @@ int _CRT_fmode = _O_BINARY;
 
 #include "cxxopts.hpp"
 
-/**
- * Output the #defines for our debug parameters. Used by the automake system.
- */
-[[noreturn]] void debug_help()
-{
-    puts( "#define DEBUG_PEDANTIC    0x0001	// check values more rigorously" );
-    puts( "#define DEBUG_PRINT_STEPS 0x0002     // prints as each scanner is started" );
-    puts( "#define DEBUG_SCANNER     0x0004	// dump all feature writes to stderr" );
-    puts( "#define DEBUG_NO_SCANNERS 0x0008     // do not run the scanners " );
-    puts( "#define DEBUG_DUMP_DATA   0x0010	// dump data as it is seen " );
-    puts( "#define DEBUG_INFO        0x0040	// print extra info" );
-    puts( "#define DEBUG_EXIT_EARLY  1000	// just print the size of the volume and exis " );
-    puts( "#define DEBUG_ALLOCATE_512MiB 1002	// Allocate 512MiB, but don't set any flags " );
-    puts( "// any debug can also be enabled by setting the corresponding environment variables");
-    puts( "// e.g. DEBUG_PRINT_STEPS=1 ./bulk_extractor ...");
-
-    exit( 1);
-}
-
 /****************************************************************
  *** Usage for the stand-alone program
  ****************************************************************/
@@ -247,8 +228,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         ("b,banner_file", "Path of file whose contents are prepended to top of all feature files",cxxopts::value<std::string>())
 	("C,context_window", "Size of context window reported in bytes",
          cxxopts::value<int>()->default_value(std::to_string(sc.context_window_default)))
-        ("d,debug", "enable debugging", cxxopts::value<int>()->implicit_value("1")->default_value("0"))
-        ("D,debug_help", "help on debugging")
+        ("d,debug", "enable debug-level diagnostic logging")
         ("E,enable_exclusive", "disable all scanners except the one specified. Same as -x all -E scanner.", cxxopts::value<std::string>())
         ("e,enable",   "enable a scanner (can be repeated)", cxxopts::value<std::vector<std::string>>())
         ("x,disable",  "disable a scanner (can be repeated)", cxxopts::value<std::vector<std::string>>())
@@ -291,15 +271,10 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     options.positional_help( "image_name" );
     options.parse_positional( "image_name" );
     auto result = options.parse( argc, argv);
-    if ( result.count( "debug_help" )){ debug_help(); return 3;}
-    const bool debug_requested = std::any_of(argv, argv + argc, [](const char *argument) {
-        const std::string_view value(argument);
-        return value == "-d" || value == "--debug" || value.rfind("--debug=", 0) == 0;
-    });
+    const bool debug_requested = result.count("debug") != 0;
 
     sc.offset_add  = result["offset_add"].as<int64_t>();
     sc.context_window_default = result["context_window"].as<int>();
-    cfg.debug = result["debug"].as<int>();
     const int max_minute_wait = result["max_minute_wait"].as<int>();
     if (max_minute_wait <= 0) {
         throw std::runtime_error("--max_minute_wait must be positive");

--- a/src/bulk_extractor.h
+++ b/src/bulk_extractor.h
@@ -15,7 +15,6 @@
 #define BE_PHASE_2 2 // cleaning up
 #define BE_PHASE_3 3 // shutdown
 
-[[noreturn]] void debug_help();
 void validate_path(const std::filesystem::path fn);
 void bulk_extractor_set_debug();
 extern bool RUNNING_UNDER_CATCH;

--- a/src/phase1.h
+++ b/src/phase1.h
@@ -57,7 +57,6 @@ public:
         Config &operator=(const Config &that) = delete;        // assignment constructor - delete
 
         Config() { }
-        uint64_t  debug {false};                 // debug
         size_t    opt_pagesize {16 * MiB};
         size_t    opt_marginsize { 4 * MiB};
         uint32_t  max_bad_alloc_errors {3}; // by default, 3 retries

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -450,6 +450,26 @@ TEST_CASE("e2e-H", "[end-to-end]") {
     REQUIRE( ret==2 );                  // -H produces 2
 }
 
+TEST_CASE("retired numeric debug options report help", "[end-to-end]")
+{
+    const char *short_mask[] = {"bulk_extractor", "-d8", nullptr};
+    const char *long_mask[] = {"bulk_extractor", "--debug=1", nullptr};
+    const char *debug_help[] = {"bulk_extractor", "-D", nullptr};
+
+    for (const auto argv : {short_mask, long_mask, debug_help}) {
+        std::stringstream cout, cerr;
+        REQUIRE(run_be(cout, cerr, argv) == 1);
+        REQUIRE(cerr.str().find("have been retired") != std::string::npos);
+        REQUIRE(cerr.str().find("Usage:") != std::string::npos);
+    }
+
+    const char *invalid[] = {"bulk_extractor", "--not-a-real-option", nullptr};
+    std::stringstream cout, cerr;
+    REQUIRE(run_be(cout, cerr, invalid) == 1);
+    REQUIRE(cerr.str().find("error:") != std::string::npos);
+    REQUIRE(cerr.str().find("Usage:") != std::string::npos);
+}
+
 /* Run on the first 100k of the emails dataset
  * bulk_extractor -0q -o [outdir] nps-2010-emails.100k.raw
  * Runs twice, so that we can also test the restarting logic


### PR DESCRIPTION
Addresses #403.

Removes the unused numeric debug-mask interface and its `-D` mask table. Retains `-d`/`--debug` as the current boolean shortcut for debug-level diagnostic logging; scanner selection remains explicit through `-x` and `-e`. Updates debug and crash-diagnosis documentation plus 2.2.0 release notes.

Validation:
- `make -C src bulk_extractor.o V=0`
- `make -C src phase1.o V=0`
- Existing `diagnostic command-line configuration` test covers `-d` and asserts the debug-level diagnostic log.
- A full local `test_be` link was blocked by an empty generated `libbe20.a` after fresh Autotools bootstrap/configure; no source compilation error was reported.