### PR TITLE
Verify Copilot review requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 GitHub activity authored by Codex must use `@${USER}-codex` when that account exists. For this workspace, use `@simsong-codex`; do not use the personal `@simsong` identity for GitHub writes, pushes, issues, pull requests, reviews, or comments.
 
-For every Codex-authored pull request, request a Copilot review after publishing it, then monitor the pull request until Copilot has responded and all required CI checks have completed. Address actionable feedback before declaring the pull request ready. Once it is green and feedback-free, mark it ready for review and assign it to `@simsong`; do not approve or merge it unless explicitly asked.
+For every Codex-authored pull request, request a Copilot review after publishing it by requesting `copilot-pull-request-reviewer` (not `copilot`). Verify the request through GitHub's review state, then monitor until a Copilot review or review thread actually appears and all required CI checks have completed. Do not report a request as made, or Copilot as having responded, based only on a CLI command or an `@copilot` comment. Address actionable feedback before declaring the pull request ready. Once it is green and feedback-free, mark it ready for review and assign it to `@simsong`; do not approve or merge it unless explicitly asked.
 
 Do not close GitHub issues. You may validate an issue, record evidence, and recommend closure in a comment, but change an issue's open/closed state only when the repository owner explicitly instructs you to do so.
 


### PR DESCRIPTION
Clarifies the AI contributor instructions for Copilot review handling.

Codex must request `copilot-pull-request-reviewer`, then verify an actual GitHub review or review thread before reporting the request or response. This prevents treating an unsuccessful CLI request or an `@copilot` comment as evidence of review.

Validation: `git diff --check`.