### PR TITLE
Initialize scoped test environment state

### DIFF
--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -356,7 +356,7 @@ class scoped_environment {
     std::string name;
     std::optional<std::string> previous_value;
 public:
-    scoped_environment(const char *name_, const char *value) : name(name_)
+    scoped_environment(const char *name_, const char *value) : name(name_), previous_value{}
     {
         if (const char *previous = getenv(name.c_str())) {
             previous_value = previous;


### PR DESCRIPTION
## Summary

Initializes `scoped_environment::previous_value` explicitly.

## Why

The restart regression test introduced the helper without an explicit initializer.  GCC with `-Weffc++ -Werror` diagnoses that omission, blocking Linux and MinGW builds of PR #602 even though the helper's default state is correct.

## Validation

- `make -C src check TESTS=test_be`
