### PR TITLE
Fix 2026 Coverity parser findings

### DIFF
--- a/src/exif_entry.cpp
+++ b/src/exif_entry.cpp
@@ -1302,6 +1302,8 @@ static std::string get_exif_ascii(tiff_handle_t &tiff_handle, uint32_t ifd_entry
     tiff_handle.bytes_read += count; // exif standard: 1 exif ascii value is 1 byte long
     if (count >= 0x10000 || tiff_handle.bytes_read >= 0x10000) throw exif_failure_exception_t();
 
+    if (count > tiff_handle.sbuf->left(offset)) throw exif_failure_exception_t();
+
     // strip off "\0" allowing up to 2 \0 markers because tiff terminates with \0 using byte pairs
     try {
         if (count > 0 && tiff_handle.sbuf->get8u(offset + count - 1) == 0) {

--- a/src/image_process.cpp
+++ b/src/image_process.cpp
@@ -74,14 +74,14 @@ std::filesystem::path image_process::image_fname() const
 
 
 
-bool image_process::fn_ends_with(std::filesystem::path path, std::string suffix)
+bool image_process::fn_ends_with(const std::filesystem::path &path, const std::string &suffix)
 {
     std::string str(path.string());
     if (suffix.size() > str.size()) return false;
     return str.substr(str.size()-suffix.size())==suffix;
 }
 
-bool image_process::is_multipart_file(std::filesystem::path fn)
+bool image_process::is_multipart_file(const std::filesystem::path &fn)
 {
     return fn_ends_with(fn,".000")
 	|| fn_ends_with(fn,".001")

--- a/src/image_process.h
+++ b/src/image_process.h
@@ -68,8 +68,8 @@ public:
     /* These two functions are only used in WIN32 but are defined here so that they can be tested on all platforms */
     static std::string filename_extension(std::filesystem::path fn); // returns extension
 
-    static bool fn_ends_with(std::filesystem::path str,std::string suffix);
-    static bool is_multipart_file(std::filesystem::path fn);
+    static bool fn_ends_with(const std::filesystem::path &str, const std::string &suffix);
+    static bool is_multipart_file(const std::filesystem::path &fn);
     static int multipart_number(const std::filesystem::path &fn);
     static std::filesystem::path multipart_filename(const std::filesystem::path &fn, int number);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,9 +8,17 @@
 #include "config.h"
 #include "bulk_extractor.h"
 
+#include <exception>
 #include <ostream>
 
 int main(int argc,char * const *argv)
 {
-    return bulk_extractor_main(std::cout, std::cerr, argc, argv);
+    try {
+        return bulk_extractor_main(std::cout, std::cerr, argc, argv);
+    } catch (const std::exception &error) {
+        std::cerr << "bulk_extractor: " << error.what() << '\n';
+    } catch (...) {
+        std::cerr << "bulk_extractor: unexpected exception\n";
+    }
+    return 1;
 }

--- a/src/scan_hiberfile.cpp
+++ b/src/scan_hiberfile.cpp
@@ -54,14 +54,14 @@ void scan_hiberfile_scan(scanner_params &sp)
         if (npos==-1) break;             // header not found
 
         pos = npos;
-        u_int compressed_length = (   (sbuf[pos+8]
-                                       + (sbuf[pos+9]<<8)
-                                       + (sbuf[pos+10] << 16)
-                                       + (sbuf[pos+11]<<24)) >> 10) + 1; // ref: Hibr2bin/MemoryBlocks.cpp
+        uint32_t compressed_length = ((static_cast<uint32_t>(sbuf[pos + 8])
+                                       | (static_cast<uint32_t>(sbuf[pos + 9]) << 8)
+                                       | (static_cast<uint32_t>(sbuf[pos + 10]) << 16)
+                                       | (static_cast<uint32_t>(sbuf[pos + 11]) << 24)) >> 10) + 1;
 
         compressed_length = (compressed_length + 7) & ~7; // ref: Hibr2bin/MemoryBlocks.cpp
         const unsigned char *compressed_buf = sbuf.get_buf() + pos + 32;		 // "the header contains 32 bytes"
-        u_int  remaining_size = sbuf.bufsize - (pos+32); // up to the end of the buffer
+        size_t remaining_size = sbuf.bufsize - (pos+32); // up to the end of the buffer
         size_t compr_size = compressed_length < remaining_size ? compressed_length : remaining_size;
         size_t max_uncompr_size = compr_size * 10; // hope that's good enough
         if (max_uncompr_size < min_uncompr_size) {

--- a/src/scan_json.cpp
+++ b/src/scan_json.cpp
@@ -442,7 +442,7 @@ void scan_json(struct scanner_params &sp)
         sp.info->scanner_version = "1.1";
         feature_recorder_def frd("json");
         frd.flags.xml = true;
-        sp.info->feature_defs.push_back( frd );
+        sp.info->feature_defs.push_back(std::move(frd));
 
 	/* Create a fast map of the valid json characters.*/
 	memset(is_json_second_char,0,sizeof(is_json_second_char));

--- a/src/scan_kml.cpp
+++ b/src/scan_kml.cpp
@@ -51,17 +51,19 @@ void scan_kml(scanner_params &sp)
 	    if(kml_loc==-1) return;
 	    ssize_t ekml_loc = sbuf.find("</kml>",kml_loc);
 	    if(ekml_loc==-1) return;
-	    ssize_t kml_len = (ekml_loc-xml_loc)+6;
+	    const size_t xml_offset = static_cast<size_t>(xml_loc);
+	    const size_t end_offset = static_cast<size_t>(ekml_loc);
+	    const size_t kml_len = end_offset - xml_offset + 6;
 
 	    /* verify the utf-8 */
-	    std::string possible_kml = sbuf.substr(xml_loc, kml_len);
+	    std::string possible_kml = sbuf.substr(xml_offset, kml_len);
 	    if(utf8::find_invalid(possible_kml.begin(),possible_kml.end()) == possible_kml.end()){
 		/* No invalid UTF-8 */
-		kml_recorder.carve(sbuf.slice(xml_loc, kml_len), ".kml", 0);
-		i = ekml_loc + 6;	// skip past end of </kml>
+		kml_recorder.carve(sbuf.slice(xml_offset, kml_len), ".kml", 0);
+		i = end_offset + 6;	// skip past end of </kml>
 	    }
 	    else {
-		i = xml_loc + 6;	// skip past <?xml ; there may be another with no errors
+		i = xml_offset + 6;	// skip past <?xml ; there may be another with no errors
 	    }
 	}
     }

--- a/src/scan_rar.cpp
+++ b/src/scan_rar.cpp
@@ -599,11 +599,11 @@ void scan_rar(scanner_params &sp)
 
         auto rar_def = feature_recorder_def(RAR_RECORDER_NAME, flags);
         rar_def.default_carve_mode = feature_recorder_def::carve_mode_t::CARVE_ENCODED;
-	sp.info->feature_defs.push_back( rar_def );
+	sp.info->feature_defs.push_back(std::move(rar_def));
 
         auto unrar_def = feature_recorder_def(UNRAR_RECORDER_NAME, flags);
         unrar_def.default_carve_mode = feature_recorder_def::carve_mode_t::CARVE_ENCODED;
-	sp.info->feature_defs.push_back( unrar_def );
+	sp.info->feature_defs.push_back(std::move(unrar_def));
         sp.get_scanner_config("rar_find_components",&record_components,"Search for RAR components");
         sp.get_scanner_config("rar_find_volumes",&record_volumes,"Search for RAR volumes");
 #else

--- a/src/scan_wordlist.cpp
+++ b/src/scan_wordlist.cpp
@@ -225,7 +225,7 @@ void scan_wordlist(scanner_params &sp)
             def.flags.no_context   = true;
             def.flags.no_stoplist  = true;
             def.flags.no_alertlist = true;
-            sp.info->feature_defs.push_back( def );
+            sp.info->feature_defs.push_back(std::move(def));
         }
         if (word_min > word_max){
             std::cerr << "ERROR: word_min (" << word_min << ") > word_max (" << word_max << ")\n";


### PR DESCRIPTION
## Summary

Addresses the additional 2026 Coverity findings shown in the Scan report.

- prevents signed-to-unsigned length conversion in the KML carver
- constructs the hiberfile compressed length as an unsigned 32-bit value
- rejects EXIF ASCII entries whose byte count extends beyond the mapped input
- converts four feature-recorder/path calls to move or reference semantics
- turns an uncaught top-level exception into a diagnostic and non-zero exit

## Root cause and impact

Several parsers combined externally derived offsets or bytes using signed arithmetic or without proving that the requested range remained inside the input. The changes preserve valid input behavior while rejecting malformed ranges before they can be used. The copy changes are non-functional performance cleanups reported by Coverity.

## Validation

- `./bootstrap.sh && ./configure`
- `make -j1 -C src test_be`

The full test executable built successfully. Its existing run stops at the known missing `test_plugin` loadable-scanner artifact.
