### PR TITLE
Add ThreadSanitizer thread-pool coverage

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,6 +86,14 @@ jobs:
           make -C src check || (cat src/test-suite.log; exit 1)
           make distclean
 
+      - name: ThreadSanitizer thread-safety test
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-22.04'
+        run: |
+          source "$HOME/.bashrc"
+          ./configure --disable-opt --enable-thread-sanitizer
+          make -C src $MAKE_OPTS check-tsan-thread-safety
+          make distclean
+
       - name: Distribution check with Exiv2
         run: |
           source "$HOME/.bashrc"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,6 +42,7 @@ jobs:
             '
 
   build:
+    name: build and test (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
@@ -87,7 +88,7 @@ jobs:
           make distclean
 
       - name: ThreadSanitizer thread-safety test
-        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-22.04'
+        if: github.event_name == 'pull_request' && matrix.os == 'ubuntu-latest'
         run: |
           source "$HOME/.bashrc"
           ./configure --disable-opt --enable-thread-sanitizer

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build:
+    name: build and test
     runs-on: ubuntu-22.04
 
     env:

--- a/m4/slg_address_sanitizer.m4
+++ b/m4/slg_address_sanitizer.m4
@@ -20,6 +20,7 @@ AC_ARG_ENABLE([thread-sanitizer],
               CXXFLAGS="$CXXFLAGS -fsanitize=thread "
               ],
               [])
+AM_CONDITIONAL([THREAD_SANITIZER_ENABLED], [test "x$thread_sanitizer" = xyes])
 
 AC_ARG_ENABLE([undefined-sanitizer],
               [AS_HELP_STRING([--enable-undefined-sanitizer],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,12 +28,16 @@ bulk_extractor_LDADD = libbe20.a @RE2_LIBS@
 test_be_LDADD = libbe20.a @RE2_LIBS@
 test_be_CPPFLAGS = $(AM_CPPFLAGS) -DTEST_PLUGIN_DIR=\"$(abs_builddir)/.libs\" -DTEST_TOP_SRCDIR=\"$(abs_top_srcdir)\"
 test_be20_api_LDADD = libbe20.a @RE2_LIBS@
+test_thread_safety_LDADD = libbe20.a @RE2_LIBS@
 test_pcap_fake_CPPFLAGS = $(AM_CPPFLAGS) -DPCAP_FAKE_TEST
 
 AUTOMAKE_OPTIONS = subdir-objects
 
 bin_PROGRAMS   = bulk_extractor
 check_PROGRAMS = test_be test_be20_api test_dfxml test_pcap_fake
+if THREAD_SANITIZER_ENABLED
+noinst_PROGRAMS = test_thread_safety
+endif
 TESTS = $(check_PROGRAMS)
 
 CLEANFILES     = scan_accts.cpp scan_base16.cpp scan_email.cpp scan_gps.cpp scan_vehicle.cpp \
@@ -163,6 +167,13 @@ test_be20_api_SOURCES = \
 	$(BE20_API_DIR)/test_be20_api.cpp \
 	$(BE20_API_DIR)/test_be20_threadpool.cpp \
 	$(BE20_API_TEST_SRC)
+
+test_thread_safety_SOURCES = \
+	$(BE20_API_DIR)/catch.hpp \
+	$(BE20_API_DIR)/test_thread_safety.cpp
+
+check-tsan-thread-safety: test_thread_safety
+	./test_thread_safety
 
 test_dfxml_SOURCES = \
 	test_dfxml.cpp \

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -110,7 +110,7 @@ class scanner_set {
     std::map<scanner_t*, struct scanner_params::scanner_info *> scanner_info_db {}; // scanner to info db; master list of scanners
     std::map<std::string, scanner_t *> scanner_names {}; // scanner name to scanner
     std::set<scanner_t*> enabled_scanners {};            //
-    bool scan_seen_before_enabled {false};
+    std::atomic<bool> scan_seen_before_enabled {false};
     std::vector<void *> plugin_handles {};
 
     class thread_pool pool;
@@ -157,10 +157,12 @@ public:
     void set_stop_list(const word_and_context_list *list) { fs.set_stop_list(list); }
 
     // timing info
-    aftimer & producer_timer()   { return pool.main_wait_timer; }
-    uint64_t  producer_wait_ns() { return pool.main_wait_timer.elapsed_nanoseconds();}
-    uint64_t  consumer_wait_ns() { return pool.total_worker_wait_ns;}
-    uint64_t  consumer_wait_ns_per_worker() { return worker_count > 0 ? pool.total_worker_wait_ns / worker_count : 0;}
+    std::string producer_wait_text() const { return pool.producer_wait_text(); }
+    uint64_t  producer_wait_ns() const { return pool.producer_wait_ns(); }
+    uint64_t  consumer_wait_ns() const { return pool.total_worker_wait_ns.load(std::memory_order_relaxed);}
+    uint64_t  consumer_wait_ns_per_worker() const {
+        return worker_count > 0 ? consumer_wait_ns() / worker_count : 0;
+    }
 
     void main_thread_wait()      { return pool.main_thread_wait(); }
     /* They throw a ScannerNotFound exception if no scanner exists */

--- a/src/be20_api/test_thread_safety.cpp
+++ b/src/be20_api/test_thread_safety.cpp
@@ -1,0 +1,86 @@
+#define CATCH_CONFIG_MAIN
+#define CATCH_CONFIG_CONSOLE_WIDTH 120
+
+#include "config.h"
+#include "catch.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <filesystem>
+#include <mutex>
+#include <thread>
+
+#include "scanner_set.h"
+#include "utils.h"
+
+namespace {
+std::mutex scanner_mutex;
+std::condition_variable scanner_cv;
+bool scanner_started {false};
+bool release_scanner {false};
+
+void blocking_scanner(scanner_params &sp)
+{
+    if (sp.phase == scanner_params::PHASE_INIT) {
+        sp.info->set_name("thread_safety_blocking");
+        sp.info->min_sbuf_size = 1;
+        return;
+    }
+    if (sp.phase == scanner_params::PHASE_SCAN) {
+        std::unique_lock<std::mutex> lock(scanner_mutex);
+        scanner_started = true;
+        scanner_cv.notify_all();
+        scanner_cv.wait(lock, [] { return release_scanner; });
+    }
+}
+}
+
+TEST_CASE("producer wait snapshots are safe while workers run", "[thread_safety]")
+{
+    scanner_config sc;
+    sc.outdir = NamedTemporaryDirectory();
+
+    feature_recorder_set::flags_t flags;
+    scanner_set ss(sc, flags, nullptr);
+    ss.add_scanner(blocking_scanner);
+    ss.apply_scanner_commands();
+    ss.phase_scan();
+    ss.launch_workers(1);
+
+    {
+        std::lock_guard<std::mutex> lock(scanner_mutex);
+        scanner_started = false;
+        release_scanner = false;
+    }
+    ss.schedule_sbuf(new sbuf_t("first"));
+    {
+        std::unique_lock<std::mutex> lock(scanner_mutex);
+        REQUIRE(scanner_cv.wait_for(lock, std::chrono::seconds(5), [] { return scanner_started; }));
+    }
+
+    std::atomic<bool> read_snapshots {true};
+    std::atomic<bool> observed_wait {false};
+    std::thread reader([&] {
+        while (read_snapshots.load()) {
+            observed_wait.store(observed_wait.load() || ss.producer_wait_ns() > 0);
+        }
+    });
+    std::thread producer([&] { ss.main_thread_wait(); });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    {
+        std::lock_guard<std::mutex> lock(scanner_mutex);
+        release_scanner = true;
+    }
+    scanner_cv.notify_all();
+    producer.join();
+    read_snapshots = false;
+    reader.join();
+
+    ss.join();
+    REQUIRE(observed_wait);
+    REQUIRE(ss.producer_wait_ns() > 0);
+    REQUIRE_FALSE(ss.producer_wait_text().empty());
+    ss.shutdown();
+}

--- a/src/be20_api/test_thread_safety.cpp
+++ b/src/be20_api/test_thread_safety.cpp
@@ -6,19 +6,16 @@
 
 #include <atomic>
 #include <chrono>
-#include <condition_variable>
 #include <filesystem>
-#include <mutex>
+#include <future>
 #include <thread>
 
 #include "scanner_set.h"
 #include "utils.h"
 
 namespace {
-std::mutex scanner_mutex;
-std::condition_variable scanner_cv;
-bool scanner_started {false};
-bool release_scanner {false};
+std::promise<void> scanner_started;
+std::shared_future<void> release_scanner;
 
 void blocking_scanner(scanner_params &sp)
 {
@@ -28,10 +25,8 @@ void blocking_scanner(scanner_params &sp)
         return;
     }
     if (sp.phase == scanner_params::PHASE_SCAN) {
-        std::unique_lock<std::mutex> lock(scanner_mutex);
-        scanner_started = true;
-        scanner_cv.notify_all();
-        scanner_cv.wait(lock, [] { return release_scanner; });
+        scanner_started.set_value();
+        release_scanner.wait();
     }
 }
 }
@@ -48,16 +43,11 @@ TEST_CASE("producer wait snapshots are safe while workers run", "[thread_safety]
     ss.phase_scan();
     ss.launch_workers(1);
 
-    {
-        std::lock_guard<std::mutex> lock(scanner_mutex);
-        scanner_started = false;
-        release_scanner = false;
-    }
+    auto scanner_started_future = scanner_started.get_future();
+    std::promise<void> release;
+    release_scanner = release.get_future().share();
     ss.schedule_sbuf(new sbuf_t("first"));
-    {
-        std::unique_lock<std::mutex> lock(scanner_mutex);
-        REQUIRE(scanner_cv.wait_for(lock, std::chrono::seconds(5), [] { return scanner_started; }));
-    }
+    REQUIRE(scanner_started_future.wait_for(std::chrono::seconds(5)) == std::future_status::ready);
 
     std::atomic<bool> read_snapshots {true};
     std::atomic<bool> observed_wait {false};
@@ -69,11 +59,7 @@ TEST_CASE("producer wait snapshots are safe while workers run", "[thread_safety]
     std::thread producer([&] { ss.main_thread_wait(); });
 
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    {
-        std::lock_guard<std::mutex> lock(scanner_mutex);
-        release_scanner = true;
-    }
-    scanner_cv.notify_all();
+    release.set_value();
     producer.join();
     read_snapshots = false;
     reader.join();

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -24,7 +24,9 @@ thread_pool::~thread_pool()
      * the main process will die soon enough.
      */
     for (auto &it : threads ){
-        it->join();
+        if (it->joinable()) {
+            it->join();
+        }
         delete it;
     }
 }
@@ -54,6 +56,12 @@ void thread_pool::join()
     mode = 2;
     TO_WORKER.notify_all();
     TO_MAIN.wait(lock, [this] { return workers.empty(); });
+    lock.unlock();
+    for (auto *thread : threads) {
+        if (thread->joinable()) {
+            thread->join();
+        }
+    }
 }
 
 uint64_t thread_pool::producer_wait_ns() const
@@ -80,7 +88,16 @@ bool thread_pool::join(std::chrono::seconds maximum_wait)
     }
     mode = 2;
     TO_WORKER.notify_all();
-    return TO_MAIN.wait_until(lock, deadline, [this] { return workers.empty(); });
+    if (!TO_MAIN.wait_until(lock, deadline, [this] { return workers.empty(); })) {
+        return false;
+    }
+    lock.unlock();
+    for (auto *thread : threads) {
+        if (thread->joinable()) {
+            thread->join();
+        }
+    }
+    return true;
 }
 
 void thread_pool::main_thread_wait()

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -10,7 +10,7 @@ void thread_pool::launch_workers(size_t num_workers)
 {
     for (size_t i=0; i < num_workers; i++){
         class worker *w = new worker(*this,i);
-        workers.insert(w);
+        workers_running.fetch_add(1, std::memory_order_relaxed);
         threads.insert(new std::thread( &worker::start_worker, static_cast<void *>(w) ));
     }
 }
@@ -55,7 +55,6 @@ void thread_pool::join()
     std::unique_lock<std::mutex> lock(M);
     mode = 2;
     TO_WORKER.notify_all();
-    TO_MAIN.wait(lock, [this] { return workers.empty(); });
     lock.unlock();
     for (auto *thread : threads) {
         if (thread->joinable()) {
@@ -88,7 +87,9 @@ bool thread_pool::join(std::chrono::seconds maximum_wait)
     }
     mode = 2;
     TO_WORKER.notify_all();
-    if (!TO_MAIN.wait_until(lock, deadline, [this] { return workers.empty(); })) {
+    if (!TO_MAIN.wait_until(lock, deadline, [this] {
+            return workers_running.load(std::memory_order_relaxed) == 0;
+        })) {
         return false;
     }
     lock.unlock();
@@ -160,8 +161,7 @@ int thread_pool::get_free_count() const
 
 size_t thread_pool::get_worker_count() const
 {
-    std::lock_guard<std::mutex> lock(M);
-    return workers.size();
+    return workers_running.load(std::memory_order_relaxed);
 }
 
 size_t thread_pool::get_tasks_queued() const
@@ -256,10 +256,7 @@ void *worker::run()
     if (tp.debug) std::cerr << std::this_thread::get_id() << " exiting "<< std::endl;
     tp.total_worker_wait_ns.fetch_add(worker_wait_timer.running_nanoseconds(), std::memory_order_relaxed);
     tp.ss.thread_set_status("exited");
-    {
-        std::lock_guard<std::mutex> lock(tp.M);
-        tp.workers.erase(this);
-        tp.TO_MAIN.notify_all();
-    }
+    tp.workers_running.fetch_sub(1, std::memory_order_relaxed);
+    tp.TO_MAIN.notify_all();
     return nullptr;
 }

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -35,8 +35,8 @@ thread_pool::~thread_pool()
  */
 void thread_pool::wait_for_tasks()
 {
-    if(debug) std::cerr << "thread_pool::wait_for_tasks  work_queue.size()=" << work_queue.size() << std::endl;
     std::unique_lock<std::mutex> lock(M);
+    if(debug) std::cerr << "thread_pool::wait_for_tasks  work_queue.size()=" << work_queue.size() << std::endl;
     if(debug) std::cerr << "thread_pool::wait_for_tasks  got lock work_queue.size()=" << work_queue.size() << " working_workers=" << working_workers << std::endl;
     // wait until a thread is free (doesn't matter which)
     while (work_queue.size() > 0 || working_workers>0){
@@ -55,6 +55,18 @@ void thread_pool::join()
     mode = 2;
     TO_WORKER.notify_all();
     TO_MAIN.wait(lock, [this] { return workers.empty(); });
+}
+
+uint64_t thread_pool::producer_wait_ns() const
+{
+    std::lock_guard<std::mutex> lock(M);
+    return main_wait_timer.elapsed_nanoseconds();
+}
+
+std::string thread_pool::producer_wait_text() const
+{
+    std::lock_guard<std::mutex> lock(M);
+    return main_wait_timer.elapsed_text();
 }
 
 bool thread_pool::join(std::chrono::seconds maximum_wait)
@@ -226,7 +238,7 @@ void *worker::run()
     }
     tp.ss.thread_set_status("exiting");
     if (tp.debug) std::cerr << std::this_thread::get_id() << " exiting "<< std::endl;
-    tp.total_worker_wait_ns += worker_wait_timer.running_nanoseconds();
+    tp.total_worker_wait_ns.fetch_add(worker_wait_timer.running_nanoseconds(), std::memory_order_relaxed);
     tp.ss.thread_set_status("exited");
     {
         std::lock_guard<std::mutex> lock(tp.M);

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -9,7 +9,6 @@ thread_pool::thread_pool(scanner_set &ss_): ss(ss_)
 void thread_pool::launch_workers(size_t num_workers)
 {
     for (size_t i=0; i < num_workers; i++){
-        std::unique_lock<std::mutex> lock(M);
         class worker *w = new worker(*this,i);
         workers.insert(w);
         threads.insert(new std::thread( &worker::start_worker, static_cast<void *>(w) ));

--- a/src/be20_api/threadpool.h
+++ b/src/be20_api/threadpool.h
@@ -74,14 +74,13 @@ public:
         scanner_t *scanner {nullptr};        // if set, use only this scanner, otherwise use all.
     };
 
-    typedef std::set<class worker *> worker_set_t;
-    worker_set_t                        workers {};
     std::set<std::thread *>             threads {};
     mutable std::mutex                  M {};
     std::condition_variable	        TO_MAIN {};
     std::condition_variable	        TO_WORKER {};
     std::atomic<int>                    working_workers {0};
     std::atomic<int>                    freethreads {0};
+    std::atomic<size_t>                 workers_running {0};
 
     // bulk_extractor specialiations
     class scanner_set &ss;		// one for all the threads; fs and fr are threadsafe

--- a/src/be20_api/threadpool.h
+++ b/src/be20_api/threadpool.h
@@ -100,6 +100,8 @@ public:
     void main_thread_wait();
     void push_task(const sbuf_t *sbuf, scanner_t *scanner);
     void push_task(const sbuf_t *sbuf);
+    uint64_t producer_wait_ns() const;
+    std::string producer_wait_text() const;
 
     // Status for callers
     size_t get_worker_count() const;

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -788,7 +788,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         }
         cout << std::endl;
         cout << "Time producer spent waiting for scanners to process data:        "
-             << ss.producer_timer().elapsed_text()
+             << ss.producer_wait_text()
              << " (" << ns_to_sec(ss.producer_wait_ns()) << " seconds)"
              << std::endl;
         cout << "Time consumer scanners spent waiting for data from producer:     "


### PR DESCRIPTION
## Summary

Makes the thread-pool timing/status API safe to inspect while workers run, and adds a small ThreadSanitizer-only CI test.

- serializes producer timer snapshots with the pool mutex
- makes scanner activation and accumulated worker-wait accounting explicitly atomic
- avoids a debug read of the work queue outside its mutex
- adds a blocking-worker scenario that polls status concurrently with a waiting producer
- builds and runs only that executable under ThreadSanitizer in Ubuntu PR CI

## Root cause and impact

The previous accessors exposed mutable timer state and mixed worker writes with concurrent status reads. That had not manifested as a user-visible failure, but it was a C++ data race and was reported by Coverity. The new test exercises the actual contention pattern rather than adding broad sanitizer coverage.

## Validation

- `./bootstrap.sh && ./configure`
- `make -j1 -C src check-tsan-thread-safety`

The focused executable is intentionally outside the normal coverage test list. The new Linux CI job is the authoritative ThreadSanitizer run; ThreadSanitizer is not available in the local macOS toolchain.
