### PR TITLE
Add container image for regular scans

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+.libs
+autom4te.cache
+build-aux
+config.h
+config.log
+config.status
+configure
+Makefile
+src/.deps
+src/.libs
+src/Makefile
+src/*.o
+src/bulk_extractor
+src/test_*
+win64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:bookworm AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    autoconf automake build-essential flex git libabsl-dev libexpat1-dev \
+    libgcrypt20-dev libgpg-error-dev libre2-dev libssl-dev libtool make \
+    pkg-config procps python3 zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+RUN bash bootstrap.sh \
+ && ./configure --disable-libewf --enable-silent-rules \
+ && make -j2
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libabsl20220623 libexpat1 libgcrypt20 libgpg-error0 libpcap0.8 libre2-9 \
+    libssl3 libsqlite3-0 libstdc++6 zlib1g \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --create-home --uid 10001 bulk_extractor
+
+COPY --from=build /src/src/bulk_extractor /usr/local/bin/bulk_extractor
+USER bulk_extractor
+WORKDIR /work
+ENTRYPOINT ["bulk_extractor"]

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,6 +26,8 @@ EXTRA_DIST = $(SRC_WIN_DIST) $(AUTO_DOC_FILES) $(AUTO_ETC_FILES) $(AUTO_LICENSES
 	$(srcdir)/CODING_STANDARDS.md \
 	$(srcdir)/LICENSE.md \
 	$(srcdir)/README.md \
+	$(srcdir)/Dockerfile \
+	$(srcdir)/.dockerignore \
 	$(srcdir)/dfxml_schema/LICENSE.md \
 	$(srcdir)/dfxml_schema/README.md \
 	$(srcdir)/dfxml_schema/VENDORED.md \

--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ same bulk_extractor source version as the executable; the scanner's PHASE_INIT
 handler must call sp.check_version(). Modules remain loaded until scanner
 cleanup completes.
 
+CONTAINER IMAGE
+===============
+
+The source tree includes a multi-stage Debian Bookworm `Dockerfile` for
+reproducible Linux scans of regular image files. Build and run it with an
+input mounted read-only and an output directory mounted read-write. The image
+runs unprivileged and intentionally omits libewf and Lightgrep; it is not a
+privileged raw-device appliance. See [doc/docker.md](doc/docker.md).
+
 BUILDING ON WINDOWS
 ===================
 Native Windows builds of bulk_extractor are not currently supported.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -2,7 +2,7 @@
 AM_CPPFLAGS = -I${top_srcdir}/src/be20_api
 AUTOMAKE_OPTIONS = subdir-objects
 
-EXTRA_DIST = carving.md logging.md scanner_api.md scanner_template.cpp testing.md \
+EXTRA_DIST = carving.md docker.md logging.md scanner_api.md scanner_template.cpp testing.md \
     programmer_manual/BEProgrammersManual.tex \
     programmer_manual/Makefile.am \
     programmer_manual/extractinformationreprocess.pdf \

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -148,6 +148,10 @@ through the project's normal pull-request and CI process.
 
 ### Build, configuration, and testing
 
+- A multi-stage Debian Bookworm container image provides a reproducible,
+  unprivileged environment for scanning regular image files. It documents its
+  libewf and Lightgrep limitations and supplements native platform CI rather
+  than replacing it ([#159](https://github.com/simsong/bulk_extractor/issues/159)).
 - AddressSanitizer now runs on every pull request while redundant workflow
   execution has been reduced
   ([PR #514](https://github.com/simsong/bulk_extractor/pull/514)).

--- a/doc/docker.md
+++ b/doc/docker.md
@@ -1,0 +1,30 @@
+# Container image
+
+`Dockerfile` builds a Linux container image for scanning regular image files.
+It builds the project's default configuration with libewf disabled, matching the
+Debian Bookworm compatibility configuration in CI. It does not include
+Lightgrep and does not claim to be a privileged raw-device appliance.
+
+Build from a source checkout:
+
+```
+docker build --tag bulk-extractor:local .
+```
+
+Scan a regular image with an immutable input mount and a writable output mount:
+
+```
+docker run --rm \
+  --mount type=bind,source="$PWD/input",target=/input,readonly \
+  --mount type=bind,source="$PWD/output",target=/output \
+  bulk-extractor:local -o /output /input/image.raw
+```
+
+The runtime process is the unprivileged `bulk_extractor` user. Do not add
+`--privileged` or device mounts for ordinary image files. Raw-device scanning
+has host-specific access, consistency, and disclosure risks and is not part of
+this image's supported interface.
+
+The image supplements, rather than replaces, the native macOS, Ubuntu, MinGW,
+and Windows-runtime CI jobs. To validate the image locally, build it and run a
+small checked-in or analyst-provided regular image with the invocation above.


### PR DESCRIPTION
## Summary

Adds a multi-stage Debian Bookworm container image for reproducible scans of regular image files.

## Scope

- Builds the supported default configuration with libewf disabled.
- Runs the executable as an unprivileged user.
- Documents safe read-only input and writable output mounts.
- States that the image omits Lightgrep and is not a privileged raw-device appliance.

## Validation

- `make distcheck`

Docker is not installed on this macOS checkout, so an image build/run remains for CI or a Docker-enabled host.
