### PR TITLE
Harden truncated hibernation headers

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -69,6 +69,10 @@ through the project's normal pull-request and CI process.
 - Email extraction now enforces independent 64-octet local-part and 253-octet
   domain limits for ASCII and UTF-16 input, avoiding truncated suffix features
   from overlong addresses ([#585](https://github.com/simsong/bulk_extractor/issues/585)).
+- Parser hardening now rejects truncated hibernation-file block headers before
+  reading their length fields, and unexpected top-level exceptions are reported
+  as diagnostics with a nonzero exit status
+  ([PR #605](https://github.com/simsong/bulk_extractor/pull/605)).
 - Hardened `sbuf` bounds, arithmetic, and ownership behavior, including
   zero-length and one-past-end cases
   ([PR #511](https://github.com/simsong/bulk_extractor/pull/511)).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,7 @@
 #include "bulk_extractor.h"
 
 #include <exception>
-#include <ostream>
+#include <iostream>
 
 int main(int argc,char * const *argv)
 {

--- a/src/scan_hiberfile.cpp
+++ b/src/scan_hiberfile.cpp
@@ -53,7 +53,8 @@ void scan_hiberfile_scan(scanner_params &sp)
         ssize_t npos = sbuf.findbin(PYEXPRESS_HEADER, sizeof(PYEXPRESS_HEADER), pos);
         if (npos==-1) break;             // header not found
 
-        pos = npos;
+        pos = static_cast<size_t>(npos);
+        if (pos > sbuf.bufsize || sbuf.bufsize - pos < 32) break;
         uint32_t compressed_length = ((static_cast<uint32_t>(sbuf[pos + 8])
                                        | (static_cast<uint32_t>(sbuf[pos + 9]) << 8)
                                        | (static_cast<uint32_t>(sbuf[pos + 10]) << 16)


### PR DESCRIPTION
Follow up on Copilot feedback received after PR #605 merged.

- Bounds-check hibernation block matches before reading header fields.
- Include the standard iostream declarations used by main.
- Document the hardened parser and top-level exception behavior in the 2.2.0 notes.

Validation: `make -C src check TESTS=test_be`.