### PR TITLE
Report restart recovery status

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -57,6 +57,9 @@ through the project's normal pull-request and CI process.
   pages that were in progress at the crash, avoiding repeated data-dependent
   crashes; the behavior is covered by a controlled-crash regression test
   ([#202](https://github.com/simsong/bulk_extractor/issues/202)).
+- Restart now reports the number of deliberately skipped pages and the archived
+  interrupted report path when it resumes a non-quiet run
+  ([#319](https://github.com/simsong/bulk_extractor/issues/319)).
 - Removed the obsolete numeric debug mask and its misleading scanner-control
   documentation. `-d`/`--debug` now explicitly enables debug-level diagnostic
   logging; scanner selection remains controlled by `-x` and `-e`

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -574,8 +574,14 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
         if ( std::filesystem::exists( sc.outdir/"report.xml" )){
             /* We are restarting! */
-            bulk_extractor_restarter r( sc,cfg);
-            r.restart();                    // load the restart file and rename report.xml
+            bulk_extractor_restarter r(sc, cfg);
+            const auto restart = r.restart();
+            if (!cfg.opt_quiet) {
+                cerr << "Restarting: skipped " << restart.skipped_pages
+                     << " page" << (restart.skipped_pages == 1 ? "" : "s")
+                     << " recorded before the crash; archived report as "
+                     << restart.archived_report << std::endl;
+            }
         }
     }
 

--- a/src/bulk_extractor_restarter.h
+++ b/src/bulk_extractor_restarter.h
@@ -18,12 +18,20 @@
 #include "phase1.h"
 
 class bulk_extractor_restarter {
+public:
+    struct restart_summary {
+        std::filesystem::path archived_report {};
+        size_t skipped_pages {0};
+    };
+
+private:
     std::stringstream       cdata {};
     std::string             thisElement {};
     std::string             provided_filename {};
     scanner_config          &sc;
     Phase1::Config          &cfg;
-public:;
+
+public:
     bulk_extractor_restarter(scanner_config &sc_,
                              Phase1::Config &cfg_):sc(sc_),cfg(cfg_){};
     class CantRestart : public std::exception {
@@ -57,7 +65,7 @@ public:;
         class bulk_extractor_restarter &self = *(bulk_extractor_restarter *)userData;
         self.cdata.write(s,len);
     }
-    void restart() {
+    restart_summary restart() {
         std::filesystem::path report_path = sc.outdir / Phase1::REPORT_FILENAME;
 
         XML_Parser parser = XML_ParserCreate(NULL);
@@ -87,11 +95,12 @@ public:;
         XML_ParserFree(parser);
         in.close();
         /* Now rename the report filename */
-        std::filesystem::path report_path_bak = report_path.string() + "." + std::to_string(time( nullptr));
+        std::filesystem::path report_path_bak = report_path.string() + "." + std::to_string(time(nullptr));
         std::filesystem::rename(report_path, report_path_bak);
+        return {report_path_bak, cfg.seen_page_ids.size()};
     }
 #else
-    void restart() {
+    restart_summary restart() {
         throw std::runtime_error("Compiled without libexpat; cannot restart.");
     }
 #endif

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -1082,8 +1082,12 @@ TEST_CASE("restarter", "[restarter]") {
     bulk_extractor_restarter r(sc, cfg);
 
     REQUIRE( std::filesystem::exists( out_xml ) == true); // because it has not been renamed yet
-    r.restart();
+    const auto restart = r.restart();
     REQUIRE( std::filesystem::exists( out_xml ) == false); // because now it has been renamed
+    REQUIRE(restart.archived_report.parent_path() == sc.outdir);
+    REQUIRE(restart.archived_report.filename().string().rfind("report.xml.", 0) == 0);
+    REQUIRE(restart.skipped_pages == cfg.seen_page_ids.size());
+    REQUIRE(restart.skipped_pages > 0);
     REQUIRE( cfg.seen_page_ids.find("369098752") != cfg.seen_page_ids.end() );
     REQUIRE( cfg.seen_page_ids.find("369098752+") == cfg.seen_page_ids.end() );
 }


### PR DESCRIPTION
Adds a concise restart summary that reports the archived partial report and the number of pages intentionally skipped after a crash. The deliberate skip protects users from repeated data-dependent crashes; it does not retry interrupted pages indefinitely.

Validation: 
```
/Library/Developer/CommandLineTools/usr/bin/make  test_be test_be20_api test_dfxml test_pcap_fake scan_test_plugin.la

make[1]: `test_be' is up to date.
make[1]: `test_be20_api' is up to date.
make[1]: `test_dfxml' is up to date.
make[1]: `test_pcap_fake' is up to date.
make[1]: `scan_test_plugin.la' is up to date.
/Library/Developer/CommandLineTools/usr/bin/make  check-TESTS
PASS: test_be
============================================================================
Testsuite summary for BULK_EXTRACTOR 2.2.0-DEVELOP
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
