### PR TITLE
Enable basic compiler stack protection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -307,7 +307,7 @@ fi
 AC_LANG_PUSH(C)
 saved_CFLAGS="$CFLAGS"
 CFLAGS="$CFLAGS -fstack-protector"
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[char stack_buffer[8]; return stack_buffer[0];]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],
                   [have_c_stack_protector=yes],
                   [have_c_stack_protector=no])
 CFLAGS="$saved_CFLAGS"
@@ -316,7 +316,7 @@ AC_LANG_POP(C)
 AC_LANG_PUSH(C++)
 saved_CXXFLAGS="$CXXFLAGS"
 CXXFLAGS="$CXXFLAGS -fstack-protector"
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[char stack_buffer[8]; return stack_buffer[0];]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[return 0;]])],
                   [have_cxx_stack_protector=yes],
                   [have_cxx_stack_protector=no])
 CXXFLAGS="$saved_CXXFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -304,6 +304,32 @@ else
   CXXFLAGS="$CXXFLAGS -fPIC"
 fi
 
+AC_LANG_PUSH(C)
+saved_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -fstack-protector"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[char stack_buffer[8]; return stack_buffer[0];]])],
+                  [have_c_stack_protector=yes],
+                  [have_c_stack_protector=no])
+CFLAGS="$saved_CFLAGS"
+AC_LANG_POP(C)
+
+AC_LANG_PUSH(C++)
+saved_CXXFLAGS="$CXXFLAGS"
+CXXFLAGS="$CXXFLAGS -fstack-protector"
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[char stack_buffer[8]; return stack_buffer[0];]])],
+                  [have_cxx_stack_protector=yes],
+                  [have_cxx_stack_protector=no])
+CXXFLAGS="$saved_CXXFLAGS"
+AC_LANG_POP(C++)
+
+if test "$have_c_stack_protector" = yes && test "$have_cxx_stack_protector" = yes ; then
+  CFLAGS="$CFLAGS -fstack-protector"
+  CXXFLAGS="$CXXFLAGS -fstack-protector"
+  AC_MSG_NOTICE([enabling -fstack-protector])
+else
+  AC_MSG_WARN([compiler does not support -fstack-protector for both C and C++; stack protection is disabled])
+fi
+
 
 ################################################################
 ## Check on two annoying warnings

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -168,6 +168,8 @@ through the project's normal pull-request and CI process.
   unprivileged environment for scanning regular image files. It documents its
   libewf and Lightgrep limitations and supplements native platform CI rather
   than replacing it ([#159](https://github.com/simsong/bulk_extractor/issues/159)).
+- Builds now enable basic compiler stack-canary protection (`-fstack-protector`)
+  when both selected C and C++ compilers support it ([#376](https://github.com/simsong/bulk_extractor/issues/376)).
 - AddressSanitizer now runs on every pull request while redundant workflow
   execution has been reduced
   ([PR #514](https://github.com/simsong/bulk_extractor/pull/514)).


### PR DESCRIPTION
Closes #376.

Adds `-fstack-protector` to C and C++ builds only after configure verifies that both selected compilers accept it. If either compiler does not, configuration continues with a clear warning rather than a partial hardening state.

Also records the baseline stack-canary hardening in the 2.2.0 release notes.

Validation:
- `./bootstrap.sh && ./configure` (confirmed the flag in both CFLAGS and CXXFLAGS)
- `make -C src check-TESTS TESTS=test_be20_api`