### PR TITLE
Address missed Copilot findings from the 2.2.0 release audit

### DIFF
--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -844,7 +844,7 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp, scanner_t *scanner)
         if (debug_flags.debug_benchmark && writer) {
             writer->xmlout("debug:bypass", "",
                            Formatter()
-                           << "sbuf='" << sbuf.pos0.str() << "' "
+                           << "sbuf='" << dfxml_writer::xmlescape(sbuf.pos0.str()) << "' "
                            << "bufsize='" << sbuf.bufsize << "' "
                            << "scanner='" << get_scanner_name(scanner) << "' "
                            << "reason='seen_before'", true);
@@ -856,7 +856,7 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp, scanner_t *scanner)
     if (ngram_size > 0 && flags.scan_ngram_buffer == false) {
         if (debug_flags.debug_benchmark && writer) {
             writer->xmlout("debug:bypass", "",
-                           Formatter() << "sbuf='" << sbuf.pos0.str() << "' ngram_size='" << ngram_size << "'", true);
+                           Formatter() << "sbuf='" << dfxml_writer::xmlescape(sbuf.pos0.str()) << "' ngram_size='" << ngram_size << "'", true);
         }
         return;
     }
@@ -865,7 +865,7 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp, scanner_t *scanner)
     if (info->min_distinct_chars > distinct_chars) {
         if (debug_flags.debug_benchmark && writer) {
             writer->xmlout("debug:bypass", "",
-                           Formatter() << "sbuf='" << sbuf.pos0.str() << "' min_distinct_chars='" << distinct_chars << "'", true);
+                           Formatter() << "sbuf='" << dfxml_writer::xmlescape(sbuf.pos0.str()) << "' min_distinct_chars='" << distinct_chars << "'", true);
         }
         return;
     }

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -501,9 +501,22 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
         /* The zap option wipes the contents of a directory, useful for debugging */
         if ( result.count( "zap" ) && std::filesystem::is_directory( sc.outdir )) {
-            for (const auto &entry : std::filesystem::directory_iterator(sc.outdir)) {
-                cout << "erasing " << entry.path().string() << std::endl;
-                std::filesystem::remove_all(entry.path());
+            std::error_code error;
+            std::vector<std::filesystem::path> entries;
+            for (std::filesystem::directory_iterator it(sc.outdir, error), end; it != end; it.increment(error)) {
+                if (error) {
+                    cerr << "error reading " << sc.outdir << ": " << error.message() << std::endl;
+                    return 7;
+                }
+                entries.push_back(it->path());
+            }
+            for (const auto &entry : entries) {
+                cout << "erasing " << entry.string() << std::endl;
+                std::filesystem::remove_all(entry, error);
+                if (error) {
+                    cerr << "error erasing " << entry << ": " << error.message() << std::endl;
+                    return 7;
+                }
             }
         }
 	if (std::filesystem::exists( sc.outdir ) == false ){
@@ -746,6 +759,13 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
         ss.shutdown();
     }
     catch ( const feature_recorder::DiskWriteError &e ) {
+        try {
+            xreport->pop("report");
+            xreport->pop("dfxml");
+            xreport->close();
+        }
+        catch (const std::exception &) {
+        }
         cerr << "Disk write error during Phase 2 ( histogram making). Disk is probably full." << std::endl
                   << "Remove extra files and restart bulk_extractor with the exact same command line to continue." << std::endl;
         return 7;

--- a/src/image_process.cpp
+++ b/src/image_process.cpp
@@ -45,15 +45,17 @@
 #include "be20_api/formatter.h"
 #include "image_process.h"
 
+#include <memory>
+
 /****************************************************************
  *** static functions
  ****************************************************************/
 
 static sbuf_t *shrink_sbuf(sbuf_t *sbuf, const pos0_t &pos0, size_t pagesize, size_t bytes_read)
 {
+    std::unique_ptr<sbuf_t> original{sbuf};
     auto *short_sbuf = sbuf_t::sbuf_malloc(pos0, bytes_read, std::min(pagesize, bytes_read));
-    memcpy(short_sbuf->malloc_buf(), sbuf->malloc_buf(), bytes_read);
-    delete sbuf;
+    memcpy(short_sbuf->malloc_buf(), original->malloc_buf(), bytes_read);
     return short_sbuf;
 }
 

--- a/src/pcap_writer.cpp
+++ b/src/pcap_writer.cpp
@@ -49,10 +49,8 @@ void pcap_writer::pcap_write2(std::ofstream &fcap, const uint16_t val) const
 
 void pcap_writer::pcap_write4(std::ofstream &fcap, const uint32_t val) const
 {
-    fcap.write(reinterpret_cast<const char *>(&val), 4);
-    if (fcap.rdstate() & (std::ios::failbit|std::ios::badbit)){
-        throw std::runtime_error("scanner pcap_writer is unable to write packet data");
-    }
+    pcap_write2(fcap, static_cast<uint16_t>(val));
+    pcap_write2(fcap, static_cast<uint16_t>(val >> 16));
 }
 
 std::ofstream &pcap_writer::pcap_stream(uint32_t link_type)

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -349,7 +349,10 @@ bool validate_pcap_packet(const std::filesystem::path &fn0, const std::filesyste
     REQUIRE(header1[3] == 0xa1);
     REQUIRE(header1[20] == (link_type & 0xff));
     REQUIRE(header1[21] == ((link_type >> 8) & 0xff));
-    return std::equal(std::istreambuf_iterator<char>(in0), {}, std::istreambuf_iterator<char>(in1));
+    REQUIRE(header1[22] == ((link_type >> 16) & 0xff));
+    REQUIRE(header1[23] == ((link_type >> 24) & 0xff));
+    return std::equal(std::istreambuf_iterator<char>(in0), {}, std::istreambuf_iterator<char>(in1)) &&
+           in1.peek() == std::char_traits<char>::eof();
 }
 
 

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -1045,6 +1045,10 @@ TEST_CASE("e2e-email_test", "[end-to-end]") {
     }
 
     std::filesystem::path inpath = test_dir() / "email_test.E01";
+    if (!std::filesystem::exists(inpath)) {
+        SUCCEED("email_test.E01 fixture unavailable; skipping E01 end-to-end test");
+        return;
+    }
     std::string inpath_string = inpath.string();
     std::filesystem::path outdir = NamedTemporaryDirectory();
     std::string outdir_string = outdir.string();


### PR DESCRIPTION
## Audit scope

Reviewed every Copilot review thread on the 45 pull requests merged to `main` that are linked to the BE 2.2.0 milestone.

## Findings addressed

- **#518** — make the short-read `sbuf` replacement exception-safe.
- **#559** — write all PCAP 32-bit fields in little-endian order, and strengthen the PCAP tests to check the full link-type field and reject unexpected trailing data.
- **#578** — XML-escape `pos0` values in all `debug:bypass` diagnostic output paths.
- **#581** — surface filesystem-iteration and removal errors from `-Z`.
- **#591** — skip the E01 end-to-end test with an explicit success message when its optional fixture is absent.
- **#598** — close the report document after a Phase 2 `DiskWriteError`, while preserving the original diagnostic.

## Validation

- `./bootstrap.sh && ./configure`
- `make -C src check TESTS='test_be test_be20_api'`
- `git diff --check`

The focused tests passed. The branch commit is signed as `Codex AI Assistant <simsong+codex@acm.org>`.

## Deferred observations

The audit also found a few comments that need separately scoped design or test work rather than a safe consolidated change here: #559 Wi-Fi packet parsing, #562 scanner-count test brittleness, #583 stream-error test coverage, and #593 email-boundary scanner semantics. Comments in #565 and #582 were not defects in the current design; the remaining actionable comments had already been addressed by later merged changes.