### PR TITLE
Clarify GPL licensing after NPS

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,57 +1,21 @@
-## Copyright/Non-Copyright Statements
+## Project license and copyright status
 
-**bulk_extractor** was originally developed by Simson Garfinkel while at
-the Naval Postgraduate School. As a work of the US Government that
-work is not subject to copyright law.
+Simson Garfinkel originally developed **bulk_extractor** while at the Naval
+Postgraduate School (NPS). Original works created in that U.S. Government
+employment are not subject to U.S. copyright protection under 17 U.S.C. § 105.
+That status applies only to the original NPS material.
 
-Simson Garfinkel left the Naval Postgraduate School in January 2015
-and continued to work on **bulk_extractor** in his personal
-capacity. Those modifications are covered under the MIT license (below).
-Other components are licensed as noted.
+Simson Garfinkel left NPS in January 2015. All bulk_extractor code and
+documentation developed or modified after that date in his personal capacity
+are licensed under the **GNU General Public License, version 3 or later
+(GPL-3.0-or-later)**. The GPLv3 text is in
+[`licenses/LICENSE.GPLv3`](licenses/LICENSE.GPLv3). Distributions of the
+program must therefore comply with the GPL and provide the corresponding
+source as required by that license.
 
-## MIT License
-
-Copyright (C) 2020, Simson L. Garfinkel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
-OR OTHER DEALINGS IN THE SOFTWARE.
-
-## CC0 Original Summary
-
-Except as otherwise noted, bulk_extractor source code files are public domain
-software.
-
-That software provided here is released by the Naval Postgraduate
-School, an agency of the U.S. Department of Navy.  The software bears
-no warranty, either expressed or implied. NPS does not assume legal
-liability nor responsibility for a User's use of the software or the
-results of such use.
-
-Please note that within the United States, copyright protection, under
-Section 105 of the United States Code, Title 17, is not available for
-any work of the United States Government and/or for any works created
-by United States Government employees.
-
-However, because some bulk_extractor source modules (e.g. pyxpress.c)
-are covered under the GNU Public License, the compiled bulk_extractor
-executable is covered under the GPL copyright. This means that binary
-distributions of bulk_extractor must include the full source code (or
-have the source code be made easily available.)
+This GPL statement supersedes the prior statement that post-NPS modifications
+were under the MIT License. Do not describe bulk_extractor as a public-domain
+project: only the identified original NPS material has that status.
 
 ## Other materials
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,57 +1,21 @@
-## Copyright/Non-Copyright Statements
+## Project license and copyright status
 
-**bulk_extractor** was originally developed by Simson Garfinkel while at
-the Naval Postgraduate School. As a work of the US Government that
-work is not subject to copyright law.
+Simson Garfinkel originally developed **bulk_extractor** while at the Naval
+Postgraduate School (NPS). Original works created in that U.S. Government
+employment are not subject to U.S. copyright protection under 17 U.S.C. § 105.
+That status applies only to the original NPS material.
 
-Simson Garfinkel left the Naval Postgraduate School in January 2015
-and continued to work on **bulk_extractor** in his personal
-capacity. Those modifications are covered under the MIT license (below). Other
-components are licensed as noted.
+Simson Garfinkel left NPS in January 2015. All bulk_extractor code and
+documentation developed or modified after that date in his personal capacity
+are licensed under the **GNU General Public License, version 3 or later
+(GPL-3.0-or-later)**. The GPLv3 text is in
+[`licenses/LICENSE.GPLv3`](licenses/LICENSE.GPLv3). Distributions of the
+program must therefore comply with the GPL and provide the corresponding
+source as required by that license.
 
-## MIT License
-
-Copyright (C) 2020-2024, Simson L. Garfinkel
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
-OR OTHER DEALINGS IN THE SOFTWARE.
-
-## CC0 Original Summary
-
-Except as otherwise noted, bulk_extractor source code files are public domain
-software.
-
-That software provided here is released by the Naval Postgraduate
-School, an agency of the U.S. Department of Navy.  The software bears
-no warranty, either expressed or implied. NPS does not assume legal
-liability nor responsibility for a User's use of the software or the
-results of such use.
-
-Please note that within the United States, copyright protection, under
-Section 105 of the United States Code, Title 17, is not available for
-any work of the United States Government and/or for any works created
-by United States Government employees.
-
-However, because some bulk_extractor source modules (e.g. pyxpress.c)
-are covered under the GNU Public License, the compiled bulk_extractor
-executable is covered under the GPL copyright. This means that binary
-distributions of bulk_extractor must include the full source code (or
-have the source code be made easily available.)
+This GPL statement supersedes the prior statement that post-NPS modifications
+were under the MIT License. Do not describe bulk_extractor as a public-domain
+project: only the identified original NPS material has that status.
 
 ## Other materials
 

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -27,6 +27,10 @@ through the project's normal pull-request and CI process.
 
 ### Highlights
 
+- The project license statement now clearly identifies post-January-2015
+  development as GPL-3.0-or-later. Original NPS works retain their distinct
+  U.S.-Government status; bulk_extractor must not be described as a
+  public-domain project. RPM package metadata now reports GPL-3.0-or-later.
 - A standalone 64-bit Windows `.exe` is built with MinGW on Ubuntu and is
   checked to ensure that it imports no non-system Windows DLLs. GitHub Actions
   publishes it as a downloadable artifact; attaching it to the 2.2.0 release

--- a/specfiles/bulk_extractor.spec.m4.in
+++ b/specfiles/bulk_extractor.spec.m4.in
@@ -8,7 +8,7 @@ ifdef([OPENSUSE],[# Please submit bugfixes or comments via http://bugs.opensuse.
 Name:           bulk_extractor
 Version:        @VERSION@
 Release:        1
-License:        Public-Domain
+License:        GPL-3.0-or-later
 Summary:        Forensics tool for extracting email addresses and URLs from bulk data.
 Url:            http://digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-@VERSION@.tar.gz
 Group:          Productivity/File utilities
@@ -52,4 +52,3 @@ make %{?_smp_mflags}
 %{_bindir}/bulk_extractor
 
 %changelog
-

--- a/src/be20_api/LICENSE.md
+++ b/src/be20_api/LICENSE.md
@@ -1,40 +1,18 @@
-## Copyright/Non-Copyright Statements
+## Project license and copyright status
 
-**bulk_extractor** was originally developed by Simson Garfinkel while at
-the Naval Postgraduate School. As a work of the US Government this
-work is not subject to copyright law.
+Simson Garfinkel originally developed **bulk_extractor** while at the Naval
+Postgraduate School (NPS). Original works created in that U.S. Government
+employment are not subject to U.S. copyright protection under 17 U.S.C. § 105.
+That status applies only to the original NPS material.
 
-Simson Garfinkel left the Naval Postgraduate School in January 2015
-and continued to work on **bulk_extractor** in his personal
-capacity. Those modifications are covered under the MIT license. Other
-components are licensed as noted.
+Simson Garfinkel left NPS in January 2015. All bulk_extractor code and
+documentation developed or modified after that date in his personal capacity
+are licensed under the GNU General Public License, version 3 or later
+(GPL-3.0-or-later). See the top-level `LICENSE.md` and
+`licenses/LICENSE.GPLv3`. Do not describe the post-NPS project as public
+domain.
 
-## MIT License.
-
-Copyright (c) 2020, Simson L. Garfinkel {{ organization }}
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
-OR OTHER DEALINGS IN THE SOFTWARE.
-
-## CC0 Original Summary
-
-Except as otherwise noted, bulk_extractor source code files are public domain
-software.
+## Original NPS material
 
 That software provided here is released by the Naval Postgraduate
 School, an agency of the U.S. Department of Navy.  The software bears
@@ -46,12 +24,6 @@ Please note that within the United States, copyright protection, under
 Section 105 of the United States Code, Title 17, is not available for
 any work of the United States Government and/or for any works created
 by United States Government employees.
-
-However, because some bulk_extractor source modules (e.g. pyxpress.c)
-are covered under the GNU Public License, the compiled bulk_extractor
-executable is covered under the GPL copyright. This means that binary
-distributions of bulk_extractor must include the full source code (or
-have the source code be made easily available.)
 
 ## Other materials
 


### PR DESCRIPTION
## Summary

Clarifies that code and documentation developed after Simson Garfinkel left NPS in January 2015 are licensed GPL-3.0-or-later. It preserves the distinct U.S.-Government status of original NPS material, removes the obsolete MIT/project-wide public-domain claims, and corrects RPM package metadata.

## Why

Downstream packagers and users need an accurate project license statement. The previous wording incorrectly described post-NPS modifications as MIT-licensed and encouraged a public-domain characterization of the project.

## Validation

- `git diff --check`
- `bash bootstrap.sh && ./configure --quiet && make dist`
- Verified the generated source archive contains `LICENSE.md`, `COPYING`, `src/be20_api/LICENSE.md`, and `specfiles/bulk_extractor.spec.m4.in`.
- Verified no stale project-level MIT/public-domain or `Public-Domain` RPM license declaration remains in the relevant files.