### PR TITLE
Correct path-printer man page options

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -217,7 +217,8 @@ through the project's normal pull-request and CI process.
   [PR #558](https://github.com/simsong/bulk_extractor/pull/558),
   [PR #557](https://github.com/simsong/bulk_extractor/pull/557)).
 - Rewrote the installed `bulk_extractor(1)` manual for the 2.2 command-line
-  interface, current logging, scanner controls, and supported documentation.
+  interface, including current logging, scanner controls, path-printer aliases,
+  output-directory requirements, and supported documentation.
 - Removed the unmaintained standalone HTML overview; the current LaTeX guide
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete

--- a/man/bulk_extractor.1
+++ b/man/bulk_extractor.1
@@ -35,12 +35,12 @@ ended are deliberately skipped so that a data-dependent failure is not repeated.
 Use a new output directory for an independent scan, or
 .B -Z
 to remove an existing directory's contents before starting.
-.SH REQUIRED ARGUMENTS
+.SH OUTPUT DIRECTORY
 .TP
 .B -o, --outdir \fIOUTDIR\fR
 Write results to
 .IR OUTDIR .
-This option is required, including when using
+This option is required for normal scans, but not when using
 .BR -p .
 .SH INPUT AND OUTPUT OPTIONS
 .TP
@@ -69,8 +69,12 @@ for hexadecimal or
 .B /r
 for raw output.  Use
 .B -p -
-for interactive input or
+or
+.B -p -i
+for interactive input, or
 .B -p -http
+or
+.B -p --http
 for HTTP input.
 .TP
 .B -A, --offset_add \fIBYTES\fR

--- a/man/bulk_extractor.1
+++ b/man/bulk_extractor.1
@@ -40,8 +40,10 @@ to remove an existing directory's contents before starting.
 .B -o, --outdir \fIOUTDIR\fR
 Write results to
 .IR OUTDIR .
-This option is required for normal scans, but not when using
-.BR -p .
+This option is required for normal scans. When using
+.BR -p ,
+do not specify
+.BR -o .
 .SH INPUT AND OUTPUT OPTIONS
 .TP
 .B -R, --recurse


### PR DESCRIPTION
## Summary
- clarify that `-o` is required for normal scans but not `-p` path-printer mode
- document `-p -i` and `-p --http` aliases
- refine the 2.2.0 release-note entry

## Copilot feedback addressed
- [PR #630 output-directory comment](https://github.com/simsong/bulk_extractor/pull/630#discussion_r3700578564)
- [PR #630 path-printer alias comment](https://github.com/simsong/bulk_extractor/pull/630#discussion_r3700578573)

## Validation
- `mandoc -Tlint man/bulk_extractor.1`
- `mandoc -Tutf8 man/bulk_extractor.1`
- `git diff --check`
- `make dist` (confirmed the source archive contains `man/bulk_extractor.1`)