### PR TITLE
Move technical-debt audit to release planning

### DIFF
--- a/doc/RELEASE_2.2.0_PLANNING.md
+++ b/doc/RELEASE_2.2.0_PLANNING.md
@@ -1,4 +1,4 @@
-# bulk_extractor and be20_api source and technical-debt audit
+# bulk_extractor 2.2.0 release planning and technical-debt audit
 
 Date: 2026-07-19
 

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -222,6 +222,11 @@ through the project's normal pull-request and CI process.
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete
   benchmarks, platforms, and SQL tuning guidance.
+- Moved the historical source and technical-debt audit to
+  [`doc/RELEASE_2.2.0_PLANNING.md`](RELEASE_2.2.0_PLANNING.md) as the 2.2.0
+  release-planning record; the live technical-debt backlog remains in
+  [Discussion #545](https://github.com/simsong/bulk_extractor/discussions/545)
+  and its linked issues.
 - Documented a controlled release procedure and release-issue template, with
   isolated artifact assembly, macOS and container `distcheck` gates, and
   source-level downstream submission paths for Debian/Kali and


### PR DESCRIPTION
## Summary

- move the historical source and technical-debt audit from `src/` to `doc/RELEASE_2.2.0_PLANNING.md`
- record the new release-planning location in the 2.2.0 release notes
- regenerate Automake distribution metadata so the new document ships in source archives

## Validation

- `git diff --check`
- `make dist`
- verified the archive includes `doc/RELEASE_2.2.0_PLANNING.md` and excludes `src/TECH_DEBT.md`
