### PR TITLE
Correct license attribution metadata

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -9,8 +9,9 @@ Simson Garfinkel left NPS in January 2015. All post-NPS, project-authored
 bulk_extractor code and documentation developed or modified in his personal
 capacity are licensed under the **GNU General Public License, version 3 or
 later (GPL-3.0-or-later)**. Third-party components retain their original
-license terms, as identified in [Other materials](#other-materials) below. The
-GPLv3 text is in
+license terms as stated in their source headers and applicable files under
+[`licenses/`](licenses/); the [Other materials](#other-materials) list is a
+non-authoritative inventory. The GPLv3 text is in
 [`licenses/LICENSE.GPLv3`](licenses/LICENSE.GPLv3). Distributions of the
 program must therefore comply with the GPL and provide the corresponding
 source as required by that license.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,8 +9,9 @@ Simson Garfinkel left NPS in January 2015. All post-NPS, project-authored
 bulk_extractor code and documentation developed or modified in his personal
 capacity are licensed under the **GNU General Public License, version 3 or
 later (GPL-3.0-or-later)**. Third-party components retain their original
-license terms, as identified in [Other materials](#other-materials) below. The
-GPLv3 text is in
+license terms as stated in their source headers and applicable files under
+[`licenses/`](licenses/); the [Other materials](#other-materials) list is a
+non-authoritative inventory. The GPLv3 text is in
 [`licenses/LICENSE.GPLv3`](licenses/LICENSE.GPLv3). Distributions of the
 program must therefore comply with the GPL and provide the corresponding
 source as required by that license.

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -30,8 +30,8 @@ through the project's normal pull-request and CI process.
 - The project license statement now clearly identifies post-January-2015
   development as GPL-3.0-or-later. Original NPS works retain their distinct
   U.S.-Government status; bulk_extractor must not be described as a
-  public-domain project. RPM package metadata now reports the complete SPDX
-  license expression for the distributed project and third-party materials.
+  public-domain project. RPM package metadata now includes the documented SPDX
+  license identifiers, including the Autoconf exception used by bundled macros.
 - A standalone 64-bit Windows `.exe` is built with MinGW on Ubuntu and is
   checked to ensure that it imports no non-system Windows DLLs. GitHub Actions
   publishes it as a downloadable artifact; attaching it to the 2.2.0 release

--- a/specfiles/bulk_extractor.spec.m4.in
+++ b/specfiles/bulk_extractor.spec.m4.in
@@ -8,7 +8,7 @@ ifdef([OPENSUSE],[# Please submit bugfixes or comments via http://bugs.opensuse.
 Name:           bulk_extractor
 Version:        @VERSION@
 Release:        1
-License:        GPL-3.0-or-later AND LGPL-2.1-or-later AND LGPL-3.0-or-later AND MIT AND CPL-1.0
+License:        GPL-3.0-or-later WITH Autoconf-exception-3.0 AND LGPL-2.1-or-later AND LGPL-3.0-or-later AND MIT AND CPL-1.0
 Summary:        Forensics tool for extracting email addresses and URLs from bulk data.
 Url:            http://digitalcorpora.org/downloads/bulk_extractor/bulk_extractor-@VERSION@.tar.gz
 Group:          Productivity/File utilities

--- a/src/be20_api/LICENSE.md
+++ b/src/be20_api/LICENSE.md
@@ -9,9 +9,11 @@ Simson Garfinkel left NPS in January 2015. All post-NPS, project-authored
 bulk_extractor code and documentation developed or modified in his personal
 capacity are licensed under the GNU General Public License, version 3 or later
 (GPL-3.0-or-later). Third-party components retain their original license terms
-as identified in [Other materials](#other-materials). See the top-level
-`LICENSE.md` and `licenses/LICENSE.GPLv3`. Do not describe the post-NPS project
-as public domain.
+as stated in their source headers and applicable license files; the
+[Other materials](#other-materials) list is non-authoritative. See the
+[top-level LICENSE](../../LICENSE.md) and
+[GPLv3 text](../../licenses/LICENSE.GPLv3). Do not describe the post-NPS
+project as public domain.
 
 ## Original NPS material
 


### PR DESCRIPTION
Fixes the five Copilot findings from merged PR #628: attribution summaries are explicitly non-authoritative, the be20 license links are relative, RPM metadata includes `Autoconf-exception-3.0`, and the release note no longer overclaims completeness.\n\nValidation: `git diff --check`; `make dist`; verified the release archive includes all changed licensing and packaging files.