### PR TITLE
Automate draft GitHub release assembly

### DIFF
--- a/.github/workflows/create-release-installer.yml
+++ b/.github/workflows/create-release-installer.yml
@@ -1,6 +1,9 @@
 name: Create source distribution
 
-on: [workflow_dispatch]
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -3,6 +3,7 @@ name: Windows MinGW build
 on:
   push:
     branches: [main]
+    tags: ["v*"]
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths-ignore:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Assemble draft GitHub release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing signed annotated tag, for example v2.2.0.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  assemble:
+    name: Assemble draft release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Assemble and publish draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          python3 scripts/assemble_github_release.py \
+            --tag "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --output-dir release-assets \
+            --publish

--- a/Makefile.am
+++ b/Makefile.am
@@ -23,6 +23,7 @@ include Makefile.auto_defs
 EXTRA_DIST = $(SRC_WIN_DIST) $(AUTO_DOC_FILES) $(AUTO_ETC_FILES) $(AUTO_LICENSES) \
 	$(srcdir)/etc/Dockerfile.fedora-distcheck \
 	$(srcdir)/etc/Dockerfile.ubuntu-distcheck \
+	$(srcdir)/scripts/assemble_github_release.py \
 	$(srcdir)/scripts/release.sh \
 	$(srcdir)/AGENTS.md \
 	$(srcdir)/.gitignore \

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -229,6 +229,11 @@ through the project's normal pull-request and CI process.
   [#622](https://github.com/simsong/bulk_extractor/issues/622),
   [#623](https://github.com/simsong/bulk_extractor/issues/623),
   [#626](https://github.com/simsong/bulk_extractor/issues/626)).
+- Added tag-driven draft-release assembly for the source archive and tested
+  Windows executable. The Python driver derives the version from `configure.ac`,
+  can assemble and checksum supplied artifacts with `--dry-run`, and never
+  publishes a GitHub Release without a release-manager action
+  ([#621](https://github.com/simsong/bulk_extractor/issues/621)).
 
 ### Known limitations and release work
 

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -18,11 +18,19 @@ records a skipped workflow run; Actions cannot filter `pull_request` events on
 the draft field before a workflow starts. Pushes to `dev-release` do not run the
 main-branch push workflows.
 
+`configure.ac` is the sole authoritative version source. In the release PR,
+change the version in `AC_INIT([BULK_EXTRACTOR], [X.Y.Z], ...)`; package
+metadata and source-archive names derive from it. Do not duplicate that value
+in a workflow or release script.
+
 After the release PR is merged and all required checks are green, create a
 signed annotated tag named `vX.Y.Z` at the reviewed commit. The tag is the
-immutable release identity; never move or reuse it. A protected tag-triggered
-workflow should create a *draft* GitHub Release. The release manager reviews
-the evidence below and explicitly publishes the draft.
+immutable release identity; never move or reuse it. The tag must exactly match
+the `configure.ac` version. Tag pushes run the existing source-distribution and
+MinGW workflows plus `.github/workflows/release.yml`. The latter waits for the
+successful artifacts from that same tag, invokes
+`scripts/assemble_github_release.py`, and creates a *draft* GitHub Release.
+The release manager reviews the evidence below and explicitly publishes it.
 
 Use a `release/X.Y` branch only when maintaining an established release line
 while `main` continues with new development. Do not create a release branch for
@@ -126,6 +134,34 @@ make release \
 
 To use a different empty staging directory, pass
 `RELEASE_ARTIFACT_DIR=/absolute/path` to `make release`.
+
+### GitHub source and Windows assembly
+
+`scripts/assemble_github_release.py` is the testable assembly path for the
+GitHub source archive and tested MinGW executable. It reads the version only
+from `configure.ac`, verifies that the source archive embeds that same version,
+and writes these files to an empty output directory:
+
+- `bulk_extractor-X.Y.Z.tar.gz`
+- `bulk_extractor64.exe`
+- `SHA256SUMS`
+
+To test assembly without a tag, GitHub credentials, or a release mutation,
+provide artifacts created by the existing workflows (or equivalent local test
+inputs) and use `--dry-run`:
+
+```sh
+python3 scripts/assemble_github_release.py \
+  --source-archive /path/to/bulk_extractor-X.Y.Z.tar.gz \
+  --windows-executable /path/to/bulk_extractor64.exe \
+  --output-dir /tmp/bulk-extractor-release-test \
+  --dry-run
+```
+
+For a tag-triggered release, the GitHub workflow supplies the repository and
+tag. The script waits for the current source and MinGW workflow runs, downloads
+their artifacts, verifies their names and version, and creates only a draft
+release. It never publishes that release.
 
 The staged set must contain:
 

--- a/scripts/assemble_github_release.py
+++ b/scripts/assemble_github_release.py
@@ -161,6 +161,8 @@ def main() -> int:
         parser.error("--dry-run and --publish are mutually exclusive")
     if (args.source_archive is None) != (args.windows_executable is None):
         parser.error("provide both local artifact paths or neither")
+    if args.publish and args.repo is None:
+        parser.error("--repo is required with --publish")
     if args.source_archive is None and args.repo is None:
         parser.error("--repo is required when artifacts are not supplied locally")
     identity = release_identity(args.source_dir, args.tag, args.publish or args.source_archive is None)

--- a/scripts/assemble_github_release.py
+++ b/scripts/assemble_github_release.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Assemble or publish the source and Windows assets for a tagged release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+CONFIGURE_VERSION_RE = re.compile(r"^AC_INIT\(\[BULK_EXTRACTOR\],\[([^]]+)\]", re.MULTILINE)
+SOURCE_WORKFLOW = "create-release-installer.yml"
+WINDOWS_WORKFLOW = "mingw.yml"
+WINDOWS_ARTIFACT = "bulk_extractor-windows-x86_64"
+RUNS_KEY = "workflow_runs"
+ID_KEY = "id"
+STATUS_KEY = "status"
+CONCLUSION_KEY = "conclusion"
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    version: str
+    tag: str
+    commit: str
+
+
+def command(*args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=True, text=True, capture_output=capture_output)
+
+
+def configured_version(source_dir: Path) -> str:
+    match = CONFIGURE_VERSION_RE.search((source_dir / "configure.ac").read_text())
+    if match is None:
+        raise ValueError("could not read BULK_EXTRACTOR version from configure.ac")
+    return match.group(1)
+
+
+def release_identity(source_dir: Path, tag: str | None, require_tag: bool) -> ReleaseIdentity:
+    version = configured_version(source_dir)
+    expected_tag = f"v{version}"
+    if tag is not None and tag != expected_tag:
+        raise ValueError(f"tag {tag} does not match configure.ac version {version}")
+    actual_tag = tag or expected_tag
+    if require_tag:
+        tag_type = command("git", "-C", str(source_dir), "cat-file", "-t", f"refs/tags/{actual_tag}", capture_output=True).stdout.strip()
+        if tag_type != "tag":
+            raise ValueError(f"{actual_tag} must be an annotated tag")
+        commit_ref = f"{actual_tag}^{{commit}}"
+    else:
+        commit_ref = "HEAD"
+    commit = command("git", "-C", str(source_dir), "rev-parse", commit_ref, capture_output=True).stdout.strip()
+    return ReleaseIdentity(version=version, tag=actual_tag, commit=commit)
+
+
+def workflow_run(repo: str, workflow: str, commit: str, timeout: int) -> int:
+    deadline = time.monotonic() + timeout
+    endpoint = f"repos/{repo}/actions/workflows/{workflow}/runs?event=push&head_sha={commit}&per_page=100"
+    while time.monotonic() < deadline:
+        response = command("gh", "api", endpoint, capture_output=True)
+        payload: dict[str, Any] = json.loads(response.stdout)
+        runs: list[dict[str, Any]] = payload.get(RUNS_KEY, [])
+        if runs:
+            run = runs[0]
+            status = run.get(STATUS_KEY)
+            conclusion = run.get(CONCLUSION_KEY)
+            if status == "completed":
+                if conclusion == "success":
+                    return int(run[ID_KEY])
+                raise RuntimeError(f"{workflow} failed for {commit}: {conclusion}")
+        time.sleep(15)
+    raise TimeoutError(f"timed out waiting for {workflow} at {commit}")
+
+
+def download_artifact(repo: str, run_id: int, artifact: str, destination: Path) -> Path:
+    destination.mkdir(parents=True, exist_ok=True)
+    command("gh", "run", "download", str(run_id), "--repo", repo, "--name", artifact, "--dir", str(destination))
+    matches = list(destination.rglob("*"))
+    files = [path for path in matches if path.is_file()]
+    if len(files) != 1:
+        raise RuntimeError(f"expected one file in downloaded {artifact} artifact, found {len(files)}")
+    return files[0]
+
+
+def archive_version(archive: Path) -> str:
+    with tarfile.open(archive, "r:gz") as source:
+        candidates = [member for member in source.getmembers() if member.name.endswith("/configure.ac")]
+        if len(candidates) != 1:
+            raise ValueError(f"{archive} does not contain exactly one configure.ac")
+        extracted = source.extractfile(candidates[0])
+        if extracted is None:
+            raise ValueError(f"could not read configure.ac from {archive}")
+        match = CONFIGURE_VERSION_RE.search(extracted.read().decode())
+    if match is None:
+        raise ValueError(f"could not read version from {archive}")
+    return match.group(1)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def assemble(identity: ReleaseIdentity, source_archive: Path, windows_executable: Path, output_dir: Path) -> list[Path]:
+    expected_archive = f"bulk_extractor-{identity.version}.tar.gz"
+    if source_archive.name != expected_archive:
+        raise ValueError(f"source archive must be named {expected_archive}")
+    if archive_version(source_archive) != identity.version:
+        raise ValueError("source archive configure.ac version does not match release tag")
+    if not windows_executable.is_file() or windows_executable.stat().st_size == 0:
+        raise ValueError("Windows executable must be a non-empty file")
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise ValueError(f"output directory must be empty: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    staged_archive = output_dir / expected_archive
+    staged_windows = output_dir / "bulk_extractor64.exe"
+    shutil.copy2(source_archive, staged_archive)
+    shutil.copy2(windows_executable, staged_windows)
+    checksums = output_dir / "SHA256SUMS"
+    checksums.write_text("".join(f"{sha256(path)}  {path.name}\n" for path in (staged_archive, staged_windows)))
+    return [staged_archive, staged_windows, checksums]
+
+
+def publish_draft(repo: str, identity: ReleaseIdentity, assets: list[Path]) -> None:
+    check = subprocess.run(("gh", "release", "view", identity.tag, "--repo", repo), text=True, capture_output=True)
+    if check.returncode == 0:
+        raise RuntimeError(f"release already exists for {identity.tag}")
+    command(
+        "gh", "release", "create", identity.tag, "--repo", repo, "--target", identity.commit,
+        "--draft", "--title", f"bulk_extractor {identity.version}", "--generate-notes",
+        *(str(asset) for asset in assets),
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--tag", help="Annotated tag; defaults to v<version from configure.ac>.")
+    parser.add_argument("--source-archive", type=Path)
+    parser.add_argument("--windows-executable", type=Path)
+    parser.add_argument("--repo", help="GitHub owner/repository used to retrieve workflow artifacts.")
+    parser.add_argument("--wait-seconds", type=int, default=3600)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--dry-run", action="store_true", help="Assemble files only; never create a GitHub Release.")
+    parser.add_argument("--publish", action="store_true", help="Create a draft GitHub Release after assembly.")
+    args = parser.parse_args()
+    if args.dry_run and args.publish:
+        parser.error("--dry-run and --publish are mutually exclusive")
+    if (args.source_archive is None) != (args.windows_executable is None):
+        parser.error("provide both local artifact paths or neither")
+    if args.source_archive is None and args.repo is None:
+        parser.error("--repo is required when artifacts are not supplied locally")
+    identity = release_identity(args.source_dir, args.tag, args.publish or args.source_archive is None)
+    temporary: tempfile.TemporaryDirectory[str] | None = None
+    try:
+        if args.source_archive is None:
+            temporary = tempfile.TemporaryDirectory(prefix="bulk-extractor-release-")
+            download_dir = Path(temporary.name)
+            source_run = workflow_run(args.repo, SOURCE_WORKFLOW, identity.commit, args.wait_seconds)
+            windows_run = workflow_run(args.repo, WINDOWS_WORKFLOW, identity.commit, args.wait_seconds)
+            args.source_archive = download_artifact(args.repo, source_run, f"bulk_extractor-{identity.version}", download_dir / "source")
+            args.windows_executable = download_artifact(args.repo, windows_run, WINDOWS_ARTIFACT, download_dir / "windows")
+        assets = assemble(identity, args.source_archive, args.windows_executable, args.output_dir)
+        if args.publish:
+            publish_draft(args.repo, identity, assets)
+        print(f"Release assets assembled in {args.output_dir}")
+        return 0
+    finally:
+        if temporary is not None:
+            temporary.cleanup()
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError, TimeoutError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
Implements #621. The Python release assembler derives the version from configure.ac, waits for the existing tag-triggered source and MinGW artifact workflows, verifies their artifacts, writes SHA256SUMS, and creates only a draft GitHub Release. It supports local --dry-run assembly with supplied artifacts.\n\nValidation: python compilation; make dist; archive inclusion; successful dry-run assembly.