### PR TITLE
Preserve Debian source package provenance

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,10 +105,11 @@ release:
 .PHONY: release-deb
 release-deb:
 	test -n "$(RELEASE_TAG)"
-	test "$$(git cat-file -t refs/tags/$(RELEASE_TAG))" = tag
-	test "$$(git rev-parse $(RELEASE_TAG)^{commit})" = "$$(git rev-parse HEAD)"
+	test "$$(git cat-file -t "refs/tags/$(RELEASE_TAG)")" = tag
+	test "$$(git rev-parse "$(RELEASE_TAG)^{commit}")" = "$$(git rev-parse HEAD)"
 	git diff --quiet
 	git diff --cached --quiet
+	test -z "$$(git ls-files --others --exclude-standard)"
 	mkdir -p "$(RELEASE_ARTIFACT_DIR)"
 	$(CONTAINER_ENGINE) build --progress=plain --file etc/Dockerfile.debian-package --tag bulk-extractor-deb-build .
 	cid=$$($(CONTAINER_ENGINE) create bulk-extractor-deb-build); \

--- a/Makefile.am
+++ b/Makefile.am
@@ -97,12 +97,18 @@ libinstall:
 # active checkout. See scripts/release.sh and doc/RELEASE_PROCEDURE.md.
 RELEASE_ARTIFACT_DIR ?= $(abs_builddir)/release-artifacts
 RELEASE_SCRIPT = $(abs_srcdir)/scripts/release.sh
+RELEASE_TAG ?=
 .PHONY: release
 release:
 	RELEASE_ARTIFACT_DIR="$(RELEASE_ARTIFACT_DIR)" RELEASE_SOURCE_DIR="$(abs_srcdir)" "$(RELEASE_SCRIPT)"
 
 .PHONY: release-deb
 release-deb:
+	test -n "$(RELEASE_TAG)"
+	test "$$(git cat-file -t refs/tags/$(RELEASE_TAG))" = tag
+	test "$$(git rev-parse $(RELEASE_TAG)^{commit})" = "$$(git rev-parse HEAD)"
+	git diff --quiet
+	git diff --cached --quiet
 	mkdir -p "$(RELEASE_ARTIFACT_DIR)"
 	$(CONTAINER_ENGINE) build --progress=plain --file etc/Dockerfile.debian-package --tag bulk-extractor-deb-build .
 	cid=$$($(CONTAINER_ENGINE) create bulk-extractor-deb-build); \

--- a/Makefile.am
+++ b/Makefile.am
@@ -105,13 +105,13 @@ release:
 .PHONY: release-deb
 release-deb:
 	test -n "$(RELEASE_TAG)"
-	test "$$(git cat-file -t "refs/tags/$(RELEASE_TAG)")" = tag
-	test "$$(git rev-parse "$(RELEASE_TAG)^{commit}")" = "$$(git rev-parse HEAD)"
-	git diff --quiet
-	git diff --cached --quiet
-	test -z "$$(git ls-files --others --exclude-standard)"
+	test "$$(git -C "$(abs_srcdir)" cat-file -t "refs/tags/$(RELEASE_TAG)")" = tag
+	test "$$(git -C "$(abs_srcdir)" rev-parse "$(RELEASE_TAG)^{commit}")" = "$$(git -C "$(abs_srcdir)" rev-parse HEAD)"
+	git -C "$(abs_srcdir)" diff --quiet
+	git -C "$(abs_srcdir)" diff --cached --quiet
+	test -z "$$(git -C "$(abs_srcdir)" ls-files --others --exclude-standard)"
 	mkdir -p "$(RELEASE_ARTIFACT_DIR)"
-	$(CONTAINER_ENGINE) build --progress=plain --file etc/Dockerfile.debian-package --tag bulk-extractor-deb-build .
+	$(CONTAINER_ENGINE) build --progress=plain --file "$(abs_srcdir)/etc/Dockerfile.debian-package" --tag bulk-extractor-deb-build "$(abs_srcdir)"
 	cid=$$($(CONTAINER_ENGINE) create bulk-extractor-deb-build); \
 	  $(CONTAINER_ENGINE) cp "$$cid":/ - | tar -xf - --wildcards --strip-components=1 \
 	    -C "$(RELEASE_ARTIFACT_DIR)" 'bulk-extractor_*'; \

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (native)
+3.0 (quilt)

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -246,8 +246,9 @@ through the project's normal pull-request and CI process.
   remain maintainer-controlled ([#622](https://github.com/simsong/bulk_extractor/issues/622)).
   `make release-deb` creates Debian 3.0 (quilt) source packages from the
   `make dist` archive, requires an annotated release tag at `HEAD` and a clean
-  checkout, and copies generated `.deb`, `.dsc`, and `.changes` artifacts to
-  `$(RELEASE_ARTIFACT_DIR)` on the host.
+  checkout, and copies generated `.deb`, `.dsc`, `.changes`, `.buildinfo`,
+  `.orig.tar.gz`, and `.debian.tar.*` artifacts to `$(RELEASE_ARTIFACT_DIR)`
+  on the host.
 - Added tag-driven draft-release assembly for the source archive and tested
   Windows executable. The Python driver derives the version from `configure.ac`,
   can assemble and checksum supplied artifacts with `--dry-run`, and never

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -244,8 +244,10 @@ through the project's normal pull-request and CI process.
   `make release-deb` build and installed-package smoke test. Debian package
   versioning is derived from `configure.ac`; archive submission and signing
   remain maintainer-controlled ([#622](https://github.com/simsong/bulk_extractor/issues/622)).
-  `make release-deb` now copies the generated `.deb`, `.dsc`, and `.changes`
-  artifacts from the container to `$(RELEASE_ARTIFACT_DIR)` on the host.
+  `make release-deb` creates Debian 3.0 (quilt) source packages from the
+  `make dist` archive, requires an annotated release tag at `HEAD` and a clean
+  checkout, and copies generated `.deb`, `.dsc`, and `.changes` artifacts to
+  `$(RELEASE_ARTIFACT_DIR)` on the host.
 - Added tag-driven draft-release assembly for the source archive and tested
   Windows executable. The Python driver derives the version from `configure.ac`,
   can assemble and checksum supplied artifacts with `--dry-run`, and never

--- a/etc/Dockerfile.debian-package
+++ b/etc/Dockerfile.debian-package
@@ -8,7 +8,7 @@ COPY . /src
 RUN python3 scripts/prepare_debian_package.py \
     && bash bootstrap.sh && ./configure --quiet && make dist \
     && version=$(sed -n 's/^AC_INIT(\[BULK_EXTRACTOR\],\[\([^]]*\)\].*/\1/p' configure.ac) \
-    && package_version=${version/-DEVELOP/~develop} \
+    && package_version=$(printf '%s\n' "$version" | sed 's/-DEVELOP$/~develop/') \
     && mkdir /build \
     && tar -C /build -xzf bulk_extractor-"$version".tar.gz \
     && mv /build/bulk_extractor-"$version" /build/bulk-extractor-"$package_version" \

--- a/etc/Dockerfile.debian-package
+++ b/etc/Dockerfile.debian-package
@@ -5,6 +5,16 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     make pkg-config python3 zlib1g-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY . /src
-RUN python3 scripts/prepare_debian_package.py && dpkg-buildpackage -us -uc -S && dpkg-buildpackage -us -uc -b
+RUN python3 scripts/prepare_debian_package.py \
+    && bash bootstrap.sh && ./configure --quiet && make dist \
+    && version=$(sed -n 's/^AC_INIT(\[BULK_EXTRACTOR\],\[\([^]]*\)\].*/\1/p' configure.ac) \
+    && package_version=${version/-DEVELOP/~develop} \
+    && mkdir /build \
+    && tar -C /build -xzf bulk_extractor-"$version".tar.gz \
+    && mv /build/bulk_extractor-"$version" /build/bulk-extractor-"$package_version" \
+    && tar -C /build -czf /build/bulk-extractor_"$package_version".orig.tar.gz bulk-extractor-"$package_version" \
+    && cp -a debian /build/bulk-extractor-"$package_version"/ \
+    && cd /build/bulk-extractor-"$package_version" \
+    && dpkg-buildpackage -us -uc
 RUN dpkg -i ../bulk-extractor_*_*.deb || (apt-get update && apt-get -fy install)
 RUN bulk_extractor -h >/dev/null

--- a/etc/Dockerfile.debian-package
+++ b/etc/Dockerfile.debian-package
@@ -15,6 +15,7 @@ RUN python3 scripts/prepare_debian_package.py \
     && tar -C /build -czf /build/bulk-extractor_"$package_version".orig.tar.gz bulk-extractor-"$package_version" \
     && cp -a debian /build/bulk-extractor-"$package_version"/ \
     && cd /build/bulk-extractor-"$package_version" \
-    && dpkg-buildpackage -us -uc
-RUN dpkg -i ../bulk-extractor_*_*.deb || (apt-get update && apt-get -fy install)
+    && dpkg-buildpackage -us -uc \
+    && cp /build/bulk-extractor_* /
+RUN dpkg -i /bulk-extractor_*_*.deb || (apt-get update && apt-get -fy install)
 RUN bulk_extractor -h >/dev/null

--- a/scripts/prepare_debian_package.py
+++ b/scripts/prepare_debian_package.py
@@ -7,7 +7,7 @@ root = Path(__file__).resolve().parents[1]
 match = re.search(r"AC_INIT\(\[BULK_EXTRACTOR\],\[([^]]+)\]", (root / "configure.ac").read_text())
 if match is None:
     raise SystemExit("cannot read version from configure.ac")
-version = match.group(1).replace("-DEVELOP", "~develop")
+version = match.group(1).replace("-DEVELOP", "~develop") + "-1"
 (root / "debian/changelog").write_text(
     f"bulk-extractor ({version}) UNRELEASED; urgency=medium\n\n"
     "  * Build package from the versioned upstream source.\n\n"


### PR DESCRIPTION
Follow-up to merged #637. Builds a quilt-format Debian source package from the generated upstream orig archive, overlays Debian packaging afterward, and makes release-deb fail closed unless HEAD is a clean annotated release tag.\n\nValidation: git diff --check. Full release-deb execution intentionally awaits a real signed release tag; no tag was fabricated.