### PR TITLE
Scope draft release write permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
     needs: assemble
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,9 +18,6 @@ jobs:
   assemble:
     name: Assemble draft release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      actions: read
 
     steps:
       - name: Checkout release tag
@@ -29,7 +26,7 @@ jobs:
           ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
 
-      - name: Assemble and publish draft release
+      - name: Assemble release assets
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
@@ -37,5 +34,50 @@ jobs:
           python3 scripts/assemble_github_release.py \
             --tag "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --output-dir release-assets \
-            --publish
+            --output-dir release-assets
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          path: release-assets
+          if-no-files-found: error
+
+  publish:
+    name: Publish draft release
+    needs: assemble
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Download release assets
+        uses: actions/download-artifact@v8
+        with:
+          name: release-assets
+          path: release-assets
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          if [ "$(git cat-file -t "refs/tags/$RELEASE_TAG")" != tag ]; then
+            echo "$RELEASE_TAG must be an annotated tag" >&2
+            exit 2
+          fi
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$(git rev-parse "$RELEASE_TAG^{commit}")" \
+            --draft \
+            --title "bulk_extractor ${RELEASE_TAG#v}" \
+            --generate-notes \
+            release-assets/bulk_extractor-*.tar.gz \
+            release-assets/bulk_extractor64.exe \
+            release-assets/SHA256SUMS

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -251,6 +251,8 @@ through the project's normal pull-request and CI process.
   can assemble and checksum supplied artifacts with `--dry-run`, and never
   publishes a GitHub Release without a release-manager action
   ([#621](https://github.com/simsong/bulk_extractor/issues/621)).
+- The release workflow now assembles and verifies artifacts in a read-only job;
+  only its separate draft-publishing job receives repository write permission.
 
 ### Known limitations and release work
 


### PR DESCRIPTION
Follow-up to #636.

The release workflow now assembles and validates assets with read-only `contents` and `actions` permissions, uploads the staged files, then runs a dependent publishing job with the only `contents: write` grant. The publishing job verifies the annotated tag and creates the draft release from those staged assets.

Validation:
- Ruby YAML parse of `.github/workflows/release.yml`
- `git diff --check`

This addresses Copilot's remaining least-privilege concern on #636.