### PR TITLE
Document Copilot review lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,18 @@ required CI are clear, the pull request has been marked ready for review, and
 `@simsong` has been assigned. If validation or feedback remains, retain draft
 status and report the exact blocker.
 
+### Periodic Copilot-to-Ready timer
+
+When the Copilot-to-Ready timer is active, wake every 20 minutes and reconcile
+live GitHub state. For the current release milestone, scan its open issues
+assigned to `@simsong-codex`, then resume the highest-priority unblocked work
+or its pending pull-request review/CI follow-through. Verify milestone,
+assignment, PR head, Copilot state, and checks live; do not rely on an earlier
+heartbeat. Do not change issue assignments or milestones, approve, merge, or
+close anything without explicit user instruction. If there is no in-scope work
+or nothing has changed, return a quiet heartbeat; otherwise report the exact
+next action or blocker.
+
 Do not approve or merge a pull request unless explicitly asked.
 
 Delete a local branch once it has merged into `main`. First verify that it is an ancestor of the current `main`; preserve unmerged branches and local files in linked worktrees.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ to verify the resulting commit before pushing. When correcting existing
 commits, use `git commit --amend --reset-author -S` rather than only amending
 the signature.
 
-For every Codex-authored pull request, follow this lifecycle in order:
+For every Codex-authored pull request, follow the **Copilot-to-Ready
+lifecycle** in order. The user may invoke this procedure by name:
 
 1. Push the branch and open the pull request as a draft.
 2. Request the Copilot bot with the exact GitHub API reviewer value
@@ -29,6 +30,12 @@ For every Codex-authored pull request, follow this lifecycle in order:
    the thread; if GitHub resolves it automatically, report that fact.
 5. After Copilot is feedback-free and all required CI checks are green, mark
    the pull request ready for review and assign it to `@simsong`.
+
+The lifecycle is not complete at a pushed fix, a thread reply, or a successful
+Copilot request. It completes only after the current head's Copilot review and
+required CI are clear, the pull request has been marked ready for review, and
+`@simsong` has been assigned. If validation or feedback remains, retain draft
+status and report the exact blocker.
 
 Do not approve or merge a pull request unless explicitly asked.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,26 @@ to verify the resulting commit before pushing. When correcting existing
 commits, use `git commit --amend --reset-author -S` rather than only amending
 the signature.
 
-For every Codex-authored pull request, request a Copilot review after publishing it by requesting `copilot-pull-request-reviewer` (not `copilot`). Verify the request through GitHub's review state, then monitor until a Copilot review or review thread actually appears and all required CI checks have completed. Do not report a request as made, or Copilot as having responded, based only on a CLI command or an `@copilot` comment. Address actionable feedback before declaring the pull request ready. When pushing a fix in response to Copilot, reply to its thread with the fix and validation evidence, but leave the thread unresolved for `@simsong` to review and resolve. Once it is green and feedback-free, mark it ready for review and assign it to `@simsong`; do not approve or merge it unless explicitly asked.
+For every Codex-authored pull request, follow this lifecycle in order:
+
+1. Push the branch and open the pull request as a draft.
+2. Request the Copilot bot with the exact GitHub API reviewer value
+   `copilot-pull-request-reviewer[bot]`; do not use the incomplete value
+   `copilot-pull-request-reviewer`. GitHub's UI "Request" control for Copilot
+   is an equivalent fallback when the API response is ambiguous. Verify a
+   Copilot pending-review entry or a `REVIEW_REQUESTED_EVENT`, not merely an
+   HTTP success response.
+3. Keep the pull request a draft while monitoring until a Copilot review or
+   review thread actually appears. Do not report a request or response based
+   only on a CLI command or an `@copilot` comment.
+4. Address every actionable Copilot finding. For each pushed fix, reply on the
+   exact Copilot thread with the commit and validation evidence, then request
+   and monitor Copilot's re-review of that new commit. Do not manually resolve
+   the thread; if GitHub resolves it automatically, report that fact.
+5. After Copilot is feedback-free and all required CI checks are green, mark
+   the pull request ready for review and assign it to `@simsong`.
+
+Do not approve or merge a pull request unless explicitly asked.
 
 Delete a local branch once it has merged into `main`. First verify that it is an ancestor of the current `main`; preserve unmerged branches and local files in linked worktrees.
 


### PR DESCRIPTION
Documents the exact Copilot review lifecycle for Codex-authored pull requests.

It records the required `copilot-pull-request-reviewer[bot]` identifier, evidence required after a request, post-fix re-review, and draft-to-ready criteria.

Validation: `git diff --check`.