### PR TITLE
Add strict Snap package workflow

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -61,7 +61,7 @@ jobs:
           if-no-files-found: error
 
   publish-stable:
-    name: Publish signed-tag snaps to stable
+    name: Publish annotated-tag snaps to stable
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: build-and-test
     runs-on: ubuntu-24.04
@@ -84,7 +84,7 @@ jobs:
             echo "publish=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Verify the signed release tag
+      - name: Verify the annotated release tag and version
         if: steps.store.outputs.publish == 'true'
         run: |
           set -euo pipefail

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,0 +1,115 @@
+name: Snap build and test
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/snap.yml'
+      - 'snap/**'
+      - 'configure.ac'
+      - 'Makefile.am'
+      - 'src/**'
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths:
+      - '.github/workflows/snap.yml'
+      - 'snap/**'
+      - 'configure.ac'
+      - 'Makefile.am'
+      - 'src/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Snap build and test (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build snap
+        id: snap
+        uses: canonical/action-build@v1
+
+      - name: Install and run the strictly confined snap
+        run: |
+          set -euo pipefail
+          sudo snap install --dangerous "${{ steps.snap.outputs.snap }}"
+          sudo snap connect bulk-extractor:home :home
+          image="$HOME/bulk_extractor-fat32.dmg"
+          output="$HOME/bulk_extractor-snap-output"
+          cp src/tests/1mb_fat32.dmg "$image"
+          bulk-extractor.bulk-extractor -0q -o "$output" "$image"
+          test -s "$output/report.xml"
+
+      - name: Upload snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: bulk-extractor-snap-${{ matrix.arch }}
+          path: ${{ steps.snap.outputs.snap }}
+          if-no-files-found: error
+
+  publish-stable:
+    name: Publish signed-tag snaps to stable
+    if: >-
+      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') &&
+      secrets.SNAPCRAFT_STORE_CREDENTIALS != ''
+    needs: build-and-test
+    runs-on: ubuntu-24.04
+    environment: snap-store
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Verify the signed release tag
+        run: |
+          set -euo pipefail
+          tag=${GITHUB_REF_NAME}
+          version=$(sed -n 's/^AC_INIT(\[BULK_EXTRACTOR\],\[\([^]]*\)\].*/\1/p' configure.ac)
+          test "$tag" = "v$version"
+          test "$(git cat-file -t "refs/tags/$tag")" = tag
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: bulk-extractor-snap-*
+          path: snaps
+          merge-multiple: true
+
+      - name: Select architecture-specific packages
+        id: snap-files
+        run: |
+          set -euo pipefail
+          amd64=$(find snaps -name '*_amd64.snap' -type f -print -quit)
+          arm64=$(find snaps -name '*_arm64.snap' -type f -print -quit)
+          test -n "$amd64"
+          test -n "$arm64"
+          printf 'amd64=%s\narm64=%s\n' "$amd64" "$arm64" >> "$GITHUB_OUTPUT"
+
+      - name: Publish amd64 snap
+        uses: canonical/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.snap-files.outputs.amd64 }}
+          release: stable
+
+      - name: Publish arm64 snap
+        uses: canonical/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.snap-files.outputs.arm64 }}
+          release: stable

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -62,19 +62,30 @@ jobs:
 
   publish-stable:
     name: Publish signed-tag snaps to stable
-    if: >-
-      github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') &&
-      secrets.SNAPCRAFT_STORE_CREDENTIALS != ''
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: build-and-test
     runs-on: ubuntu-24.04
     environment: snap-store
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
 
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
+      - name: Determine whether protected Store credentials are available
+        id: store
+        run: |
+          if [ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Snap Store credentials are not configured; leaving this tagged build unpublished."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Verify the signed release tag
+        if: steps.store.outputs.publish == 'true'
         run: |
           set -euo pipefail
           tag=${GITHUB_REF_NAME}
@@ -83,12 +94,14 @@ jobs:
           test "$(git cat-file -t "refs/tags/$tag")" = tag
 
       - uses: actions/download-artifact@v4
+        if: steps.store.outputs.publish == 'true'
         with:
           pattern: bulk-extractor-snap-*
           path: snaps
           merge-multiple: true
 
       - name: Select architecture-specific packages
+        if: steps.store.outputs.publish == 'true'
         id: snap-files
         run: |
           set -euo pipefail
@@ -99,17 +112,15 @@ jobs:
           printf 'amd64=%s\narm64=%s\n' "$amd64" "$arm64" >> "$GITHUB_OUTPUT"
 
       - name: Publish amd64 snap
+        if: steps.store.outputs.publish == 'true'
         uses: canonical/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.snap-files.outputs.amd64 }}
           release: stable
 
       - name: Publish arm64 snap
+        if: steps.store.outputs.publish == 'true'
         uses: canonical/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
           snap: ${{ steps.snap-files.outputs.arm64 }}
           release: stable

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -50,7 +50,7 @@ jobs:
           image="$HOME/bulk_extractor-fat32.dmg"
           output="$HOME/bulk_extractor-snap-output"
           cp src/tests/1mb_fat32.dmg "$image"
-          bulk-extractor.bulk-extractor -0q -o "$output" "$image"
+          snap run bulk-extractor -0q -o "$output" "$image"
           test -s "$output/report.xml"
 
       - name: Upload snap

--- a/Makefile.am
+++ b/Makefile.am
@@ -106,7 +106,7 @@ release:
 
 .PHONY: snap
 snap:
-	snapcraft pack
+	cd "$(abs_srcdir)" && snapcraft pack
 
 .PHONY: release-deb
 release-deb:

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,6 +25,8 @@ EXTRA_DIST = $(SRC_WIN_DIST) $(AUTO_DOC_FILES) $(AUTO_ETC_FILES) $(AUTO_LICENSES
 	$(srcdir)/etc/Dockerfile.ubuntu-distcheck \
 	$(srcdir)/scripts/assemble_github_release.py \
 	$(srcdir)/scripts/release.sh \
+	$(srcdir)/snap/snapcraft.yaml \
+	$(srcdir)/doc/snap.md \
 	$(srcdir)/AGENTS.md \
 	$(srcdir)/.gitignore \
 	$(srcdir)/CODING_STANDARDS.md \
@@ -101,6 +103,10 @@ RELEASE_TAG ?=
 .PHONY: release
 release:
 	RELEASE_ARTIFACT_DIR="$(RELEASE_ARTIFACT_DIR)" RELEASE_SOURCE_DIR="$(abs_srcdir)" "$(RELEASE_SCRIPT)"
+
+.PHONY: snap
+snap:
+	snapcraft pack
 
 .PHONY: release-deb
 release-deb:

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -258,6 +258,11 @@ through the project's normal pull-request and CI process.
   ([#621](https://github.com/simsong/bulk_extractor/issues/621)).
 - The release workflow now assembles and verifies artifacts in a read-only job;
   only its separate draft-publishing job receives repository write permission.
+- Added a strict-confinement Snap package and native amd64/arm64 build and
+  install-test workflow. Stable Snap Store publication is limited to annotated
+  release tags, protected release-manager credentials, and a project-owned
+  publisher account; raw-device access remains an explicitly connected,
+  Store-reviewed interface ([#626](https://github.com/simsong/bulk_extractor/issues/626)).
 
 ### Known limitations and release work
 

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -225,7 +225,7 @@ The following release-engineering issues close the remaining automation gaps:
 - [#626][snap-issue]: optional project-owned Snap Store publication for Ubuntu
   users; it does not replace the Debian-to-Ubuntu path. The strict-confinement
   interface model, local `make snap` entry point, amd64/arm64 install-test
-  workflow, and protected signed-tag stable publication are documented in
+  workflow, and protected annotated-tag stable publication are documented in
   [doc/snap.md](snap.md).
 
 Once these are complete, a release manager should be able to direct Codex to

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -223,7 +223,10 @@ The following release-engineering issues close the remaining automation gaps:
 - [#624][aws-issue]: budget-capped AWS large-image validation and secure
   reporting.
 - [#626][snap-issue]: optional project-owned Snap Store publication for Ubuntu
-  users; it does not replace the Debian-to-Ubuntu path.
+  users; it does not replace the Debian-to-Ubuntu path. The strict-confinement
+  interface model, local `make snap` entry point, amd64/arm64 install-test
+  workflow, and protected signed-tag stable publication are documented in
+  [doc/snap.md](snap.md).
 
 Once these are complete, a release manager should be able to direct Codex to
 prepare a release PR, validate the tag, trigger the protected workflow, and

--- a/doc/snap.md
+++ b/doc/snap.md
@@ -12,7 +12,7 @@ ordinary image files stored in a user's non-hidden home directory:
 ```sh
 sudo snap install bulk-extractor
 sudo snap connect bulk-extractor:home :home
-bulk-extractor.bulk-extractor -o ~/bulk-extractor-output ~/image.dd
+bulk-extractor -o ~/bulk-extractor-output ~/image.dd
 ```
 
 For image files stored on mounted removable media, explicitly connect
@@ -20,7 +20,7 @@ For image files stored on mounted removable media, explicitly connect
 
 ```sh
 sudo snap connect bulk-extractor:removable-media :removable-media
-bulk-extractor.bulk-extractor -o ~/bulk-extractor-output /mnt/image.dd
+bulk-extractor -o ~/bulk-extractor-output /mnt/image.dd
 ```
 
 ## Raw devices
@@ -32,7 +32,7 @@ an administrator must explicitly connect the interface:
 
 ```sh
 sudo snap connect bulk-extractor:block-devices :block-devices
-sudo bulk-extractor.bulk-extractor -o /mnt/bulk-extractor-output /dev/sdb
+sudo snap run bulk-extractor -o /mnt/bulk-extractor-output /dev/sdb
 ```
 
 `block-devices` is requested with `allow-partitions: true`, so both disks and

--- a/doc/snap.md
+++ b/doc/snap.md
@@ -1,0 +1,56 @@
+# Snap package
+
+The project-maintained `bulk-extractor` Snap is a supplemental Ubuntu delivery
+channel. The primary distribution path remains Debian source package, Ubuntu
+Universe sync, and Kali downstream update.
+
+## Normal image-file scans
+
+The package uses strict confinement. After installation, connect `home` to scan
+ordinary image files stored in a user's non-hidden home directory:
+
+```sh
+sudo snap install bulk-extractor
+sudo snap connect bulk-extractor:home :home
+bulk-extractor.bulk-extractor -o ~/bulk-extractor-output ~/image.dd
+```
+
+For image files stored on mounted removable media, explicitly connect
+`removable-media`; it permits files under `/media`, `/run/media`, and `/mnt`:
+
+```sh
+sudo snap connect bulk-extractor:removable-media :removable-media
+bulk-extractor.bulk-extractor -o ~/bulk-extractor-output /mnt/image.dd
+```
+
+## Raw devices
+
+Raw-device scanning is deliberately not enabled by default. It uses the
+super-privileged `block-devices` interface and therefore requires a Snap Store
+declaration before publication. Once the Store has approved that declaration,
+an administrator must explicitly connect the interface:
+
+```sh
+sudo snap connect bulk-extractor:block-devices :block-devices
+sudo bulk-extractor.bulk-extractor -o /mnt/bulk-extractor-output /dev/sdb
+```
+
+`block-devices` is requested with `allow-partitions: true`, so both disks and
+their partition nodes can be read when the installed snapd supports that
+attribute. The application opens input read-only; nevertheless, raw-device
+selection remains an administrator responsibility.
+
+## Release administration
+
+Before a stable publication, the release manager must register
+`bulk-extractor` under a project-owned Snapcraft account and add named project
+collaborators. Store credentials are exported with only package access, push,
+update, and release ACLs, scoped to this package and an expiry, and saved as
+the protected `SNAPCRAFT_STORE_CREDENTIALS` secret for the `snap-store`
+environment. They are never placed in the repository.
+
+The `Snap build and test` workflow builds and install-tests amd64 and arm64
+packages from a non-sensitive FAT32 image fixture. It publishes only an
+annotated `vX.Y.Z` tag whose version matches `configure.ac`, after both
+architecture jobs succeed. Record the store revision, architectures, and the
+install-test workflow URLs in the release issue.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,64 @@
+name: bulk-extractor
+base: core22
+adopt-info: bulk-extractor
+summary: High-performance bulk data analysis for digital forensics
+description: |
+  bulk_extractor scans disk images, files, and other byte streams for forensic
+  features without requiring a filesystem. This strictly confined package
+  supports ordinary image-file scans and can optionally be connected to raw
+  block devices by an administrator.
+license: GPL-3.0-or-later
+contact: https://github.com/simsong/bulk_extractor/issues
+website: https://github.com/simsong/bulk_extractor
+source-code: https://github.com/simsong/bulk_extractor
+grade: stable
+confinement: strict
+
+apps:
+  bulk-extractor:
+    command: usr/bin/bulk_extractor
+    plugs:
+      - home
+      - removable-media
+      - block-devices
+
+plugs:
+  block-devices:
+    allow-partitions: true
+
+parts:
+  bulk-extractor:
+    plugin: nil
+    source: .
+    build-packages:
+      - autoconf
+      - automake
+      - build-essential
+      - flex
+      - libabsl-dev
+      - libexpat1-dev
+      - libgcrypt20-dev
+      - libgpg-error-dev
+      - libre2-dev
+      - libssl-dev
+      - libtool
+      - pkg-config
+      - zlib1g-dev
+    stage-packages:
+      - libabsl20220623
+      - libexpat1
+      - libgcrypt20
+      - libgpg-error0
+      - libre2-9
+      - libssl3
+      - zlib1g
+    override-pull: |
+      craftctl default
+      version=$(sed -n 's/^AC_INIT(\[BULK_EXTRACTOR\],\[\([^]]*\)\].*/\1/p' configure.ac)
+      test -n "$version"
+      craftctl set version="$version"
+    override-build: |
+      bash bootstrap.sh
+      ./configure --prefix=/usr --disable-libewf --disable-lightgrep --quiet
+      make -j"$(nproc)"
+      make install DESTDIR="$CRAFT_PART_INSTALL"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
       - pkg-config
       - zlib1g-dev
     stage-packages:
-      - libabsl20220623
+      - libabsl20210324
       - libexpat1
       - libgcrypt20
       - libgpg-error0

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -59,6 +59,6 @@ parts:
       craftctl set version="$version"
     override-build: |
       bash bootstrap.sh
-      ./configure --prefix=/usr --disable-libewf --disable-lightgrep --quiet
+      ./configure --prefix=/usr --disable-libewf --quiet
       make -j"$(nproc)"
       make install DESTDIR="$CRAFT_PART_INSTALL"


### PR DESCRIPTION
## Summary

- add a strict-confinement `bulk-extractor` Snap with normal-image and explicit raw-device interfaces
- build and install-test native amd64 and arm64 packages against the non-sensitive FAT32 fixture
- publish to Snap Store stable only from a matching annotated tag through the protected `snap-store` environment
- document project-owned publisher and least-privilege credential requirements

## Validation

- `make -n snap`
- `make -j1 dist`
- verified the source archive includes `snap/snapcraft.yaml` and `doc/snap.md`

The native Snapcraft build and install scan run in the new GitHub Actions matrix.