### PR TITLE
Automate Fedora and openSUSE RPM release builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,7 +20,6 @@ src/.deps
 src/Makefile
 src/*.o
 src/bulk_extractor
-src/test_*
 src/tests/Makefile
 tests/Makefile
 bulk_extractor-*

--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,9 @@ src/.deps
 src/Makefile
 src/*.o
 src/bulk_extractor
+src/test_*
+!src/test_*.cpp
+!src/test_*.h
 src/tests/Makefile
 tests/Makefile
 bulk_extractor-*

--- a/Makefile.am
+++ b/Makefile.am
@@ -129,12 +129,17 @@ release-rpm:
 	test ! -e "$(RELEASE_RPM_ARTIFACT_DIR)"
 	mkdir -p "$(RELEASE_RPM_ARTIFACT_DIR)"
 	@set -e; for distribution in fedora opensuse; do \
-	  image=bulk-extractor-rpm-$$distribution-build; \
-	  $(CONTAINER_ENGINE) build --progress=plain --file "$(abs_srcdir)/etc/Dockerfile.$$distribution-rpm-package" --tag "$$image" "$(abs_srcdir)"; \
-	  cid=$$($(CONTAINER_ENGINE) create "$$image"); \
-	  mkdir -p "$(RELEASE_RPM_ARTIFACT_DIR)/$$distribution"; \
-	  $(CONTAINER_ENGINE) cp "$$cid":/artifacts/. "$(RELEASE_RPM_ARTIFACT_DIR)/$$distribution"; \
-	  $(CONTAINER_ENGINE) rm "$$cid"; \
+	  ( set -e; \
+	    cid=; \
+	    cleanup() { test -z "$$cid" || $(CONTAINER_ENGINE) rm -f "$$cid" >/dev/null 2>&1 || :; }; \
+	    trap cleanup EXIT; \
+	    trap 'cleanup; exit 1' HUP INT TERM; \
+	    image=bulk-extractor-rpm-$$distribution-build; \
+	    $(CONTAINER_ENGINE) build --progress=plain --file "$(abs_srcdir)/etc/Dockerfile.$$distribution-rpm-package" --tag "$$image" "$(abs_srcdir)"; \
+	    cid=$$($(CONTAINER_ENGINE) create "$$image"); \
+	    mkdir -p "$(RELEASE_RPM_ARTIFACT_DIR)/$$distribution"; \
+	    $(CONTAINER_ENGINE) cp "$$cid":/artifacts/. "$(RELEASE_RPM_ARTIFACT_DIR)/$$distribution"; \
+	  ); \
 	done
 
 # Each Finch build copies a clean source context and runs the real distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -98,6 +98,7 @@ libinstall:
 RELEASE_ARTIFACT_DIR ?= $(abs_builddir)/release-artifacts
 RELEASE_SCRIPT = $(abs_srcdir)/scripts/release.sh
 RELEASE_TAG ?=
+RELEASE_RPM_ARTIFACT_DIR ?= $(abs_builddir)/release-rpm-artifacts
 .PHONY: release
 release:
 	RELEASE_ARTIFACT_DIR="$(RELEASE_ARTIFACT_DIR)" RELEASE_SOURCE_DIR="$(abs_srcdir)" "$(RELEASE_SCRIPT)"
@@ -116,6 +117,25 @@ release-deb:
 	  $(CONTAINER_ENGINE) cp "$$cid":/ - | tar -xf - --wildcards --strip-components=1 \
 	    -C "$(RELEASE_ARTIFACT_DIR)" 'bulk-extractor_*'; \
 	  $(CONTAINER_ENGINE) rm "$$cid"
+
+.PHONY: release-rpm
+release-rpm:
+	test -n "$(RELEASE_TAG)"
+	test "$$(git -C "$(abs_srcdir)" cat-file -t "refs/tags/$(RELEASE_TAG)")" = tag
+	test "$$(git -C "$(abs_srcdir)" rev-parse "$(RELEASE_TAG)^{commit}")" = "$$(git -C "$(abs_srcdir)" rev-parse HEAD)"
+	git -C "$(abs_srcdir)" diff --quiet
+	git -C "$(abs_srcdir)" diff --cached --quiet
+	test -z "$$(git -C "$(abs_srcdir)" ls-files --others --exclude-standard)"
+	test ! -e "$(RELEASE_RPM_ARTIFACT_DIR)"
+	mkdir -p "$(RELEASE_RPM_ARTIFACT_DIR)"
+	@set -e; for distribution in fedora opensuse; do \
+	  image=bulk-extractor-rpm-$$distribution-build; \
+	  $(CONTAINER_ENGINE) build --progress=plain --file "$(abs_srcdir)/etc/Dockerfile.$$distribution-rpm-package" --tag "$$image" "$(abs_srcdir)"; \
+	  cid=$$($(CONTAINER_ENGINE) create "$$image"); \
+	  mkdir -p "$(RELEASE_RPM_ARTIFACT_DIR)/$$distribution"; \
+	  $(CONTAINER_ENGINE) cp "$$cid":/artifacts/. "$(RELEASE_RPM_ARTIFACT_DIR)/$$distribution"; \
+	  $(CONTAINER_ENGINE) rm "$$cid"; \
+	done
 
 # Each Finch build copies a clean source context and runs the real distcheck
 # inside it. Finch selects native arm64 and emulated amd64 on Apple Silicon.

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -258,6 +258,10 @@ through the project's normal pull-request and CI process.
   ([#621](https://github.com/simsong/bulk_extractor/issues/621)).
 - The release workflow now assembles and verifies artifacts in a read-only job;
   only its separate draft-publishing job receives repository write permission.
+- Added a tagged, clean-checkout `make release-rpm` gate that builds and smoke
+  tests binary RPMs and SRPMs in pinned Fedora and openSUSE environments for
+  GitHub download testing; distribution archives continue to build submitted
+  source packages themselves ([#623](https://github.com/simsong/bulk_extractor/issues/623)).
 
 ### Known limitations and release work
 

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -194,13 +194,24 @@ is a release failure.
    sync request. Do not pursue Ubuntu's default third-party-source list for this
    free-software tool. The reproducible build and downstream tracking are in
    [#622][deb-issue].
-5. Submit source-level RPM packaging changes: use the Fedora package-review or
-   dist-git workflow as applicable, and fork the openSUSE package repository to
-   submit a Gitea pull request containing the updated spec, source reference,
-   and changelog. Let the distribution build service build and archive the RPMs;
-   record the accepted request URL. The reproducible build and downstream
-   tracking are in [#623][rpm-issue].
-6. Publish the GitHub Release only after a release manager has reviewed every
+5. Run `make release-rpm RELEASE_TAG=vVERSION`. It requires an annotated tag
+   at `HEAD` and a completely clean checkout, then builds the tagged source in
+   version-pinned Fedora and openSUSE Leap environments. It writes each
+   distribution's binary RPM and SRPM to its subdirectory under
+   `release-rpm-artifacts/` and verifies the installed binary in the same
+   clean environment. These are GitHub
+   direct-download/test artifacts only.
+6. Submit source-level RPM packaging changes: for Fedora, determine whether a
+   package already exists; otherwise file a new-package review at
+   <https://bugzilla.redhat.com/enter_bug.cgi?product=Fedora&component=Package%20Review>.
+   For an existing Fedora package, use its dist-git update workflow. For
+   openSUSE, identify the live package repository and maintainer in
+   <https://build.opensuse.org/>, fork that repository in openSUSE Gitea, and
+   submit a pull request updating the spec, source reference, and changelog.
+   Let the distribution build service build and archive the RPMs; record each
+   accepted request URL and downstream build result in the release issue. The
+   reproducible build and downstream tracking are in [#623][rpm-issue].
+7. Publish the GitHub Release only after a release manager has reviewed every
    required gate and external package publication is either complete or clearly
    disclosed in the release notes.
 

--- a/etc/Dockerfile.fedora-rpm-package
+++ b/etc/Dockerfile.fedora-rpm-package
@@ -1,0 +1,18 @@
+FROM fedora:44
+RUN dnf -y install abseil-cpp-devel autoconf automake exiv2-devel expat-devel \
+    flex gcc-c++ libgcrypt-devel libtool make pkgconf-pkg-config python3 re2-devel \
+    redhat-rpm-config rpm-build zlib-devel && dnf clean all
+WORKDIR /src
+COPY . /src
+RUN sed -i 's/-DEVELOP//' configure.ac \
+    && bash bootstrap.sh \
+    && ./configure --quiet --disable-libewf \
+    && make -C specfiles bulk_extractor.fedora.spec \
+    && make dist \
+    && mkdir -p /build/SOURCES /build/SPECS /artifacts \
+    && cp bulk_extractor-*.tar.gz /build/SOURCES/ \
+    && cp specfiles/bulk_extractor.fedora.spec /build/SPECS/bulk_extractor.spec \
+    && rpmbuild --define '_topdir /build' -ba /build/SPECS/bulk_extractor.spec \
+    && cp /build/RPMS/*/bulk_extractor-*.rpm /build/SRPMS/bulk_extractor-*.src.rpm /artifacts/
+RUN dnf -y install /artifacts/bulk_extractor-*.rpm \
+    && bulk_extractor -V >/dev/null

--- a/etc/Dockerfile.opensuse-rpm-package
+++ b/etc/Dockerfile.opensuse-rpm-package
@@ -1,0 +1,20 @@
+FROM opensuse/leap:15.6
+RUN zypper --non-interactive install --no-recommends \
+    autoconf automake gcc13-c++ libexpat-devel libexiv2-devel libgcrypt-devel \
+    libtool make pkg-config re2-devel rpm-build zlib-devel flex python3 \
+    && zypper clean --all
+WORKDIR /src
+COPY . /src
+RUN ln -s README.md README \
+    && sed -i 's/-DEVELOP//' configure.ac \
+    && bash bootstrap.sh \
+    && CC=gcc-13 CXX=g++-13 ./configure --quiet --disable-libewf \
+    && make -C specfiles bulk_extractor.opensuse.spec \
+    && make dist \
+    && mkdir -p /build/SOURCES /build/SPECS /artifacts \
+    && cp bulk_extractor-*.tar.gz /build/SOURCES/ \
+    && cp specfiles/bulk_extractor.opensuse.spec /build/SPECS/bulk_extractor.spec \
+    && CC=gcc-13 CXX=g++-13 rpmbuild --define '_topdir /build' -ba /build/SPECS/bulk_extractor.spec \
+    && cp /build/RPMS/*/bulk_extractor-*.rpm /build/SRPMS/bulk_extractor-*.src.rpm /artifacts/
+RUN zypper --non-interactive install --allow-unsigned-rpm /artifacts/bulk_extractor-*.rpm \
+    && bulk_extractor -V >/dev/null

--- a/specfiles/bulk_extractor.spec.m4.in
+++ b/specfiles/bulk_extractor.spec.m4.in
@@ -3,6 +3,8 @@ changequote([,])dnl
 # spec file for package bulk_extractor
 #
 ifdef([OPENSUSE],[# Please submit bugfixes or comments via http://bugs.opensuse.org/])
+ifdef([FEDORA],[# Flex-generated scanners define incompatible yyguts_t types; disable Fedora's LTO until they are isolated.])
+ifdef([FEDORA],[%global _lto_cflags %{nil}])
 #
 
 Name:           bulk_extractor
@@ -15,12 +17,14 @@ Group:          Productivity/File utilities
 AutoReqProv:    on
 Source:         bulk_extractor-@VERSION@.tar.gz
 BuildRequires:  zlib-devel
-BuildRequires:  libewf-devel
 ifdef([OPENSUSE],[BuildRequires:  libexiv2-devel])
 ifdef([FEDORA],[BuildRequires:  exiv2-devel])
-ifdef([FEDORA],[BuildRequires:  librx-devel])
-BuildRequires:  gcc-c++
+ifdef([OPENSUSE],[BuildRequires:  gcc13-c++])
+ifdef([FEDORA],[BuildRequires:  gcc-c++])
 BuildRequires:  flex
+BuildRequires:  make
+BuildRequires:  pkgconfig(re2)
+BuildRequires:  pkgconfig(expat)
 
 %description
 bulk_extractor is a C++ program that scans a disk image, a file, or a
@@ -39,7 +43,8 @@ as features that are more common tend to be more important.
 %setup -q
 
 %build
-%configure
+ifdef([OPENSUSE],[export CC=gcc-13 CXX=g++-13])
+%configure --disable-libewf
 make %{?_smp_mflags}
 
 %install
@@ -47,7 +52,7 @@ make %{?_smp_mflags}
 
 %files
 %defattr(-,root,root)
-%doc ChangeLog README COPYING
+%doc ChangeLog README.md COPYING
 %doc %{_mandir}/man1/bulk_extractor.1.gz
 %{_bindir}/bulk_extractor
 

--- a/specfiles/bulk_extractor.spec.m4.in
+++ b/specfiles/bulk_extractor.spec.m4.in
@@ -17,6 +17,8 @@ Group:          Productivity/File utilities
 AutoReqProv:    on
 Source:         bulk_extractor-@VERSION@.tar.gz
 BuildRequires:  zlib-devel
+BuildRequires:  libgcrypt-devel
+BuildRequires:  libgpg-error-devel
 ifdef([OPENSUSE],[BuildRequires:  libexiv2-devel])
 ifdef([FEDORA],[BuildRequires:  exiv2-devel])
 ifdef([OPENSUSE],[BuildRequires:  gcc13-c++])

--- a/src/rar/unpack.cpp
+++ b/src/rar/unpack.cpp
@@ -319,10 +319,10 @@ static const byte* buildDBits()
     byte* DBitsInit = (byte*) malloc(sizeof(byte) * DC);
     memset(DBitsInit, 0x00, sizeof(byte) * DC);
 
-    int Dist=0,BitLength=0,Slot=0;
+    int BitLength=0,Slot=0;
     for (unsigned I=0;I<sizeof(DBitLengthCounts)/sizeof(DBitLengthCounts[0]);I++,BitLength++)
     {
-        for (int J=0;J<DBitLengthCounts[I];J++,Slot++,Dist+=(1<<BitLength))
+        for (int J=0;J<DBitLengthCounts[I];J++,Slot++)
         {
             DBitsInit[Slot]=BitLength;
         }
@@ -791,7 +791,10 @@ bool Unpack::ReadTables()
       else
       {
         ZeroCount+=2;
-        while (ZeroCount-- > 0 && I<(int)(sizeof(BitLength)/sizeof(BitLength[0])))
+        const int remaining=BC-I;
+        if (ZeroCount>remaining)
+          ZeroCount=remaining;
+        while (ZeroCount-- > 0)
           BitLength[I++]=0;
         I--;
       }


### PR DESCRIPTION
## Summary

- add a clean-tag `make release-rpm` gate that builds RPMs and SRPMs from the tagged source archive
- build and smoke-test installed packages in pinned Fedora 44 and openSUSE Leap 15.6 containers
- retain each distribution's artifacts separately and document downstream Fedora/openSUSE source-submission paths

Implements #623.

## Validation

- `make release-rpm RELEASE_TAG=codex-test-rpm-623 RELEASE_RPM_ARTIFACT_DIR=/private/tmp/bulk-extractor-issue-623-rpm-artifacts-12`
  - Fedora 44: RPM/SRPM built; installed package passed `bulk_extractor -V`
  - openSUSE Leap 15.6: RPM/SRPM built; installed package passed `bulk_extractor -V`
- `git diff --check origin/main...HEAD`