### PR TITLE
Restore comprehensive 2.2 manuals

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,6 +9,7 @@ on:
       - '**.md'
       - 'AGENTS.md'
       - 'doc/**'
+      - '.github/workflows/latex-docs.yml'
       - '.github/CODEOWNERS'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,6 +11,7 @@ on:
       - '**.md'
       - 'AGENTS.md'
       - 'doc/**'
+      - '.github/workflows/latex-docs.yml'
       - '.github/CODEOWNERS'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'

--- a/.github/workflows/latex-docs.yml
+++ b/.github/workflows/latex-docs.yml
@@ -4,12 +4,12 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - 'doc/**/*.tex'
+      - 'doc/**'
       - '.github/workflows/latex-docs.yml'
   push:
     branches: [main]
     paths:
-      - 'doc/**/*.tex'
+      - 'doc/**'
       - '.github/workflows/latex-docs.yml'
   workflow_dispatch:
 
@@ -24,7 +24,6 @@ concurrency:
 
 jobs:
   build:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -10,6 +10,7 @@ on:
       - '**.md'
       - 'AGENTS.md'
       - 'doc/**'
+      - '.github/workflows/latex-docs.yml'
       - '.github/CODEOWNERS'
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/pull_request_template.md'

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -4,6 +4,7 @@ AUTOMAKE_OPTIONS = subdir-objects
 
 EXTRA_DIST = carving.md docker.md logging.md scanner_api.md scanner_template.cpp testing.md \
     programmer_manual/BEProgrammersManual.tex \
+    programmer_manual/references.bib \
     programmer_manual/Makefile.am \
     programmer_manual/extractinformationreprocess.pdf \
     programmer_manual/histogramprocessing.pdf \

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -233,6 +233,9 @@ through the project's normal pull-request and CI process.
   guidance, development examples, and coding practices. The historical
   BEViewer workflow is retained in an appendix, clearly marked as unavailable
   in 2.2 and as requirements for its planned return in the 2.x series.
+- LaTeX documentation CI now builds draft pull requests and runs for every
+  change under `doc/`, so manual-source and supporting-file errors are caught
+  before a pull request is marked ready for review.
 - Removed the unmaintained standalone HTML overview; the current LaTeX guide
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -235,7 +235,9 @@ through the project's normal pull-request and CI process.
   in 2.2 and as requirements for its planned return in the 2.x series.
 - LaTeX documentation CI now builds draft pull requests and runs for every
   change under `doc/`, so manual-source and supporting-file errors are caught
-  before a pull request is marked ready for review.
+  before a pull request is marked ready for review. The code, coverage, and
+  Windows workflows ignore changes limited to documentation and this LaTeX
+  workflow.
 - Removed the unmaintained standalone HTML overview; the current LaTeX guide
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -237,7 +237,8 @@ through the project's normal pull-request and CI process.
   change under `doc/`, so manual-source and supporting-file errors are caught
   before a pull request is marked ready for review. The code, coverage, and
   Windows workflows ignore changes limited to documentation and this LaTeX
-  workflow.
+  workflow. The user-manual build uses an explicit, portable asset manifest
+  rather than a GNU `make`-specific wildcard.
 - Removed the unmaintained standalone HTML overview; the current LaTeX guide
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -235,10 +235,10 @@ through the project's normal pull-request and CI process.
   in 2.2 and as requirements for its planned return in the 2.x series.
 - LaTeX documentation CI now builds draft pull requests and runs for every
   change under `doc/`, so manual-source and supporting-file errors are caught
-  before a pull request is marked ready for review. The code, coverage, and
-  Windows workflows ignore changes limited to documentation and this LaTeX
-  workflow. The user-manual build uses an explicit, portable asset manifest
-  rather than a GNU `make`-specific wildcard.
+  before a pull request is marked ready for review. For pull requests, the
+  code, coverage, and Windows workflows ignore changes limited to
+  documentation and this LaTeX workflow. The user-manual build uses an
+  explicit, portable asset manifest rather than a GNU `make`-specific wildcard.
 - Removed the unmaintained standalone HTML overview; the current LaTeX guide
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -226,6 +226,13 @@ through the project's normal pull-request and CI process.
 - Rewrote the installed `bulk_extractor(1)` manual for the 2.2 command-line
   interface, including current logging, scanner controls, path-printer aliases,
   output-directory requirements, and supported documentation.
+- Restored the substantive version 1 user- and programmer-manual material that
+  remains applicable to 2.2, including theory of operation, forensic paths,
+  feature files and histograms, investigation workflows, worked public-corpus
+  examples, troubleshooting, detailed scanner architecture, recorder and sbuf
+  guidance, development examples, and coding practices. The historical
+  BEViewer workflow is retained in an appendix, clearly marked as unavailable
+  in 2.2 and as requirements for its planned return in the 2.x series.
 - Removed the unmaintained standalone HTML overview; the current LaTeX guide
   and published documentation site are the supported user documentation.
 - Removed the unmaintained version-1 performance notebook with obsolete

--- a/doc/latex_manuals/BECurrentGuide.tex
+++ b/doc/latex_manuals/BECurrentGuide.tex
@@ -665,7 +665,7 @@ the installed \code{bulk\_extractor(1)} manual are authoritative.
 \code{-Z} & Remove existing output contents before scanning. \\
 \code{-Y START[-END]} & Scan a byte-offset range. \\
 \code{-z PAGE} & Begin at a page number. \\
-\code{-p PATH} & Print a forensic path instead of running a normal scan. \\
+\code{-p PATH} & Print data selected by a forensic-path expression. \\
 \code{-A BYTES} & Add a value to reported feature locations. \\
 \code{-b FILE} & Prepend a banner to feature files. \\
 \code{-r FILE} & Read an alert list. \\
@@ -687,7 +687,7 @@ the installed \code{bulk\_extractor(1)} manual are authoritative.
 \code{--max\_minute\_wait N} & Bound processing and shutdown wait time. \\
 \code{--max\_bad\_alloc\_errors N} & Set tolerated allocation failures. \\
 \code{-d} & Enable debug-level diagnostics. \\
-\code{--log-level LEVEL} & Set trace through off diagnostic severity. \\
+\code{--log-level LEVEL} & Set diagnostic severity to trace, debug, info, warning, error, critical, or off. \\
 \code{--log-file FILE} & Select the diagnostic log file. \\
 \code{-q} & Suppress status and performance output. \\
 \code{-0} & Disable real-time notifications. \\

--- a/doc/latex_manuals/BECurrentGuide.tex
+++ b/doc/latex_manuals/BECurrentGuide.tex
@@ -254,7 +254,7 @@ cannot be read are diagnosed and skipped. Do not use \code{-R} on a directory
 that represents the segments of one image.
 
 On Windows, supported raw-device forms include \code{C:},
-\code{\\\\.\\PhysicalDriveN}, \code{\\\\.\\X:}, and a named volume path
+\verb|\\.\PhysicalDriveN|, \verb|\\.\X:|, and a named volume path
 without its trailing mounted-directory backslash. Raw devices normally require
 an elevated command prompt. They are opened read-only; the examiner remains
 responsible for appropriate evidence-handling procedures and write protection.

--- a/doc/latex_manuals/BECurrentGuide.tex
+++ b/doc/latex_manuals/BECurrentGuide.tex
@@ -1,50 +1,711 @@
 \documentclass[11pt]{article}
 \usepackage[margin=1in]{geometry}
-\usepackage[hidelinks]{hyperref}
+\usepackage[T1]{fontenc}
+\usepackage{booktabs}
 \usepackage{fancyvrb}
-\title{bulk\_extractor 2.2 Current Operating Guide}
-\author{bulk\_extractor project}
-\date{July 2026}
+\usepackage{graphicx}
+\usepackage{xurl}
+\usepackage[hidelinks]{hyperref}
+\usepackage{longtable}
+\usepackage{listings}
+\usepackage{xspace}
+
+\newcommand{\bulk}{\textit{bulk\_extractor}\xspace}
+\newcommand{\viewer}{\textit{Bulk Extractor Viewer}\xspace}
+\newcommand{\code}[1]{\texttt{#1}}
+\newcommand{\verbbf}[1]{\textbf{#1}}
+\lstdefinestyle{customfile}{basicstyle=\footnotesize\ttfamily,
+  breaklines=true, frame=single}
+
+\title{bulk\_extractor 2.2 User Manual}
+\author{Jessica R. Bradley, Simson L. Garfinkel, and the bulk\_extractor project}
+\date{August 2026}
 
 \begin{document}
 \maketitle
 
-\section*{Scope}
-This guide describes the supported 2.2 command-line workflow.
+\begin{abstract}
+\bulk extracts forensic features from images, devices, files, and directories
+without relying on file-system metadata. This manual restores the operational
+explanations, investigative guidance, worked examples, and historical context
+of the version 1 manuals and updates them for release 2.2. The command-line
+help produced by the installed executable remains authoritative for the exact
+scanners and options in a particular build.
+\end{abstract}
 
-\section*{Build from source}
-Clone the repository or download a release from
-\url{https://github.com/simsong/bulk_extractor/releases}. Install the platform
-dependencies described by the repository README, then run:
+\tableofcontents
+\clearpage
+
+\section{Quick start}
+
+Obtain a disk image or other input that you are authorized to examine. Public
+test images are available from \url{https://digitalcorpora.org/}. Choose a new
+output directory and run:
+
 \begin{Verbatim}
+bulk_extractor -o output mydisk.raw
+\end{Verbatim}
+
+The output directory contains feature files, histograms where enabled, carved
+objects where applicable, a diagnostic log, and \code{report.xml}. Read the
+most frequent features first, but always inspect the feature, its context, and
+its forensic path before drawing a conclusion.
+
+For a directory of ordinary files, add \code{-R}:
+
+\begin{Verbatim}
+bulk_extractor -R -o output evidence-directory
+\end{Verbatim}
+
+Do not use \code{-R} for a directory containing the segments of one E01 or
+split-raw image. Supply the first image segment instead. Run
+\code{bulk\_extractor -H} to see the scanners, defaults, and scanner-specific
+settings compiled into the executable, and \code{bulk\_extractor -h} for the
+current option summary.
+
+\section{Introduction}
+
+\subsection{What bulk\_extractor does}
+
+\bulk extracts email addresses, URLs, domains, telephone numbers, credit-card
+numbers, network information, executable metadata, image metadata, and other
+structured features. It operates on raw or split-raw images, E01 images when
+the build includes libewf, regular files, directories of files, memory images,
+packet captures, and supported raw devices. It does not parse a file system to
+decide which bytes deserve examination.
+
+The program is useful for triage, malware and intrusion investigations,
+identity investigations, cyber investigations, imagery analysis, and the
+creation of word lists for password recovery. Its unusual capabilities
+include:
+
+\begin{itemize}
+\item optimistic decoding and recursive examination of recognized compressed
+  or encoded data, including incomplete data when the decoder can recover it;
+\item parallel processing of independent input pages and concurrent scanners;
+\item tab-delimited feature files suitable for inspection or automated
+  processing;
+\item histograms that bring frequent email addresses, domains, URLs, search
+  terms, and other features to an examiner's attention; and
+\item carving of validated objects, including objects recovered from derived
+  or compressed data.
+\end{itemize}
+
+\subsection{Origins and an early success}
+
+The original requirements came from interviews with law-enforcement examiners
+between 2005 and 2008. They wanted a highly automated tool that could find
+identifiers and investigative leads, process many media formats at storage
+speed, exploit multiple processors, and continue making progress on damaged or
+unusual evidence. That requirement still explains the program's emphasis on
+stream processing, forensic provenance, and simple output.
+
+An early deployment by the City of San Luis Obispo Police Department
+illustrated the value of rapid triage. An examiner received a 250 GB drive the
+day before a preliminary hearing. In roughly two and a half hours the program
+identified more than 10,000 candidate credit-card numbers, the dominant email
+address, search queries concerning credit-card fraud and bank-identification
+numbers, and geographically relevant web activity. Those observations did not
+replace forensic validation; they rapidly directed the examiner to evidence
+that warranted closer review.
+
+\subsection{Scope and conventions}
+
+This manual is for new, intermediate, and experienced users. Program names and
+literal commands appear in fixed-width type. Scanner availability and defaults
+are build-dependent. Examples from the original version 1 manual are retained
+because their investigative method remains useful; captured output and file
+lists in those examples are historical and will not exactly match a 2.2 run.
+
+BEViewer is not bundled with version 2.2. Its version 1 workflow has been moved
+to Appendix~\ref{sec:viewer-history}, both as historical documentation and as
+requirements for the viewer planned for restoration in the 2.x series.
+
+\section{How bulk\_extractor works}
+
+\subsection{Pages, scanners, and recursion}
+
+The input is divided into overlapping pages. Every eligible page is presented
+to the enabled scanners. The overlap, called the \emph{margin}, allows a
+scanner to recognize a feature that begins near the end of one page and
+continues into the next.
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.70\linewidth]{archPics/margindepiction.pdf}
+\caption{Adjacent input pages overlap by a margin.}
+\end{figure}
+
+Scanners receive bounds-checked safe buffers, or \code{sbuf}s. A recursive
+scanner can decode a validated region and return the derived buffer to the
+framework for another pass. This permits, for example, the email scanner to
+find an address in text extracted from a PDF or decompressed from a GZIP
+stream. Depth limits, duplicate detection, buffer characteristics, and scanner
+flags prevent or limit inappropriate recursion.
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.72\linewidth]{archPics/howitworks.pdf}
+\caption{Extraction, feature recording, and post-processing.}
+\end{figure}
+
+\subsection{Feature files}
+
+A feature recorder receives findings from one or more scanners and writes the
+corresponding feature file. A normal row has three tab-separated fields: a
+forensic path, the feature, and surrounding context. A simplified excerpt is:
+
+\begin{Verbatim}[fontsize=\small]
+48198832  domexuser2@gmail.com  <name>domexuser2@gmail.com</name>
+48200361  domexuser2@live.com   <name>domexuser2@live.com</name>
+\end{Verbatim}
+
+The context helps an examiner distinguish a useful feature from a false
+positive. Feature files are UTF-8 text, but individual scanners may use their
+fields to report scanner-specific metadata. Empty feature files are normal:
+they show that a recorder was active but accepted no findings.
+
+\subsection{Histograms}
+
+Histograms summarize selected feature files. Each line begins with the number
+of occurrences, followed by the normalized feature. They are sorted with the
+most frequent feature first:
+
+\begin{Verbatim}[fontsize=\small]
+n=875  mozilla@example.org
+n=651  charlie@m57.biz
+n=186  pat@m57.biz
+\end{Verbatim}
+
+Frequency can reveal a system's principal user, organization, correspondents,
+services, and search interests. A common feature is not necessarily probative,
+and a rare feature is not necessarily irrelevant. Confirm the underlying rows
+and their contexts.
+
+\subsection{Forensic paths}
+
+A byte offset alone cannot describe a feature recovered from transformed
+data. A forensic path records the original location and the transformations
+used to reach the feature. For example:
+
+\begin{Verbatim}[fontsize=\small]
+11052168704-GZIP-3437  live.com  domexuser@live.com
+\end{Verbatim}
+
+This means the feature was found at offset 3437 within data decompressed from a
+GZIP object beginning at source offset 11052168704. Paths may contain several
+transformations. Preserve the entire path when recording or citing a finding;
+the path is the link back to the source evidence.
+
+\section{Installing bulk\_extractor 2.2}
+
+\subsection{Release archive or Git checkout}
+
+Prefer a tested release from
+\url{https://github.com/simsong/bulk_extractor/releases}. A release archive
+already contains \code{configure}:
+
+\begin{Verbatim}
+./configure
+make
+make check
+sudo make install
+\end{Verbatim}
+
+A Git checkout requires the bootstrap step:
+
+\begin{Verbatim}
+git clone https://github.com/simsong/bulk_extractor.git
+cd bulk_extractor
 bash bootstrap.sh
 ./configure
 make
 make check
 sudo make install
 \end{Verbatim}
-The README is the canonical build and platform-support reference. Native
-Windows builds are not supported. The repository's Windows MinGW workflow
-cross-compiles a standalone \texttt{bulk\_extractor64.exe} on Ubuntu for each
-pull request. Download it from the Windows workflow artifact; it is not a
-signed installer or release distribution. The workflow verifies the PE imports
-and runs the executable on a Windows runner against a Unicode-named input file.
 
-\section*{Run a scan}
-Choose a new output directory and an input image or file:
+The README and installation wiki are the maintained dependency references.
+Release 2.2 requires C++17. Optional libraries affect available input formats
+and scanners; read the final \code{configure} summary and check \code{-H} on
+the resulting executable.
+
+\subsection{Windows}
+
+Native Windows builds and the old signed installer are not supported in 2.2.
+The project's Windows MinGW workflow cross-compiles a standalone
+\code{bulk\_extractor64.exe} on Ubuntu and validates it on a Windows runner.
+The workflow artifact is not a signed installer or release distribution, and
+the current artifact is built without E01 support. A release manager may
+attach the validated executable to the 2.2 release.
+
+\section{Running a scan}
+
+\subsection{Input data}
+
+Supply one image, file, device, or directory. Raw and split-raw images are
+supported. E01 support is present when the executable was built with libewf.
+Memory images and packet captures can be scanned directly; a protocol-aware
+tool such as \code{tcpflow} may provide more complete reconstruction of
+application streams before those reconstructed files are scanned.
+
+With \code{-R}, ordinary files below a directory are visited recursively in a
+deterministic order. Symlinks are not followed as directories, and paths that
+cannot be read are diagnosed and skipped. Do not use \code{-R} on a directory
+that represents the segments of one image.
+
+On Windows, supported raw-device forms include \code{C:},
+\code{\\\\.\\PhysicalDriveN}, \code{\\\\.\\X:}, and a named volume path
+without its trailing mounted-directory backslash. Raw devices normally require
+an elevated command prompt. They are opened read-only; the examiner remains
+responsible for appropriate evidence-handling procedures and write protection.
+
+\subsection{Output and resuming}
+
+The \code{-o} option is always required. A new scan normally uses a new output
+directory. If an existing output directory contains \code{report.xml}, 2.2
+resumes the interrupted scan. Pages recorded as in progress are deliberately
+skipped so that a repeatable data-dependent crash is not immediately repeated.
+The interrupted report is archived and the program reports how many pages were
+skipped.
+
+Use \code{-Z} only when you intend to remove the existing output contents and
+start over. It removes nested files and directories beneath the selected
+output directory. A completed output normally contains:
+
+\begin{itemize}
+\item feature files such as \code{email.txt}, \code{url.txt}, or
+  \code{winpe.txt};
+\item histogram files declared by enabled scanners;
+\item \code{report.xml}, containing DFXML provenance, configuration, timing,
+  scanner, and source information;
+\item \code{bulk\_extractor.log}, unless another log destination was chosen;
+\item \code{alerts.txt} when an alert list matches; and
+\item carving directories and their corresponding feature files when carving
+  is enabled and validated objects are found.
+\end{itemize}
+
+\subsection{Scanner selection and settings}
+
+Run \code{bulk\_extractor -H} to list the actual scanners and their settings.
+Scanners can cooperate: disabling a decoder can prevent another scanner from
+seeing features inside the decoded data.
+
 \begin{Verbatim}
-bulk_extractor -o output mydisk.raw
+bulk_extractor -e wordlist -o output image.raw
+bulk_extractor -x accts -o output image.raw
+bulk_extractor -E aes -o output image.raw
+bulk_extractor -x all -e aes -o output image.raw
+bulk_extractor -S name=value -o output image.raw
 \end{Verbatim}
-Use \texttt{bulk\_extractor --help} on the installed binary as the authoritative
-reference for options and scanner settings. A scan produces feature files,
-histograms where enabled, carved content where applicable, and DFXML run
-metadata in the output directory.
 
-\section*{Develop scanners}
-The maintained scanner contract is
-\url{https://github.com/simsong/bulk_extractor/blob/main/doc/scanner_api.md}.
-Read it before changing a built-in scanner or starting a loadable scanner, and
-begin from \texttt{doc/scanner\_template.cpp}. It documents the 2.x lifecycle,
-concurrency requirements, feature-recorder rules, and module factory.
+\code{-e} enables a scanner, \code{-x} disables one, and \code{-E} selects
+one scanner exclusively. Options may be repeated. The \code{-S} names are not
+a stable global list; they are declared by the scanners and feature recorders
+in a specific build. Use \code{-H}, not the version 1 settable-options file,
+as the 2.2 authority.
+
+Common scanner families include account and identifier scanners; email,
+domain, URL, and RFC822 scanners; network scanners; executable and Windows
+artifact scanners; image and metadata scanners; structured-data scanners; and
+decoders for compressed or encoded input. The word-list scanner remains
+disabled by default because of its output volume and cost. Outlook and
+hibernation processing may also be disabled by default pending stronger tests.
+
+\subsection{Searching for investigator-supplied patterns}
+
+Use \code{-f} for one RE2 pattern or \code{-F} for a file of patterns. Pattern
+matching is case-insensitive unless \code{--find-case-sensitive} is supplied:
+
+\begin{Verbatim}
+bulk_extractor -F findlist.txt -o output image.raw
+bulk_extractor --find-case-sensitive -f 'Project[ -]?Name' \
+  -o output image.raw
+\end{Verbatim}
+
+The old Lightgrep-specific workflow is not supported in 2.2. Lightgrep remains
+an optional, source-broken configuration and must not be assumed present.
+
+\subsection{Carving}
+
+Carving is configured per feature recorder:
+
+\begin{Verbatim}
+bulk_extractor -S jpeg_carve_mode=2 -o output image.raw
+\end{Verbatim}
+
+Mode 0 disables carving, mode 1 carves objects reached through an encoded or
+derived path, and mode 2 carves every object accepted by that recorder, subject
+to validation, deduplication, and size limits. JPEG and RAR recorders default
+to mode 1; \code{zip\_carved} and \code{sqlite\_carved} default to mode 2.
+There is no global carve-mode switch. Consult \code{doc/carving.md} and
+\code{-H} for current recorder names, defaults, and size settings.
+
+Carving does not reconstruct a file system. It writes byte sequences accepted
+by a scanner's validator. Treat carved extensions and filenames as analytical
+conveniences, not proof of the original filename or allocation state.
+
+\section{Reducing noise and highlighting evidence}
+
+\subsection{Stop lists}
+
+Operating systems, applications, and sample data contain many common email
+addresses, domains, and other features that are irrelevant to a particular
+case. A stop list supplied with \code{-w} diverts matching features out of the
+normal feature file. Stopped results are retained in the corresponding
+\code{\_stopped.txt} file so the examiner can audit what was suppressed.
+
+Each non-comment line may be a literal feature or a context-sensitive record.
+Use feature-file-format input when context matters, and test a new list against
+known data before relying on it. A stop list improves review efficiency; it
+does not prove that the suppressed item is harmless.
+
+\begin{Verbatim}
+bulk_extractor -w stoplist.txt -o output image.raw
+\end{Verbatim}
+
+\subsection{Alert lists and banners}
+
+An alert list supplied with \code{-r} identifies words or features that should
+also be recorded in \code{alerts.txt}. Context-sensitive entries can limit an
+alert to the specified surrounding evidence. An alert is an investigative
+lead, not a conclusion.
+
+\begin{Verbatim}
+bulk_extractor -r alertlist.txt -o output image.raw
+\end{Verbatim}
+
+In classified or otherwise specialized environments, \code{-b banner.txt}
+prepends a required banner to feature files. The banner is preserved in normal,
+stopped, alert, and histogram-related output paths.
+
+\section{Why compressed and encoded data matter}
+
+Unallocated space and damaged media often contain fragments of compressed or
+encoded objects. A file-system-oriented tool may not associate those fragments
+with a live file. \bulk probes the byte stream for supported signatures and
+attempts to decode recoverable data. Derived buffers are recursively examined
+by the scanner set, which can reveal features unavailable in the original byte
+representation.
+
+ZIP, GZIP, PDF text streams, Base16, Base64, RAR versions 1 through 3, and
+Microsoft XPress hibernation data are examples of supported or scanner-specific
+transformations. Availability and default enablement vary. The RAR decoder does
+not handle every archive or UTF-8 component name. Recursive depth, decoded-size
+limits, duplicate suppression, and allocation-failure limits protect against
+unbounded expansion and decompression bombs.
+
+\section{Investigation-oriented use cases}
+
+\subsection{Digital-media triage}
+
+Begin with histograms and the feature files most closely related to the case.
+Look for dominant identities, organizations, services, and communication
+patterns. Validate high-value rows in context, then use their forensic paths to
+locate the source. Triage prioritizes examination; it does not replace a
+complete forensic process when one is required.
+
+\subsection{Malware and intrusion investigations}
+
+Useful outputs may include Windows PE and ELF metadata, URLs and domains,
+network addresses and packets, JSON, Windows directory records, link and
+prefetch data, and AES key schedules. Carved executables or structured objects
+should be validated with format-aware tools. Network feature files contain
+false positives, particularly when arbitrary memory resembles packet data;
+checksum and context information are important.
+
+\subsection{Cyber and network investigations}
+
+The network scanner can report Ethernet, WiFi, IP, and TCP information and may
+carve PCAP data. Release 2.2 preserves IEEE 802.11 link types and reports WiFi
+metadata in \code{wifi.txt}. Features recovered from memory or unstructured
+data may be incomplete. Correlate them with packet captures, logs, timestamps,
+and other evidence.
+
+\subsection{Identity investigations}
+
+Email addresses, domains, URLs, telephone numbers, credit-card candidates,
+personal identifiers, vCards, GPS information, and investigator-supplied search
+patterns can help identify a person and their associates. Credit-card and
+telephone patterns produce false positives; checksums reduce but do not
+eliminate them. Histograms are particularly useful for distinguishing repeated
+identifiers from isolated byte patterns.
+
+\subsection{Password recovery}
+
+The word-list scanner extracts words within its configured length limits from
+ordinary and recursively decoded data. Enable it explicitly:
+
+\begin{Verbatim}
+bulk_extractor -e wordlist -o output image.raw
+\end{Verbatim}
+
+The resulting lists can seed authorized password-recovery tools. Expect large
+outputs and increased processing time. Review \code{-H} for the current minimum
+and maximum word lengths and related settings.
+
+\subsection{Imagery and geolocation}
+
+The EXIF scanner recognizes JPEG metadata, reports EXIF and GPS features, and
+can carve validated JPEGs. A finding can survive even when part of the image is
+damaged. Carving mode 1 is designed to emphasize images reached through a
+derived path; mode 2 requests all validated images. The optional Exiv2 scanner
+is disabled unless the build was configured with its dependency.
+
+\section{Tuning and specialized operation}
+
+The defaults are appropriate for most examinations. \bulk normally chooses a
+worker count based on the host. Use \code{-j N} to limit workers or \code{-J}
+to process without worker threads. More threads help only while CPU and storage
+can supply useful work; benchmark the actual image and scanner set before
+changing a production procedure.
+
+\code{-G} changes the primary page size, and \code{-g} changes the margin.
+The margin must be large enough for scanners to recognize boundary-spanning
+features. \code{-M} limits recursive depth. \code{-s} performs random
+sampling, \code{-Y} selects an offset range, and \code{-z} begins at a page.
+Sampling is useful for research and rapid characterization but cannot establish
+that an unsampled feature is absent.
+
+\code{--max\_minute\_wait} bounds phase-one completion and shutdown.
+\code{--max\_bad\_alloc\_errors} controls tolerated allocation failures.
+Use \code{-q} for quiet operation. \code{-d} enables debug-level logging; the
+old numeric debug mask no longer exists. \code{--log-level} and
+\code{--log-file} provide explicit diagnostic control.
+
+\section{Post-processing}
+
+The \code{python/} directory contains scripts that consume reports and feature
+files. They are useful project tools, but they do not receive the same release
+and compatibility guarantees as the primary executable.
+
+\subsection{Comparing two runs}
+
+\code{bulk\_diff.py} compares two output directories and reports differences
+in their feature files. This can show what appeared or disappeared between two
+acquisitions:
+
+\begin{Verbatim}
+python3 python/bulk_diff.py pre-output post-output
+\end{Verbatim}
+
+Differences can result from evidence changes, scanner configuration, software
+version, or build dependencies. Record all of these before attributing a
+difference to user activity.
+
+\subsection{Associating features with filenames}
+
+\code{identify\_filenames.py} combines feature locations with file-system
+information, normally produced by \code{fiwalk}, to identify the containing
+file where possible:
+
+\begin{Verbatim}
+python3 python/identify_filenames.py --all bulk-output identified-output
+\end{Verbatim}
+
+A feature in unallocated space, compressed data, or a damaged structure may
+have no recoverable filename. The forensic path remains the primary provenance
+record.
+
+\section{Worked investigations}
+\label{sec:worked-examples}
+
+The following version 1 case studies are retained because the analytical
+questions, feature interpretation, false-positive cautions, and use of
+histograms remain applicable. Their captured console output, exact runtime,
+scanner inventory, and directory listings are historical. Run the 2.2 commands
+described earlier in this manual and expect the current executable to produce a
+different set of files and status messages.
+
+\begingroup
+\sloppy
+\input{BEWorkedExamples.tex}
+\endgroup
+
+\section{Troubleshooting}
+
+\subsection{A scan stops or crashes}
+
+Re-run the same command against the same output directory to use 2.2 resume
+behavior. The framework skips pages that were in progress when the previous
+run ended, records the restart, and continues with later pages. Do not use
+\code{-Z} if the existing partial results and restart record must be preserved.
+
+Check \code{bulk\_extractor.log}, terminal diagnostics, free disk space,
+\code{report.xml}, and the archived interrupted report. If the failure follows
+one scanner, isolate it with \code{-x all -e scanner}. A reproducible report
+should include the exact version, build configuration, command, scanner,
+forensic path or byte range, exit status, and the smallest redistributable
+fixture that demonstrates the problem. Do not submit sensitive evidence.
+
+\subsection{The output disk fills}
+
+Feature files, word lists, histograms, decoded data, and carved objects can be
+large. A write failure stops normal shutdown and histogram completion so the
+program does not report a clean run after losing output. Preserve the log and
+partial report, choose storage with adequate free space, and start an
+independent scan in a new output directory.
+
+\subsection{Unexpected, missing, or duplicate findings}
+
+Confirm the scanner is present and enabled with \code{-H}. Check stop lists,
+carve modes, recursive depth, page and margin settings, input-format support,
+and whether the feature came from a derived path. Isolate the scanner on a
+small fixture. A feature at a page boundary should be reported according to the
+framework's margin rules; changing page or margin sizes can expose scanner
+defects and should be mentioned in a bug report.
+
+\subsection{Getting help and reporting defects}
+
+Use the GitHub issue tracker at
+\url{https://github.com/simsong/bulk_extractor/issues}. Search existing issues
+first. Include enough non-sensitive evidence to reproduce the behavior and
+distinguish a source defect from a missing optional dependency or unsupported
+platform.
+
+\appendix
+\clearpage
+\section{BEViewer in version 1 and planned restoration}
+\label{sec:viewer-history}
+
+\textbf{Historical status.} The Java-based BEViewer described in this appendix
+worked with the version 1 product. It is not bundled, built, tested, or
+supported by the 2.2 release. The project intends to restore viewer capability
+in the 2.x series. This appendix preserves the former workflow and the user
+capabilities that a restored viewer should provide; it is not an instruction
+to install the old viewer with 2.2.
+
+\subsection{Version 1 installation and startup}
+
+The version 1 Windows installer installed both the command-line executable and
+BEViewer and required Java 6 or later. Linux and macOS source distributions
+contained a \code{java\_gui} directory and launched the viewer with
+\code{./BEViewer}. Windows launched a 32- or 64-bit viewer entry from the Start
+menu. These installers and launch paths do not exist in 2.2.
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.82\linewidth]{viewerPics/startup.png}
+\caption{Historical BEViewer start window.}
+\end{figure}
+
+\subsection{Launching a scan}
+
+The version 1 viewer exposed the command-line workflow through a gear-and-arrow
+control. The examiner selected an image and a new output feature directory,
+optionally adjusted scanner or tuning options, and pressed ``Start
+bulk\_extractor.'' A status window displayed progress and completion.
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.76\linewidth]{viewerPics/runBulk.png}
+\caption{Historical scan configuration window.}
+\end{figure}
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.76\linewidth]{viewerPics/selectOutputDirectory.png}
+\caption{Historical image and output-directory selection.}
+\end{figure}
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.70\linewidth]{viewerPics/runCompleteStatus.png}
+\caption{Historical scan-progress window.}
+\end{figure}
+
+\subsection{Browsing reports, features, and histograms}
+
+After completion, the viewer added the report to a report tree. Expanding the
+report displayed feature and histogram files. Selecting a feature displayed
+its context; selecting a histogram entry connected the frequency summary to
+the underlying feature rows and their contexts. This linked navigation was a
+central usability feature and should be preserved in a 2.x replacement.
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.72\linewidth]{viewerPics/listOfOutput.png}
+\caption{Historical report and output-file tree.}
+\end{figure}
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.82\linewidth]{viewerPics/emailFeatureFile.png}
+\caption{Historical feature and context view.}
+\end{figure}
+
+\begin{figure}[ht]
+\centering
+\includegraphics[width=.82\linewidth]{viewerPics/emailHistogramView.png}
+\caption{Historical histogram linked to feature context.}
+\end{figure}
+
+A restored viewer should at minimum open an existing 2.x report, enumerate its
+feature, stopped, alert, histogram, and carving outputs, preserve forensic
+paths, show feature context safely, link histograms to underlying features,
+launch the installed executable without hiding its exact command, display logs
+and progress, and represent resume behavior and scanner settings accurately.
+
+\section{Command-line reference}
+
+This appendix groups the 2.2 options so the information formerly printed in
+the manual is available in the PDF. \code{bulk\_extractor -h}, \code{-H}, and
+the installed \code{bulk\_extractor(1)} manual are authoritative.
+
+\begin{longtable}{p{.29\linewidth}p{.65\linewidth}}
+\toprule
+\textbf{Option} & \textbf{Purpose} \\
+\midrule
+\endfirsthead
+\toprule
+\textbf{Option} & \textbf{Purpose} \\
+\midrule
+\endhead
+\code{-o DIR} & Required output directory. \\
+\code{-R} & Recursively scan ordinary files below a directory. \\
+\code{-Z} & Remove existing output contents before scanning. \\
+\code{-Y START[-END]} & Scan a byte-offset range. \\
+\code{-z PAGE} & Begin at a page number. \\
+\code{-p PATH} & Print a forensic path instead of running a normal scan. \\
+\code{-A BYTES} & Add a value to reported feature locations. \\
+\code{-b FILE} & Prepend a banner to feature files. \\
+\code{-r FILE} & Read an alert list. \\
+\code{-w FILE} & Read a stop list. \\
+\code{-e NAME} & Enable a scanner. \\
+\code{-x NAME} & Disable a scanner; \code{-x all} disables all scanners. \\
+\code{-E NAME} & Disable all scanners except one. \\
+\code{-P DIR} & Add a loadable-scanner directory. \\
+\code{-S NAME=VALUE} & Set a scanner or recorder option reported by \code{-H}. \\
+\code{-f PATTERN} & Search for one RE2 pattern. \\
+\code{-F FILE} & Read search patterns from a file. \\
+\code{--find-case-sensitive} & Make \code{-f} and \code{-F} patterns case-sensitive. \\
+\code{-j N} & Use N worker threads. \\
+\code{-J} & Process without worker threads. \\
+\code{-G BYTES} & Set the primary page size. \\
+\code{-g BYTES} & Set the page margin. \\
+\code{-M N} & Set maximum recursive depth. \\
+\code{-s FRACTION[:PASSES]} & Randomly sample the input. \\
+\code{--max\_minute\_wait N} & Bound processing and shutdown wait time. \\
+\code{--max\_bad\_alloc\_errors N} & Set tolerated allocation failures. \\
+\code{-d} & Enable debug-level diagnostics. \\
+\code{--log-level LEVEL} & Set trace through off diagnostic severity. \\
+\code{--log-file FILE} & Select the diagnostic log file. \\
+\code{-q} & Suppress status and performance output. \\
+\code{-0} & Disable real-time notifications. \\
+\code{-1} & Use version-1-style console notifications. \\
+\code{-H} & Report scanners and their \code{-S} settings. \\
+\code{-V} & Print the version. \\
+\code{-h} & Print command-line help. \\
+\bottomrule
+\end{longtable}
+
+\section{Related reading}
+
+The project README, \code{doc/carving.md}, \code{doc/logging.md}, release
+notes, scanner API, and Digital Corpora test images supplement this manual.
+Research on bulk data analysis, forensic paths, DFXML, decompression, and
+digital-media triage provides the design and evidentiary context for the tool.
+
+\bibliographystyle{plain}
+\bibliography{references}
 
 \end{document}

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -203,9 +203,9 @@ n=4952	www.microsoft.com
 n=4470	patft.uspto.gov
 \end{lstlisting}
 
-Many of these domains are part of the operating system, such as openoffice.org, but some are not, such as www.uspto.gov. The histogram file provides insight into the users activity on the machine and which sites they were most frequently visiting. \\
+Many of these domains are part of the operating system, such as openoffice.org, but some are not, such as www.uspto.gov. The histogram file provides insight into the user's activity on the machine and which sites they were most frequently visiting. \\
 
-The file \texttt{rfc822.txt} primarily provides email headers and HTTP headers both of which are in a format specified by RFC822, the Internet Message Standard. It can be useful to see the subject of emails that have been sent and information form HTTP requests. The following is an excerpt from the text file:
+The file \texttt{rfc822.txt} primarily provides email headers and HTTP headers both of which are in a format specified by RFC822, the Internet Message Standard. It can be useful to see the subject of emails that have been sent and information from HTTP requests. The following is an excerpt from the text file:
 \lstset{style=customfile}
 \begin{lstlisting}
 114074196 SUBJECT:softabs	ll|micro)\x5CW?cap\x00SUBJECT:softabs\x00SUBJECT:Caili
@@ -217,7 +217,7 @@ SUBJECT:st0ck\x00\x00\x00SUBJECT:Your Personal Quarantine Folder\x00SUBJECT:role
 \end{lstlisting}
 Much of what is found in the file shown above are spam messages.\\
 
-Telephone numbers found on the disk image are stored in \texttt{telephone.txt}. This following numbers found in the file are clearly for technical support (found within installed software):
+Telephone numbers found on the disk image are stored in \texttt{telephone.txt}. The following numbers found in the file are clearly for technical support (found within installed software):
 \lstset{style=customfile}
 \begin{lstlisting}
 88850883 (800) 563-9048 rmation centre: (800) 563-9048\x0D\x0A<BR><b><i>Tech

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -136,13 +136,13 @@ In this example, we look at the \texttt{charlie-2009-12-11.E01} image to quickly
 \begin{itemize}
 \item Who are the users of the drive?
 \item Who is this person communicating with?
-\item What kinds of websites have they have been visiting most often?
+\item What kinds of websites have they been visiting most often?
 \item What search terms are used?
 \end{itemize}
 
-To answer many of these questions, we look at the identify information on the drive including email addresses, credit card information, search terms, Facebook IDs, domain names and vCard data. The output files created by \bulk contain all of this type of information that was found on the disk image. \\
+To answer many of these questions, we look at the identity information on the drive including email addresses, credit card information, search terms, Facebook IDs, domain names and vCard data. The output files created by \bulk contain all of this type of information that was found on the disk image. \\
 
-The scenario setup leads us to believe that Charlie is the user of the this drive (based on the name of the disk image). First, we look at \texttt{email.txt} to find information about the email addresses contained on the disk. The first two lines of the email features found are the following (each block of text represents one long line of offset, feature and context):
+The scenario setup leads us to believe that Charlie is the user of this drive (based on the name of the disk image). First, we look at \texttt{email.txt} to find information about the email addresses contained on the disk. The first two lines of the email features found are the following (each block of text represents one long line of offset, feature and context):
 \lstset{style=customfile}
 \begin{lstlisting}
 50395384	n\x00o\x00m\x00b\x00r\x00e\x00_\x001\x002\x003\x00@\x00h\x00o\x00t
@@ -734,7 +734,7 @@ XP</os><filename>MSIEXEC.EXE</filename><header_size>152</header_size>
 </file><file>\x5CDEVICE\x5CHARDDISKVOLUME1\x5CWINDOWS\x5CSYSTEM32\x5CKERNEL32.DLL
 ...
 \end{lstlisting}
-Printing the line out here would cover almost two pages. It includes a lot of information about the Prefetch file including the name of the executable, the name of the DLLs, the directory of DLLs, the atime, the number of runs, the serial number, and the ctime. The Prefetch file is searchable and useable by investigators searching for EXEs or DLLs related to a malware investigation.\\
+Printing the line out here would cover almost two pages. It includes a lot of information about the Prefetch file including the name of the executable, the name of the DLLs, the directory of DLLs, the atime, the number of runs, the serial number, and the ctime. The Prefetch file is searchable and usable by investigators searching for EXEs or DLLs related to a malware investigation.\\
 
 JSON is the JavaScript Object Notation (used in Facebook, etc). The file \texttt{json.txt}  provides the offset, JSON and MD5 hash of the JSON information found on the disk image. \bulk is great at finding JSON in compressed streams and HIBER files. The following are a few lines from the JSON file:
 \lstset{style=customfile}

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -1,0 +1,829 @@
+The worked examples illustrate how to use \bulk output to answer specific
+questions and conduct investigations. Each uses a public dataset that readers
+can obtain from Digital Corpora. The screen captures, scanner inventories,
+runtime measurements, and output listings were produced by version 1.4 and are
+preserved as historical evidence. Re-run the examples with the 2.2 commands in
+the main text; do not expect byte-for-byte identical output.
+
+\subsection {Encoding}
+\newcommand\charpicture[1]{\raisebox{-2pt}[0pt][0pt]{\includegraphics[height=11pt]{#1}}}
+We describe the encoding system here in order to prepare users to view
+the feature files produced by \bulk. Unicode is the international
+standard used by all modern computer systems to define a mapping
+between information stored inside a computer and the letters, digits,
+and symbols that are displayed on the screens or printed on
+paper. UTF-8 is a variable width encoding that can represent every
+character in the Unicode character set. It was designed for backward
+compatibility with ASCII and to avoid the complications of endianness
+and byte order marks in UTF-16 and UTF-32. Feature files in \bulk are
+all coded in UTF-8 format. This means that the odd looking symbols,
+such as accented characters (\`{e} ), funny symbols
+(\charpicture{otherPics/U+2234}) and the occasional Chinese
+character (\charpicture{otherPics/U+611B}) that may show up in the
+files are legitimate. Glyphs from language, for example, Cyrillic
+(\charpicture{otherPics/U+0428}) or Arabic (\charpicture{otherPics/U+062D}) may show up in features files as all
+foreign languages can be coded in UTF-8 format. It is perfectly
+appropriate and typical to open up a feature file and see characters
+that the user may not recognize.\\
+
+\section{2009-M57 Patents Scenario}
+The 2009-M57-Patents scenario tracks the first four weeks of corporate history of the (fictional) M57 Patents company. The company started operation on Friday, November 13th, 2009, and ceased operation on Saturday, December 12, 2009. This specific scenario was built to be used as a teaching tool both as a disk forensics exercise and as a network forensics exercise. The scenario data is also useful for computer forensics research because the hard drive of each computer and each computers memory were imaged every day. In this example, we are not particularly interested in the exercises related to illegal activity, exfiltration and eavesdropping; they do however provide interesting components for us to examine in the example data\cite{m57scenario}.
+
+\subsection{Run \bulk with the Data}
+For this example, we downloaded and utilized one of the disk images from the 2009-M57-Patents Scenario. Those images are available at \url{http://digitalcorpora.org/corp/nps/scenarios/2009-m57-patents/drives-redacted/}. The file used throughout this example is called \texttt{charlie-2009-12-11.E01}. Running \bulk on the command line produces the following output (text input by the user is bold):\\
+
+\begingroup
+\footnotesize
+\texttt{C:\textbackslash bulk\_extractor\textgreater \textbf{bulk\_extractor -o ../Output/charlie-2009-12-11 charlie-2009-12-11.E01}}
+\endgroup
+\begingroup
+\footnotesize
+\begin{Verbatim}[fontfamily=courier, commandchars=\\\{\}]
+bulk_extractor version: 1.4.0
+Input file: charlie-2009-12-11.E01
+Output directory: ../Output/charlie-2009-12-11
+Disk Size: 10239860736
+Threads: 4
+ 8:02:08 Offset 67MB (0.66%) Done in  1:21:23 at 09:23:31
+ 8:02:34 Offset 150MB (1.47%) Done in  1:05:18 at 09:07:52
+ 8:03:03 Offset 234MB (2.29%) Done in  1:01:39 at 09:04:42
+ 8:03:49 Offset 318MB (3.11%) Done in  1:09:19 at 09:13:08
+...
+9:06:23 Offset 10049MB (98.14%) Done in  0:01:13 at 09:07:36
+9:06:59 Offset 10133MB (98.96%) Done in  0:00:41 at 09:07:40
+9:07:29 Offset 10217MB (99.78%) Done in  0:00:08 at 09:07:37
+
+All data are read; waiting for threads to finish...
+Time elapsed waiting for 4 threads to finish:
+     (timeout in 60 min .)
+Time elapsed waiting for 3 threads to finish:
+    7 sec (timeout in 59 min 53 sec.)
+Thread 0: Processing 10200547328
+Thread 2: Processing 10217324544
+Thread 3: Processing 10234101760
+
+Time elapsed waiting for 2 threads to finish:
+    13 sec (timeout in 59 min 47 sec.)
+Thread 0: Processing 10200547328
+Thread 2: Processing 10217324544
+
+All Threads Finished!
+Producer time spent waiting: 3645.8 sec.
+Average consumer time spent waiting: 3.67321 sec.
+*******************************************
+** bulk_extractor is probably CPU bound. **
+**    Run on a computer with more cores  **
+**      to get better performance.       **
+*******************************************
+Phase 2. Shutting down scanners
+Phase 3. Creating Histograms
+   ccn histogram...   ccn_track2 histogram...   domain histogram...
+   email histogram...   ether histogram...   find histogram...
+   ip histogram...   lightgrep histogram...   tcp histogram...
+   telephone histogram...   url histogram...   url microsoft-live...
+   url services...   url facebook-address...   url facebook-id...
+   url searches...Elapsed time: 3991.77 sec.
+Overall performance: 2.56524 MBytes/sec
+Total email features found: 15277
+\end{Verbatim}
+\endgroup
+\begin{figure}
+	\center
+	\includegraphics[scale=1.00]{charlieRunOutput.png}
+	\caption{Screenshot from Windows Explorer of the Output Directory Created by the \bulk run}
+	\label{fig:charlieOutput}
+\end{figure}
+All of the results from the \bulk run are stored in the output directory \textit{charlie-2009-12-11}. The contents of that directory after the run include the feature files, histogram files and carved output. Figure ~\ref{fig:charlieOutput} is a screenshot of the Windows output directory. Additionally, the following output shows a list of the files, directories and their sizes under Linux:
+
+\begingroup
+\footnotesize
+\texttt{C:\textbackslash bulk\_extractor\textbackslash charlie-2009-12-11\textgreater \textbf{ls -s -F}}
+\endgroup
+\begingroup
+\footnotesize
+\begin{Verbatim}[fontfamily=courier, commandchars=\\\{\}]
+    1 aes_keys.txt                  0 kml.txt
+    0 alerts.txt                    0 lightgrep.txt
+    4 ccn.txt                       0 lightgrep_histogram.txt
+    1 ccn_histogram.txt           196 packets.pcap
+    0 ccn_track2.txt                1 rar.txt
+    0 ccn_track2_histogram.txt    108 report.xml
+23028 domain.txt                 3728 rfc822.txt
+  192 domain_histogram.txt         20 tcp.txt
+    0 elf.txt                       4 tcp_histogram.txt
+ 1696 email.txt                    60 telephone.txt
+   36 email_histogram.txt           8 telephone_histogram.txt
+   24 ether.txt                 70108 url.txt
+    1 ether_histogram.txt           1 url_facebook-address.txt
+  508 exif.txt                      0 url_facebook-id.txt
+    0 find.txt                   6684 url_histogram.txt
+    0 find_histogram.txt            0 url_microsoft-live.txt
+    0 gps.txt                      12 url_searches.txt
+    0 hex.txt                     156 url_services.txt
+   32 ip.txt                        0 vcard.txt
+    4 ip_histogram.txt          16432 windirs.txt
+   12 jpeg/                     20800 winpe.txt
+  504 jpeg.txt                   1864 winprefetch.txt
+ 1896 json.txt                  29624 zip.txt
+\end{Verbatim}
+\endgroup
+Many of the feature files and histograms are populated with data. Additionally, there were some JPEG files carved and placed in the \textit{jpeg} directory. In the following sections, we demonstrate how to look at these results to discover more information about the disk user and the files contained on the disk image.
+
+\subsection{Digital Media Triage}
+Digital media triage is the process of using the results of a rapid and automated analysis of the media, performed when the media is first encountered to determine if the media is likely to have information of intelligence value and, therefore, should be prioritized for immediate analysis. \bulk performs bulk data analysis to help investigators quickly decide which piece of digital media is the most relevant and useful to an investigation. Thus, \bulk can be used to aid in investigations (through the identification of new leads and social networks) rather than just aiding in conviction-support (through the identification of illegal materials)\cite{digitalmediatriage}.\\
+
+In this example, we look at the \texttt{charlie-2009-12-11.E01} image to quickly assess what kinds of information useful to an investigation might be present on the disk. For the purposes of this example, we will assume we are investigating corporate fraud and trying to discover the answers to the following questions:
+\begin{itemize}
+\item Who are the users of the drive?
+\item Who is this person communicating with?
+\item What kinds of websites have they have been visiting most often?
+\item What search terms are used?
+\end{itemize}
+
+To answer many of these questions, we look at the identify information on the drive including email addresses, credit card information, search terms, Facebook IDs, domain names and vCard data. The output files created by \bulk contain all of this type of information that was found on the disk image. \\
+
+The scenario setup leads us to believe that Charlie is the user of the this drive (based on the name of the disk image). First, we look at \texttt{email.txt} to find information about the email addresses contained on the disk. The first two lines of the email features found are the following (each block of text represents one long line of offset, feature and context):
+\lstset{style=customfile}
+\begin{lstlisting}
+50395384	n\x00o\x00m\x00b\x00r\x00e\x00_\x001\x002\x003\x00@\x00h\x00o\x00t
+\x00m\x00a\x00i\x00l\x00.\x00c\x00o\x00m\x00    e\x00m\x00p\x00l\x00o\x00\x00\x0A\x00
+\x09\x00n\x00o\x00m\x00b\x00r\x00e\x00_\x001\x002\x003\x00@\x00h\x00o\x00t\x00m
+\x00a\x00i\x00l\x00.\x00c\x00o\x00m\x00\x0A\x00\x09\x00m\x00i\x00n\x00o\x00m\x00b\x00
+
+50395432	m\x00i\x00n\x00o\x00m\x00b\x00r\x00e\x00@\x00m\x00s\x00n\x00.\x00c
+\x00o\x00m\x00	i\x00l\x00.\x00c\x00o\x00m\x00\x0A\x00\x09\x00m\x00i\x00n\x00o\x00m
+\x00b \x00r\x00e\x00@\x00m\x00s\x00n\x00.\x00c\x00o\x00m\x00\x0A\x00\x09\x00e\x00j
+\x00e\x00m\x00p\x00l\x00
+\end{lstlisting}
+
+It is important to note that UTF-16 formatted text is escaped with \textbackslash x00. This means that "\textbackslash x00t \textbackslash x00e \textbackslash x00x \textbackslash x00t" translates to "text." The first two features found are "nombre\_123@hotmail.com" and "minombre@msn.com."  Both of the offset values, 50395384 and 50395432, are early on the disk. At this point, there is no way to know if either of these email addresses are of any significance unless they happen to belong to a suspect or person related to the investigation. The first set of email features found appear on the disk printed in UTF-16 formatted text, like the lines above.\\
+
+Further down in the feature file, we find the following:
+\lstset{style=customfile}
+\begin{lstlisting}
+9263459	charlie@m57.biz	21)(88=Charlie <charlie@m57.biz>)(89\x0D\x0A    =Pat
+9263497	pat@m57.biz	    =Pat McGoo <pat@m57.biz>)(8B=WELCOME TO
+\end{lstlisting}
+
+Finding Charlie's email address on the computer begins to further confirm the assumption that this is his computer. The \texttt{email\_histogram.txt} file provides important information. It shows the most frequently occurring email addresses found on the disk. The following is an excerpt from that top of that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=875	mozilla@kewis.ch	(utf16=3)
+n=651	charlie@m57.biz	(utf16=120)
+n=605	ajbanck@planet.nl
+n=411	mikep@oeone.com
+n=395	belhaire@ief.u-psud.fr
+n=379	premium-server@thawte.com	(utf16=11)
+n=356	lilmatt@mozilla.com
+n=312	cedric.corazza@wanadoo.fr
+\end{lstlisting}
+This histogram output shows us that Charlie's email address is the second most frequently occurring name on the disk. It would likely be the first but, as described in the scenario description, this company has only been in business for three weeks and its employees are new users of the computers. Looking at this histogram file also gives us some insight into who the user of this disk is communicating with. Those email addresses occurring most frequently that are not part of the software installed on the machine (such as ajbanck@planet.nl) might indicate addresses of people with whom the drive user is corresponding or they may result from other software or web pages that were downloaded. (In this case, the email is from a Firefox extension.)\\
+
+The file \texttt{domain.txt} provides a list of all the "domains" and host names that were found. The sources include URLS, email and dotted quads. Much of the beginning of the feature file is populated with microsoft.com domains. This is largely due to the fact that the disk image is from a Windows machine. Further down in the file we find the following:
+\lstset{style=customfile}
+\begin{lstlisting}
+53878576	www.uspto.gov	<a href="http://www.uspto.gov/patft/index.htm
+53879083	www.uspto.gov	<A HREF="http://www.uspto.gov/patft/help/help
+53880076	ebiz1.uspto.gov	<A HREF="http://ebiz1.uspto.gov/vision-service/
+53880536	ebiz1.uspto.gov	<A HREF="http://ebiz1.uspto.gov/vision-service/
+\end{lstlisting}
+
+The domains that were found make sense given that the disk image was obtained from a startup company that deals with patents. Many of the domains found in the file are also in UTF-16 format (with "escaped" characters). It is also worth noting as users browse the domain output file that domains are common in compressed data.\\
+
+The \texttt{domain\_histogram.txt} file provides a histogram of the domains found on the disk image. It tends to give us better information for digital media triage than the \texttt{domain.txt} file as it provides information about which domains most frequently appear on the disk image and not just the order in which they were found. The beginning of the histogram file looks like the following:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=10749	www.w3.org
+n=6670	chroniclingamerica.loc.gov
+n=6384	openoffice.org
+n=5998	www.uspto.gov
+n=5733	www.mozilla.org
+n=5212	www.osti.gov
+n=4952	www.microsoft.com
+n=4470	patft.uspto.gov
+\end{lstlisting}
+
+Many of these domains are part of the operating system, such as openoffice.org, but some are not, such as www.uspto.gov. The histogram file provides insight into the users activity on the machine and which sites they were most frequently visiting. \\
+
+The file \texttt{rfc822.txt} primarily provides email headers and HTTP headers both of which are in a format specified by RFC822, the Internet Message Standard. It can be useful to see the subject of emails that have been sent and information form HTTP requests. The following is an excerpt from the text file:
+\lstset{style=customfile}
+\begin{lstlisting}
+114074196 SUBJECT:softabs	ll|micro)\x5CW?cap\x00SUBJECT:softabs\x00SUBJECT:Caili
+114074212 SUBJECT:Cailis	SUBJECT:softabs\x00SUBJECT:Cailis\x00\x00SUBJECT:st0ck
+114074228 SUBJECT:st0ck	SUBJECT:Cailis\x00\x00SUBJECT:st0ck\x00\x00\x00SUBJECT:Your
+114074244 SUBJECT:Your Personal Quarantine Folder
+SUBJECT:st0ck\x00\x00\x00SUBJECT:Your Personal Quarantine Folder\x00SUBJECT:rolex\x00
+114074284	SUBJECT:rolex arantine Folder\x00SUBJECT:rolex\x00\x00\x00SUBJECT:(bro
+\end{lstlisting}
+Much of what is found in the file shown above are spam messages.\\
+
+Telephone numbers found on the disk image are stored in \texttt{telephone.txt}. This following numbers found in the file are clearly for technical support (found within installed software):
+\lstset{style=customfile}
+\begin{lstlisting}
+88850883 (800) 563-9048 rmation centre: (800) 563-9048\x0D\x0A<BR><b><i>Tech
+88850995 (905) 568-4494 indows&nbsp;95: (905) 568-4494\x0D\x0A<BR> Microsoft
+88851056 (905) 568-2294 ice components: (905) 568-2294\x0D\x0A<BR> Other sta
+88851111 (905) 568-3503 hnical support: (905) 568-3503\x0D\x0A<BR> Priority
+88851162 (800) 668-7975 rt information: (800) 668-7975\x0D\x0A<BR> Text Tele
+\end{lstlisting}
+The next set of "telephone" numbers are clearly bogus numbers:
+\lstset{style=customfile}
+\begin{lstlisting}
+3649684174 008-017-0108 WA,98366,1,4031-008-017-0108,City of Port Or
+3649684741 000-031-0009 98337,0.13,3768-000-031-0009,Kitsap County C
+3649818237 000-001-0005 8312,2.25,"3768-000-001-0005, 3768-000-003-0
+3649818274 000-004-0002 0-003-003, 3768-000-004-0002, 3768-000-005-0
+\end{lstlisting}
+Finally, many of the numbers found are legitimate ones. These numbers were all found in GZIP compressed data:
+\lstset{style=customfile}
+\begin{lstlisting}
+3772517888-GZIP-28322 (831) 373-5555 onterey - <nobr>(831) 373-5555</nobr><br><a cl
+3772517888-GZIP-29518 (831) 899-8300 Seaside - <nobr>(831) 899-8300</nobr><br><a cl
+3772517888-GZIP-31176 (831) 899-8300 Seaside - <nobr>(831) 899-8300</nobr><br><a cl
+\end{lstlisting}
+Typically, the file \texttt{telephone\_histogram.txt} is the best place to look for phone numbers. In this file, the non-digits are extracted from the phone numbers. The following is an excerpt from the beginning of that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=42	+14159618830
+n=35	8477180400
+n=24	+27112570000
+n=24	2225552222
+n=18	8005043248
+n=15	2225551111
+n=13	8662347350
+n=12	8772768437
+n=11	2522277013
+\end{lstlisting}
+Investigators looking for specific information about the user of a disk image or who they have been communicating with can look quickly at this file and see how frequently numbers appear. It also consolidates the numbers in a way that makes it easy for investigators looking for a specific number or set of numbers to see them quickly.\\
+
+Finally, in performing digital media triage on the disk image, investigators would like to know what specific URLs have been visited and what search terms the user has been using. The set of URL files provided as output provide insight into this information. First, \texttt{url.txt} contains the URLs found on the disk. The following is an excerpt from that file (note that the UTF-16 formatted information is escaped):
+\lstset{style=customfile}
+\begin{lstlisting}
+175165385 http://www.unicode.org/reports/tr25/#_TocDelimiters E and U+23DF:\x0A#
+http://www.unicode.org/reports/tr25/#_TocDelimiters\x0A\x5Cu23DE = \x5CuE13B
+
+159045397 h\x00t\x00t\x00p\x00:\x00/\x00/\x00w\x00w\x00w\x00.\x00d\x00o\x00w
+\x00n\x00l\x00o\x00a\x00d\x00.\x00w\x00i\x00n\x00d\x00o\x00w\x00s\x00u\x00p
+\x00d\x00a\x00t\x00e\x00.\x00c\x00o\x00m\x00/\x00m\x00s\x00d\x00o\x00w\x00n\x00l\x00o
+\x00a\x00d\x00/\x00u\x00p\x00d\x00a\x00t\x00e\x00/\x00s\x00o\x00f\x00t\x00w\x00a\x00r
+\x00e\x00/\x00s\x00e\x00c\x00u\x00/\x002\x000\x000\x008\x00/\x000\x006\x00/\x00w\x00i
+\x00n\x00d\x00o\x00w\x00s\x00x\x00p\x00-\x00k\x00b\x009\x005\x001\x003\x007\x006\x00-
+\x00v\x002\x00-\x00x\x008\x006\x00-\x00e\x00n\x00u\x00_\x00e\x009\x00b\x006\x008\x00c
+\x005\x00e\x006\x003\x00a\x00c\x00b\x005\x007\x008\x006\x00a\x000\x005\x00b\x005\x003
+\x00b\x004\x00 \xB4\xF4\x82\x94C\xE3\xB6C\xB1p\x9Ae\xBC\x82,wh\x00t\x00t\x00p\x00:
+\x00/\x00/\x00w\x00w\x00w\x00.\x00d\x00o\x00w\x00n\x00l\x00o\x00a\x00d\x00.\x00w
+\x00i\x00n\x00d\x00o\x00w\x00s\x00u\x00p\x00d\x00a\x00t\x00e\x00.\x00c\x00o
+\x00m\x00/\x00m\x00s\x00d\x00o\x00w\x00n\x00l\x00o\x00a\x00d\x00/\x00u\x00p\x00d
+\x00a\x00t\x00e\x00/\x00s\x00o\x00f\x00t\x00w\x00a\x00r\x00e\x00/\x00s\x00e\x00c\x00u
+\x00/\x002\x000\x000\x008\x00/\x000\x006\x00/\x00w\x00i\x00n\x00d\x00o\x00w\x00s\x00x
+\x00p\x00-\x00k\x00b\x009\x005\x001\x003\x007\x006\x00-\x00v\x002\x00-\x00x\x008\x006
+\x00-\x00e\x00n\x00u\x00_\x00e\x009\x00b\x006\x008\x00c\x005\x00e\x006\x003\x00a\x00c
+\x00b\x005\x007\x008\x006\x00a\x000\x005\x00b\x005\x003\x00b\x004\x003\x003\x002\x004
+\x006\x005\x00d\x00e\x00
+
+175197993	http://www.uspto.gov/patft/index.html enter>\x0A<a href="http://www.
+uspto.gov/patft/index.html"><img src="/net
+
+175198500	http://www.uspto.gov/patft/help/help.htm e></a>\x0A<AHREF="http://www.
+uspto.gov/patft/help/help.htm"><IMG BORDER="0
+\end{lstlisting}
+The file \texttt{url\_histogram.txt} provides the histogram of the potential urls. In that file, UTF-16 formatted text is converted to UTF-8. Note that not all URLs contained in the histogram file are accurate. The are actually URLs that were typed into a web browser. The following are lines taken from that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=3922	http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul	(utf16=2609)
+n=859	http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xu	(utf16=858)
+...
+n=2	http://math.nist.gov/~KRemington/papers/europvm.ps
+n=2	http://math.nist.gov/~MDonahue/pubs/nan.ps.gz
+n=2	http://math.nist.gov/~RBoisvert/publications/ADL95.ps.gz
+n=2	http://math.nist.gov/~RBoisvert/publications/IMACS97.ps.gz
+\end{lstlisting}
+Because the histogram file converts the UT-16 formatted text to UTF-8, the histogram file is more human readable than the \texttt{url.txt} file alone. The files \texttt{url\_facebook.txt}, \texttt{url\_microsoft-live}, \texttt{url\_services} and \texttt{url\_searches} all extract specific types of information from URLs. The most useful for digital media triage is likely the file \texttt{url\_searches.txt} because it shows histogram of searches from the disk image. Searches frequently convey intent. The following is an excerpt from that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=60	1
+n=53	exotic+car+dealer
+n=41	ford+car+dealer
+n=34	2009+Shelby
+n=25	steganography
+n=23	General+Electric
+n=23	time+travel
+n=19	steganography+tool+free
+n=19	vacation+packages
+n=16	firefox
+n=16	quicktime
+n=14	7zip
+\end{lstlisting}
+
+
+The file \texttt{ccn.txt} provides credit card numbers that have been found on the disk. Based on the scenario set-up for this disk image, credit card numbers are not necessarily highly relevant to this investigation. However, \bulk did find some credit card numbers on this disk image that are not actually credit card numbers; This is common behavior so it is worth examining the file here to demonstrate how it can be used in other investigations. The credit card number finder considers a pattern of digits and uses the Luhn checksum algorithm and the distribution of digits and the local context to identify potential credit card numbers. It is important to note that there are frequently false positives. The first few lines of the \texttt{ccn.txt} file for this disk image look like the following:
+\lstset{style=customfile}
+\begin{lstlisting}
+88284672-GZIP-177427 5273347458642687 734B55CD5\x0A5273347458642687\x0AC0841BAFA1B4C28
+4814857216-GZIP-793 4015751530102097 ebO.d=0;ebO.rnd=4015751530102097;ebO.title="";eb
+4909069775 6543210123456788	\x0Addadd7540 add '6543210123456788' 0.499999999
+4909069811 6543210123456788 499999999   -> '6543210123456788' Inexact Rounde
+4909069861 6543210123456788 \x0Addadd7541 add '6543210123456788' 0.5
+4909069897 6543210123456788 5           -> '6543210123456788' Inexact Rounde
+4909069947 6543210123456788 \x0Addadd7542 add '6543210123456788' 0.500000001
+5304221350 5678901234560000 +4   -> 5678901234560000\x0D\x0Addshi052 shift
+5612375618 6543210123456788 \x0D\x0Aaddx6240 add '6543210123456788' 0.499999999
+5612375654 6543210123456788 499999999   -> '6543210123456788' Inexact Rounde
+5612375703 6543210123456788 \x0D\x0Aaddx6241 add '6543210123456788' 0.5
+5612375739 6543210123456788 5 -> '6543210123456788' Inexact Rounde
+5612375788 6543210123456788 \x0D\x0Aaddx6242 add '6543210123456788' 0.500000001
+5612715901 5700122152274696 div4036 divide  5700122152274696   5700122152251
+\end{lstlisting}
+In the above example, `525273347458642687' looks like it could be a valid credit card number from the context (\textbackslash x0A is a new line). The number `4015751530102097' looks like a random number in a piece of Java Script. Note that both of those numbers were compressed; the offset indicates they were found in GZIP streams (shown as a number followed by `-GZIP'). The numbers whose context include ``Inexact Rounde'' are actually from Python source code and not credit card numbers at all. Again, the \texttt{ccn.txt} tends to alert on a lot of false positives. \\
+
+The \texttt{ccn\_track2.txt} file did not find any information in this disk image but is also useful for credit card fraud and identity theft investigations. It will contain credit card track 2 information found on the disk image.\\
+
+Using the files produced by \bulk described above, an investigator can quickly review a disk image for important information that is relevant to an investigation and find actionable intelligence quickly.
+
+\subsection{Analyzing Imagery}
+The scenario described in the M57 Patents data is not necessarily relevant to an imagery investigation. However, there is imagery information on the disk. We use that information here to demonstrate how imagery information can be analyzed by an investigator using \bulk.\\
+
+The file in the output directory, \texttt{jpeg.txt}, lists all JPEGs that were found on the disk whether they were carved or not. \bulk was run with default values meaning that only encoded JPEGs were carved. The following excerpt from the JPEG file shows information about JPEGs found on the disk image:
+\lstset{style=customfile}
+\begin{lstlisting}
+54798824	../Output/charlie-2009-12-11/jpeg/54783488.jpg	<fileobject><filename>
+../Output/charlie-2009-12-11/jpeg/54783488.jpg</filename><filesize>15336</filesize>
+<hashdigest type='md5'>13823ce7c21587d31f6eb4474612e660
+</hashdigest></fileobject>
+\end{lstlisting}
+The JPEG described above was not carved because it was not encoded. However, the first section ``../Output/charlie-2009-12-11/jpeg/54783488.jpg'' shows where the file would be found in the output directories if it had been carved. The next section of information also gives the file size, the hash type (in this case `md5') and the hash value of the file (in this case 13823ce7c21587d31f6eb4474612e660). Note that this may not match the hash value of the file in the original file system as \bulk cannot properly carve fragmented files.\\
+
+Information about encoded JPEGs can also be found in the \texttt{jpeg.txt} file. The following excerpt shows a description of a JPEG found in a GZIP format on the disk:
+\lstset{style=customfile}
+\begin{lstlisting}
+3771686400-GZIP-8332	../Output/charlie-2009-12-11/jpeg/3771686400-GZIP-0.jpg
+<fileobject><filename>../Output/charlie-2009-12-11/jpeg/3771686400-GZIP-0.jpg
+</filename><filesize>8332</filesize><hashdigest type='md5'>
+5b77035c983b04996774370f735ea72a</hashdigest></fileobject>
+\end{lstlisting}
+The JPEG described above was carved and can be found in the \textit{/jpeg} output directory in the file named \texttt{3771686400-GZIP-0.jpg}. The file also gives information about the filesize, hash type and hash ID. That file is shown in the  directory output shown below along with all of the encoded JPEGs that were found on the disk image and were carved. The contents of the \textit{/jpeg} directory are as follows:
+
+\begingroup
+\footnotesize
+\begin{Verbatim}
+10037939712-GZIP-0.jpg  5324841013-ZIP-0.jpg
+10117679783-ZIP-0.jpg   6039195136-GZIP-0.jpg
+3761630720-GZIP-0.jpg   6039215616-GZIP-0.jpg
+3764534784-GZIP-0.jpg   6039223808-GZIP-0.jpg
+3771686400-GZIP-0.jpg   6039232000-GZIP-0.jpg
+3771706880-GZIP-0.jpg   6039244288-GZIP-0.jpg
+3771715072-GZIP-0.jpg   6039301632-GZIP-0.jpg
+3771723264-GZIP-0.jpg   6039318016-GZIP-0.jpg
+3771735552-GZIP-0.jpg   6883925636-ZIP-0.jpg
+3771792896-GZIP-0.jpg   6884040324-ZIP-0.jpg
+3771809280-GZIP-0.jpg   6884056948-ZIP-0.jpg
+3771833856-GZIP-0.jpg   7276064256-GZIP-0.jpg
+3771858432-GZIP-0.jpg   7279128576-GZIP-0.jpg
+429788672-GZIP-0.jpg    8877243047-ZIP-0.jpg
+5310405287-ZIP-0.jpg    9948655104-GZIP-0.jpg
+\end{Verbatim}
+\endgroup
+All of these JPEG files can be viewed and used by investigators. The filename is the forensic path of where the JPEG was found. The file \texttt{3771686400-GZIP-0.jpg} mentioned above is shown in Figure ~\ref{fig:carvedJPEG}.
+
+\begin{figure}
+	\center
+	\includegraphics[scale=.90]{carvedJPEG.jpg}
+	\caption{A JPEG carved from encoded data on the M57 Patents disk image}
+	\label{fig:carvedJPEG}
+\end{figure}
+
+\subsection{Password Cracking}
+The \textbf{\textit{wordlist}} generates a list of words found on the disk
+within its configured length range. The word list can be useful in determining
+combinations to use for authorized password recovery. The scanner is disabled
+by default because it can produce substantial output and increase run time. To
+show the word list in this example, \bulk was run again on the M57 Patents
+scenario data with the scanner enabled. The version 1 run produced the
+following historical output:
+
+
+\begingroup
+\footnotesize
+\texttt{C:\textbackslash be\textbackslash \textgreater \textbf{bulk\_extractor -e wordlist -o ../Output/charlie-wordlist charlie-2009-12-11.E01}}
+\endgroup
+\begingroup
+\footnotesize
+\begin{Verbatim}[fontfamily=courier, commandchars=\\\{\}]
+bulk_extractor version: 1.4.0
+Input file: charlie-2009-12-11.E01
+Output directory: ../Output/charlie-wordlist
+Disk Size: 10239860736
+Threads: 4
+12:58:46 Offset 67MB (0.66%) Done in  1:14:55 at 14:13:41
+...
+14:03:24 Offset 10217MB (99.78%) Done in  0:00:08 at 14:03:32
+All data are read; waiting for threads to finish...
+Time elapsed waiting for 4 threads to finish:
+     (timeout in 60 min .)
+Time elapsed waiting for 4 threads to finish:
+    8 sec (timeout in 59 min 52 sec.)
+Thread 0: Processing 10200547328
+Thread 1: Processing 10234101760
+Thread 2: Processing 10183770112
+Thread 3: Processing 10217324544
+
+Time elapsed waiting for 1 thread to finish:
+    14 sec (timeout in 59 min 46 sec.)
+Thread 3: Processing 10217324544
+
+All Threads Finished!
+Producer time spent waiting: 3627.92 sec.
+Average consumer time spent waiting: 4.1518 sec.
+*******************************************
+** bulk_extractor is probably CPU bound. **
+**    Run on a computer with more cores  **
+**      to get better performance.       **
+*******************************************
+Phase 2. Shutting down scanners
+Phase 3. Uniquifying and recombining wordlist
+Phase 3. Creating Histograms
+   ccn histogram...   ccn_track2 histogram...   domain histogram...
+   email histogram...   ether histogram...   find histogram...
+   ip histogram...   lightgrep histogram...   tcp histogram...
+   telephone histogram...   url histogram...   url microsoft-live...
+   url services...   url facebook-address...   url facebook-id
+   url searches...Elapsed time: 4065.09 sec.
+Overall performance: 2.51898 MBytes/sec
+Total email features found: 152775
+\end{Verbatim}
+\endgroup
+
+Note that it took 3991.71 seconds to run \bulk without the \textbf{\textit{wordlist}} scanner enabled and, in this case, it took 4065.09 seconds with \textbf{\textit{wordlist}} enabled.  The new output directory contains a file called \texttt{wordlist.txt}. That file has both filenames and words in it. The following is an excerpt from that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+50497556	usemodem.jpg
+50497624	usemsn.jpg
+50497692	usemsnnow.jpg
+50497760	welcome.htm
+50497828	whereNow.htm
+50497896	xmlutil.js
+50497987	^Photoshop
+50498009	Resolution
+50498050	Global
+50498057	Lighting
+50498090	Global
+50498097	Altitude
+50498153	Copyright
+50498181	Japanese
+50498229	Halftone
+50498238	Settings
+50498335	Transfer
+\end{lstlisting}
+The wordlist contains ALL words found on the disk between 6 and 14 characters long. Automated programs can be used to generate passwords from combinations of these words. The \textbf{\textit{wordlist}} scanner also generates a split wordlist containing the same words found in the \texttt{wordlist.txt} file with all words deduplicated, sorted by size and alphabetized. The following is an excerpt from the file \texttt{wordlist\_split\_000.txt} generated from the disk image:
+\lstset{style=customfile}
+\begin{lstlisting}
+!!!!!!
+concluded|1
+concluder/2
+concluder/M
+concluir/XQ
+conclurai/x
+conclusion,
+conclusion.
+conclusione
+conclusions
+conclusive,
+\end{lstlisting}
+The split wordlist is the file that is typically fed to password cracking software.
+
+\subsection{Post Processing}
+The programs \textbf{identify\_filenames.py} and \textbf{bulk\_diff.py} can provide further insight into the data contained on the disk image. The \textbf{identify\_filenames.py} program can be used on the feature files produced from the \bulk run to show the file location of the features that were found. Running the program on all of the feature files produced by the \bulk run produces the following output (where \textit{charlie-2009-12-11} is the \bulk output directory and \textit{charlieAnnotatedOutput} is where all the annotated files are written):\\
+
+\begingroup
+\footnotesize
+\texttt{C:\textbackslash be\textbackslash \textgreater \textbf{python3 python/identify\_filenames.py --all charlie-2009-12-11 charlieAnnotatedOutput}}
+\endgroup
+\begingroup
+\footnotesize
+\begin{Verbatim}[fontfamily=courier, commandchars=\\\{\}]
+Reading file map by running fiwalk on charlie-2009-12-11.E01
+Processed 1000 fileobjects in DFXML file
+Processed 2000 fileobjects in DFXML file
+...
+Processed 39000 fileobjects in DFXML file
+Processed 40000 fileobjects in DFXML file
+feature_file: aes_keys.txt
+feature_file: ccn.txt
+feature_file: domain.txt
+feature_file: email.txt
+feature_file: ether.txt
+feature_file: exif.txt
+feature_file: ip.txt
+feature_file: jpeg.txt
+feature_file: json.txt
+feature_file: rar.txt
+feature_file: rfc822.txt
+feature_file: telephone.txt
+feature_file: url.txt
+feature_file: windirs.txt
+feature_file: winpe.txt
+feature_file: winprefetch.txt
+feature_file: zip.txt
+******************************
+** Total Features:   754038 **
+** Total Located:   754038 **
+******************************
+\end{Verbatim}
+\endgroup
+
+Note, in this example that \textbf{fiwalk} is installed on the computer running the \textbf{identify\_filenames.py} program. The directory \textit{charlieAnnotatedOutput} contains all of the annotated feature files, showing the file location of the features. The directory contents are as follows:
+
+\begingroup
+\footnotesize
+\begin{Verbatim}
+annotated_aes_keys.txt        annotated_rar.txt
+annotated_ccn.txt        annotated_rfc822.txt
+annotated_domain.txt        annotated_telephone.txt
+annotated_email.txt        annotated_url.txt
+annotated_ether.txt        annotated_windirs.txt
+annotated_exif.txt        annotated_winpe.txt
+annotated_ip.txt        annotated_winprefetch.txt
+annotated_jpeg.txt        annotated_zip.txt
+annotated_json.txt
+\end{Verbatim}
+\endgroup
+
+The annotated files display the feature with the file in which the feature was found (where it was identified by the program). The following is an excerpt from the \texttt{annotated\_email.txt} file:
+\lstset{style=customfile}
+\begin{lstlisting}
+27767966 pat@m57.biz	m: "Pat McGoo" <pat@m57.biz>\x0D\x0ATo: <charlie@ Documents
+and Settings/Charlie/Application Data/Thunderbird/Profiles/4zy34x9h.default/Mail/Local
+Folders/Inbox dcb794e350bd198c4279614eae6c8b76
+
+27767985 charlie@m57.biz @m57.biz>\x0D\x0ATo: <charlie@m57.biz>,\x0D\x0A\x09<jo@m
+57.biz	Documents and Settings/Charlie/Application Data/Thunderbird/Profiles/4zy34x9h.
+default/Mail/Local Folders/Inbox dcb794e350bd198c4279614eae6c8b76
+
+27768022 terry@m57.biz jo@m57.biz>,\x0D\x0A\x09<terry@m57.biz>\x0D\x0AX-ASG-Orig-
+Su Documents and Settings/Charlie/Application Data/Thunderbird/Profiles/4zy34x9h.def
+ault/Mail/Local Folders/Inbox dcb794e350bd198c4279614eae6c8b76
+\end{lstlisting}
+The email address "pat@m57biz" was found in the file \texttt{Documents and Settings/Charlie/}\newline\texttt{Application Data/Thunderbird/Profiles/4zy34x9h.default/Mail/Local Folders/Inbox} and investigators can refer to that location on the disk image to view the full text.\\
+
+The program \textbf{bulk\_diff.py} shows the difference between two \bulk runs. In this case, we used a disk image from the same user ("charlie") taken almost a month before the disk image that has been used throughout this example. The disk image we have been using throughout this example is dated December 11, 2009. The older disk image we downloaded for comparison is dated November 17, 2009.  The earlier disk image data is stored in a file named \texttt{charlie-2009-11-17.E01} and can be downloaded from \url{http://digitalcorpora.org/corp/nps/scenarios/2009-m57-patents/drives-redacted/}.\\
+
+After running \bulk using the earlier disk image, we ran the program \textbf{bulk\_diff.py} on the output of that disk image and on the output of the \texttt{charlie-2009-12-11.E01} run. To run, we typed the following, piping the output of the program to a file called \texttt{bulkdiffoutput.txt}:
+\begin{Verbatim}[commandchars=\\\{\}]
+\verbbf{python3 python/bulk\_diff.py /charlie-2009-11-17 /charlie-2009-12-11 > bulkdiffoutput.txt}
+\end{Verbatim}
+The output shows the features differences on the disk image. The following is an excerpt of that output:
+\lstset{style=customfile}
+\begin{lstlisting}
+domain_histogram.txt:
+	#in PRE		#in POST	Value
+--------------------------------------------------------------------------
+401	4,470		4,069		patft.uspto.gov
+181	3,151		2,970		www.wipo.int
+295	3,157		2,862		www.google.com
+0	2,537		2,537		l.yimg.com
+\end{lstlisting}
+The output specifically shows the differences in the histograms between the two runs across all of the histogram files that were created. The excerpt above shows that "charlie" (the disk user) visited the domain "patft.uspto.gov" frequently between the time the two images were recorder. It was found 4,069 more times in the later disk image than in the one taken earlier. It also shows that the domain "l.yimg.com" was not found on the earlier disk image but was found 2,537 times on the later disk image. The results are sorted by the amount of the difference. This means that features that are most different appear first. This can be very helpful because those features generally give the most insight into the disk users activity over that period of time.
+
+\section{NPS DOMEX Users Image}
+NPS Test Disk Images are a set of disk images that have been created for testing computer forensic tools. These images are free of non-public Personally Identifiable Information (PII) and are approved for release to the general public. The NPS-created data in the images is public domain and free of any copyright restriction; the images may contain some copyrighted data that was made available by the copyright holder. These copyrights, where known, are noted in the files themselves\cite{npsdiskimages}. \\
+
+The NPS DOMEX users image is a disk image of a Windows XP SP3 system that has two users, domexuser1 and domexuser2, who communicate with a third user (domexuser3) via IM and email.  The data is available for download at \url{http://digitalcorpora.org/corp/nps/drives/nps-2009-domexusers/}. For this example, we use the file \texttt{nps-2009-domexusers.E01} which includes the full system including the Microsoft Windows executables. Running \bulk on the command line produces the following output:\\
+
+\begingroup
+\footnotesize
+\texttt{C:\textbackslash be\textbackslash \textgreater \textbf{bulk\_extractor -o ../Output/nps-2009-domexusers nps-2009-domexusers.E01}}
+\endgroup
+\begingroup
+\footnotesize
+\begin{Verbatim}[fontfamily=courier, commandchars=\\\{\}]
+bulk_extractor version: 1.4.0
+Input file: nps-2009-domexusers.E01
+Output directory: ../Output/nps-2009-domexusers2
+Disk Size: 42949672960
+Threads: 4
+16:50:53 Offset 67MB (0.16%) Done in  4:23:43 at 21:14:36
+16:51:19 Offset 150MB (0.35%) Done in  3:58:37 at 20:49:56
+...
+16:13:12 Offset 42849MB (99.77%) Done in  0:00:11 at 16:13:23
+16:13:13 Offset 42932MB (99.96%) Done in  0:00:01 at 16:13:14
+All data are read; waiting for threads to finish...
+Time elapsed waiting for 3 threads to finish:
+     (timeout in 60 min .)
+Time elapsed waiting for 1 thread to finish:
+    6 sec (timeout in 59 min 54 sec.)
+Thread 0: Processing 42932895744
+
+Time elapsed waiting for 1 thread to finish:
+    12 sec (timeout in 59 min 48 sec.)
+Thread 0: Processing 42932895744
+
+All Threads Finished!
+Producer time spent waiting: 4254.07 sec.
+Average consumer time spent waiting: 89.309 sec.
+*******************************************
+** bulk_extractor is probably CPU bound. **
+**    Run on a computer with more cores  **
+**      to get better performance.       **
+*******************************************
+Phase 2. Shutting down scanners
+Phase 3. Creating Histograms
+   ccn histogram...   ccn_track2 histogram...   domain histogram...
+   email histogram...   ether histogram...   find histogram...
+   ip histogram...   lightgrep histogram...   tcp histogram...
+   telephone histogram...   url histogram...   url microsoft-live...
+   url services...   url facebook-address...   url facebook-id...
+   url searches...Elapsed time: 4846.74 sec.
+Overall performance: 8.86156 MBytes/sec
+Total email features found: 8774
+\end{Verbatim}
+\endgroup
+
+All of the results from the \bulk run are stored in the output directory \textit{nps-2009-domex}. The contents of that directory after the run are as follows:
+
+\begingroup
+\footnotesize
+\begin{Verbatim}
+    1 aes_keys.txt                  1 kml.txt
+    0 alerts.txt                    0 lightgrep.txt
+    1 ccn.txt                       0 lightgrep_histogram.txt
+    1 ccn_histogram.txt             4 packets.pcap
+    0 ccn_track2.txt                1 rar.txt
+    0 ccn_track2_histogram.txt    424 report.xml
+ 7364 domain.txt                  536 rfc822.txt
+   44 domain_histogram.txt          1 tcp.txt
+    0 elf.txt                       1 tcp_histogram.txt
+ 1528 email.txt                    48 telephone.txt
+   32 email_histogram.txt           4 telephone_histogram.txt
+    1 ether.txt                 51888 url.txt
+    1 ether_histogram.txt           0 url_facebook-address.txt
+  152 exif.txt                      0 url_facebook-id.txt
+    0 find.txt                   1240 url_histogram.txt
+    0 find_histogram.txt            0 url_microsoft-live.txt
+    0 gps.txt                       4 url_searches.txt
+    0 hex.txt                      32 url_services.txt
+    4 ip.txt                        0 vcard.txt
+    1 ip_histogram.txt          15228 windirs.txt
+   20 jpeg/                     26516 winpe.txt
+  380 jpeg.txt                   1312 winprefetch.txt
+  316 json.txt                   1956 zip.txt
+\end{Verbatim}
+\endgroup
+For this example, we will focus on the files that are most important to malware investigations and cyber investigations, showing how those files can be interpreted and used by investigators.
+
+\subsection{Malware Investigations}
+In a malware investigation, investigators are looking for information about programmatic intrusions. In this example, we examine all files that provide information about executables, Windows directory entries and information downloaded from web-based applications. We recommend that "-e xor" be enabled for malware investigations.\\
+
+The file \texttt{windirs.txt} provides information about FAT32 and NTFS directories. It contains most of the disk entries. The following is an excerpt showing one line from the file:
+\lstset{style=customfile}
+\begin{lstlisting}
+281954816	A0001801.dll	<fileobject
+src='mft'><atime>2008-10-21T00:45:51Z</atime><attr_flags>8224</attr_flags>
+<crtime>2008-10-21T00:45:51Z</crtime><ctime>2008-10-21T00:45:51Z</ctime>
+<filename>A0001801.dll</filename><filesize>1000000000000</filesize><filesize_alloc>
+0</filesize_alloc><lsn>123437339</lsn><mtime>2008-10-21T00:45:51Z</mtime>
+<nlink>1</nlink><par_ref>12017</par_ref><par_seq>3</par_seq><seq>1</seq>
+</fileobject>
+\end{lstlisting}
+The line from the file gives information about the disk entry \texttt{A0001801.dll}. It provides some data about the file including the file size, file creation time (ctime) and time of last file modification (mtime). It is important to note that the error rate for FAT32 entries is high and those entries should be ignored if the drive is not FAT. \\
+
+For investigations on Windows disk images, such as the \texttt{nps-2009-domexusers}, the file \texttt{winpe.txt} shows information relating to Windows Portable Executable files.  These file entries contain very long lines. The following is \textbf{one} line from the file:
+\lstset{style=customfile}
+\begin{lstlisting}
+42753536 87d84154e7789013878c6340a4d2d445 <PE><FileHeader Machine=
+"IMAGE_FILE_MACHINE_I386"NumberOfSections="3" TimeDateStamp="1208131815"
+ PointerToSymbolTable="0"NumberOfSymbols="0"SizeOfOptionalHeader="224">
+<Characteristics><IMAGE_FILE_EXECUTABLE_IMAGE />
+<IMAGE_FILE_LINE_NUMS_STRIPPED /><IMAGE_FILE_LOCAL_SYMS_STRIPPED />
+<IMAGE_FILE_32BIT_MACHINE/><IMAGE_FILE_DLL /></Characteristics>
+</FileHeader><OptionalHeaderStandard Magic="PE32" MajorLinkerVersion="7"
+MinorLinkerVersion="10" SizeOfCode="512" SizeOfInitializedData="1536"
+SizeOfUninitializedData="0" AddressOfEntryPoint="0x1046" BaseOfCode=
+"0x1000" /><OptionalHeaderWindows ImageBase="0x6c6c0000" SectionAlignment
+="1000" FileAlignment="200"MajorOperatingSystemVersion="5"
+MinorOperatingSystemVersion="1" MajorImageVersion="5"
+MinorImageVersion="1" MajorSubsystemVersion="4" MinorSubsystemVersion="0"
+Win32VersionValue="0" SizeOfImage="4000" SizeOfHeaders="400" CheckSum="
+0x7485" SubSystem="" SizeOfStackReserve="40000"SizeOfStackCommit="1000"
+SizeOfHeapReserve="100000" SizeOfHeapCommit="1000" LoaderFlags="0"
+NumberOfRvaAndSizes="10"><DllCharacteristics>
+<IMAGE_DLL_CHARACTERISTICS_NO_SEH /></DllCharacteristics>
+</OptionalHeaderWindows><Sections><SectionHeader Name=".text" VirtualSize
+="be" VirtualAddress="1000" SizeOfRawData="200" PointerToRawData="400"
+PointerToRelocations="0" PointerToLinenumbers="0" ><Characteristics>
+<IMAGE_SCN_CNT_CODE /><IMAGE_SCN_MEM_EXECUTE />
+<IMAGE_SCN_MEM_READ /></Characteristics></SectionHeader><SectionHeader
+Name=".rsrc" VirtualSize="400" VirtualAddress="2000" SizeOfRawData="400"
+PointerToRawData="600" PointerToRelocations="0" PointerToLinenumbers="0"
+><Characteristics><IMAGE_SCN_CNT_INITIALIZED_DATA />
+<IMAGE_SCN_MEM_READ /></Characteristics></SectionHeader>
+<SectionHeader Name=".reloc" VirtualSize="8" VirtualAddress="3000"
+SizeOfRawData="200" PointerToRawData="a00" PointerToRelocations="0"
+PointerToLinenumbers="0" ><Characteristics><IMAGE_SCN_CNT_INITIALIZED_DATA />
+<IMAGE_SCN_MEM_DISCARDABLE /><IMAGE_SCN_MEM_READ /></Characteristics>
+</SectionHeader></Sections></PE>
+\end{lstlisting}
+The first number is the offset and tells you were to find the file. Most executables are not fragmented. The second is the MD5 has of the first 4k of the file that can be used to deduplicate and look up the file in the hash database. Finally, the bulk of the information is contained in the <PE> XML block that breaks out all of the Windows PE header information. It contains information about the File header, the characteristics of the file, Windows header information and section header information.\\
+
+The file \texttt{winprefetch.txt} contains the information from carved files Windows Prefetch that were discovered anywhere on the drive. \bulk will carve the Prefetch files from unallocated space. This extremely useful because Prefetch files are frequently deleted. A single line in the prefetch output file is also very long. The following is only the beginning of one line from the file:
+\lstset{style=customfile}
+\begin{lstlisting}
+55758336	MSIEXEC.EXE	<prefetch><os>Windows
+XP</os><filename>MSIEXEC.EXE</filename><header_size>152</header_size>
+<atime>2008-10-30T03:17:27Z</atime><runs>14</runs><filenames>
+<file>\x5CDEVICE\x5CHARDDISKVOLUME1\x5CWINDOWS\x5CSYSTEM32\x5CNTDLL.DLL
+</file><file>\x5CDEVICE\x5CHARDDISKVOLUME1\x5CWINDOWS\x5CSYSTEM32\x5CKERNEL32.DLL
+...
+\end{lstlisting}
+Printing the line out here would cover almost two pages. It includes a lot of information about the Prefetch file including the name of the executable, the name of the DLLs, the directory of DLLs, the atime, the number of runs, the serial number, and the ctime. The Prefetch file is searchable and useable by investigators searching for EXEs or DLLs related to a malware investigation.\\
+
+JSON is the JavaScript Object Notation (used in Facebook, etc). The file \texttt{json.txt}  provides the offset, JSON and MD5 hash of the JSON information found on the disk image. \bulk is great at finding JSON in compressed streams and HIBER files. The following are a few lines from the JSON file:
+\lstset{style=customfile}
+\begin{lstlisting}
+62836579 {"ask":["Ask"],"delicious":["Del.icio.us"],"digg":["Digg"],"email":["Email"],
+"favorites":["Favorites"],"facebook":["Facebook"],"fark":["Fark"],"furl":["Furl"],
+"google":["Google"],"live":["Live"],"myspace":["MySpace"],"myweb":["Yahoo MyWeb"
+,"yahoo-myweb"],"newsvine":["Newsvine"],"reddit":["Reddit"],"sk*rt":["Sk*rt","skrt"],
+"slashdot":["Slashdot"],"stumbleupon":["StumbleUpon","su"],"stylehive":["Stylehive"],
+"tailrank":["Tailrank","tailrank2"],"technorati":["Technorati"],"thisnext":
+["ThisNext"],"twitter":["Twitter"],"ballhype":["BallHype"],"yardbarker":
+["Yardbarker"],"kaboodle":["Kaboodle"],"more":["More ..."]}
+26d3b8c5010f4d39250dab3a1c1b839e
+
+62842797 ["6jb4","3j1d","v1me","gu83","uefc","fq1j","r5l7","ftho","gdq9","717h",
+"24b7","d0en","ads7","m9b4","n0lq","42c3","p5mp","7hbi","f0g6","7v98","mv86",
+"d0ns","9a8a","64gg","jogl","cehp","mu2r","6h7h","sntb","94ds","n1fv","3a2i",
+"3end","l42s","a9j","q3dj","s150","di3s","3nu5","sk74","e39d","mkvj","482d","kfej",
+"nlcv","eroi","m6ee","rvaa","9nis","ef6b","g00q","b4hp","kbpq","bm4l","f7iu",
+"e5gb","1sbj","rk0a","ck86","1etp","26sr","fivt","3v95","foqq","vtmj","canb",
+"bchv","ku35","q4p9","gdkt","gng8","mdb9","ejjg","27k9","30mf","nene",
+"smmm","q204","83ot","6kbr","df1o","1q0j","nh32","ebso","d6t5","f2dp",
+"3sqp","i4cs","6k7b","a1pv","ki2l","1f7","d6lv","u7r5","9t0e","5h0l","j8kn",
+"7akj","9tj","jmu3","1ir1"]	5a04af7518ad74c497c9e74b7025736e
+
+64044544-GZIP-610 ["Top","Left","Right","Bottom"] 5354ef6838974b1979e49ee379883c56
+\end{lstlisting}
+Some of the JSON features found, such as the one located at '62836579', are comprised of a lot of information in the notation. Other JSON features are very short, such as the feature located at in the GZIP compressed stream at '64044544-GZIP-610.' All of the lines contain the MD5 hash of the JSON that is used for deduplication.\\
+
+The file \texttt{elf.txt} typically contains information about ELF executables, which is the executable file format for Linux and Android systems. The sample corpus used in this example is from a Windows machine and does not contain any ELF executables.
+
+\subsection{Cyber Investigations}
+Cyber investigations cover a wide variety of areas. However, most involve looking for encryption keys, hash values or information about ethernet packets. \bulk finds all of those things on the disk and writes them to different output files. Of note, \bulk also finds information in Base64 encoding and decompresses fragments of Windows Hibernation files. There are not specific files created for that processing; the information found in data with these encodings will be processed by other scanners and stored in the appropriate feature files. The fact that a feature came from encoded data will be indicated in the forensic path. The information contained therein may very well be relevant to cyber investigations.\\
+
+AES encryption implementation system sometimes leaves keys in memory and \bulk finds those keys, usually in RAM, Swap or hibernation files. The keys can sometimes be used to decrypt AES encrypted material. The file \texttt{aes.txt} contains the keys that are found. There was only one AES key found on the \texttt{nps-2009-domexusers} disk image. The following is the line that describes it from the keys file including the offset, key and key size descriptor (AES256):
+\lstset{style=customfile}
+\begin{lstlisting}
+1608580652	28 90 90 5e f7 ce b4 a7 2b 7d d9 45 d8 b0 56 99 97 f4 42
+33 35 f1 54 9a 79 36 e7 1c 94 02 28 78 	AES256
+\end{lstlisting}
+
+The file \texttt{hex.txt} contains extracted hexidecimal strings of a special length. The block sizes cotained within it are either 128 or 256 due to the fact that those are the sizes used for encryption keys and hash values. The disk image used in this example does not have any of those and the file is blank.\\
+
+\bulk produces network information including PCAP files, Ethernet addresses, and TCP/IP connections. The files \texttt{ether.txt} and \texttt{ether\_histogram.txt} provide a list of ethernet  addresses from packets and ASCII. These are the addresses found on the disk and located in \texttt{ether.txt}:
+\lstset{style=customfile}
+\begin{lstlisting}
+2435863552	00:0C:29:26:BB:CD	 (ether_dhost)
+2435863552	00:50:56:E0:FE:24	 (ether_shost)
+2435865088	00:0C:29:26:BB:CD	 (ether_dhost)
+2435865088	00:50:56:E0:FE:24	 (ether_shost)
+22637986225	00:80:C7:8F:6C:96	 apter.\x0AExample: 00:80:C7:8F:6C:96\x00\x00
+\end{lstlisting}
+The file {ether\_histogram.txt} groups these ethernet addresses in a histogram:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=2	00:0C:29:26:BB:CD
+n=2	00:50:56:E0:FE:24
+n=1	00:80:C7:8F:6C:96
+\end{lstlisting}
+Packets likely traveled from 00:0C:29:26:BB:CD to 00:50:56:E0:FE:24.  The other usage has Ethernet addresses in UTF-16 format.\\
+
+The file \texttt{ip.txt} contains IP addresses from packet carving, not from dotted quads. The following is an excerpt from that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+2435865102	inet_ntop win32	struct ip L (src) cksum-ok
+2435865102	inet_ntop win32	struct ip R (dst) cksum-ok
+2805534669	123.12.0.192	sockaddr_in
+8694397397	135.5.0.234	sockaddr_in
+9047318477	123.12.0.192	sockaddr_in
+9446959573	135.5.0.234	sockaddr_in
+11295228937	1.70.0.1	sockaddr_in
+\end{lstlisting}
+The \textit{L} or \textit{R} in the 'struct ip' information indicates Local or Remote. This line also includes the IP checksum is ok. The value could also be listed as "cksum-bad" to indicate it is bad. Bad checksums may indicate a false positive and not a legitimate IP address. Finally, the "sockaddr\_in" indicates the IP address is from a "sockaddr\_in" structure. The file \texttt{ip\_histogram.txt} removes the random noise that is found in the \texttt{ip.txt}. Here is an excerpt from the histogram file:
+\lstset{style=customfile}
+\begin{lstlisting}
+n=5	2.172.0.101
+n=4	123.12.0.192
+n=4	inet_ntop win32
+n=3	135.5.0.234
+n=2	209.85.147.109
+n=2	65.55.15.242
+\end{lstlisting}
+
+The file \texttt{packets.pcap} is a pcap file made from carved packet. To view that file, use any packet analysis tool you like (such as \textbf{tcpdump}). Only packets carved from a PCAP  file will have the correct packet time stamp; others will given a time in 1970.\\
+
+Finally, the file \texttt{tcp.txt} contains details about TCP (and UDP) network flows. It contains more detail than \texttt{ip.txt} but investigators should be careful of false positives, as there are often many in this file. The following are the two lines found in that file:
+\lstset{style=customfile}
+\begin{lstlisting}
+2435863566	inet_ntop win32:80 -> inet_ntop win32:1034 (TCP)	 Size: 1472
+2435865102	inet_ntop win32:80 -> inet_ntop win32:1034 (TCP)	 Size: 1252
+\end{lstlisting}
+The file \texttt{tcp\_histogram.txt} often provides further insight into the tcp information found on the disk image. In this case, it does not because there were only two features found. It is important to note that the histogram file still contains a lot of false positives.

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -563,7 +563,7 @@ default/Mail/Local Folders/Inbox dcb794e350bd198c4279614eae6c8b76
 Su Documents and Settings/Charlie/Application Data/Thunderbird/Profiles/4zy34x9h.def
 ault/Mail/Local Folders/Inbox dcb794e350bd198c4279614eae6c8b76
 \end{lstlisting}
-The email address "pat@m57biz" was found in the file \texttt{Documents and Settings/Charlie/}\newline\texttt{Application Data/Thunderbird/Profiles/4zy34x9h.default/Mail/Local Folders/Inbox} and investigators can refer to that location on the disk image to view the full text.\\
+The email address "pat@m57.biz" was found in the file \texttt{Documents and Settings/Charlie/}\newline\texttt{Application Data/Thunderbird/Profiles/4zy34x9h.default/Mail/Local Folders/Inbox} and investigators can refer to that location on the disk image to view the full text.\\
 
 The program \textbf{bulk\_diff.py} shows the difference between two \bulk runs. In this case, we used a disk image from the same user ("charlie") taken almost a month before the disk image that has been used throughout this example. The disk image we have been using throughout this example is dated December 11, 2009. The older disk image we downloaded for comparison is dated November 17, 2009.  The earlier disk image data is stored in a file named \texttt{charlie-2009-11-17.E01} and can be downloaded from \url{http://digitalcorpora.org/corp/nps/scenarios/2009-m57-patents/drives-redacted/}.\\
 
@@ -571,7 +571,7 @@ After running \bulk using the earlier disk image, we ran the program \textbf{bul
 \begin{Verbatim}[commandchars=\\\{\}]
 \verbbf{python3 python/bulk\_diff.py /charlie-2009-11-17 /charlie-2009-12-11 > bulkdiffoutput.txt}
 \end{Verbatim}
-The output shows the features differences on the disk image. The following is an excerpt of that output:
+The output shows the feature differences on the disk image. The following is an excerpt of that output:
 \lstset{style=customfile}
 \begin{lstlisting}
 domain_histogram.txt:

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -582,7 +582,7 @@ domain_histogram.txt:
 295	3,157		2,862		www.google.com
 0	2,537		2,537		l.yimg.com
 \end{lstlisting}
-The output specifically shows the differences in the histograms between the two runs across all of the histogram files that were created. The excerpt above shows that "charlie" (the disk user) visited the domain "patft.uspto.gov" frequently between the time the two images were recorder. It was found 4,069 more times in the later disk image than in the one taken earlier. It also shows that the domain "l.yimg.com" was not found on the earlier disk image but was found 2,537 times on the later disk image. The results are sorted by the amount of the difference. This means that features that are most different appear first. This can be very helpful because those features generally give the most insight into the disk users activity over that period of time.
+The output specifically shows the differences in the histograms between the two runs across all of the histogram files that were created. The excerpt above shows that "charlie" (the disk user) visited the domain "patft.uspto.gov" frequently between the time the two images were recorded. It was found 4,069 more times in the later disk image than in the one taken earlier. It also shows that the domain "l.yimg.com" was not found on the earlier disk image but was found 2,537 times on the later disk image. The results are sorted by the amount of the difference. This means that features that are most different appear first. This can be very helpful because those features generally give the most insight into the disk user's activity over that period of time.
 
 \section{NPS DOMEX Users Image}
 NPS Test Disk Images are a set of disk images that have been created for testing computer forensic tools. These images are free of non-public Personally Identifiable Information (PII) and are approved for release to the general public. The NPS-created data in the images is public domain and free of any copyright restriction; the images may contain some copyrighted data that was made available by the copyright holder. These copyrights, where known, are noted in the files themselves\cite{npsdiskimages}. \\
@@ -722,7 +722,7 @@ PointerToLinenumbers="0" ><Characteristics><IMAGE_SCN_CNT_INITIALIZED_DATA />
 <IMAGE_SCN_MEM_DISCARDABLE /><IMAGE_SCN_MEM_READ /></Characteristics>
 </SectionHeader></Sections></PE>
 \end{lstlisting}
-The first number is the offset and tells you were to find the file. Most executables are not fragmented. The second is the MD5 has of the first 4k of the file that can be used to deduplicate and look up the file in the hash database. Finally, the bulk of the information is contained in the <PE> XML block that breaks out all of the Windows PE header information. It contains information about the File header, the characteristics of the file, Windows header information and section header information.\\
+The first number is the offset and tells you where to find the file. Most executables are not fragmented. The second is the MD5 hash of the first 4k of the file that can be used to deduplicate and look up the file in the hash database. Finally, the bulk of the information is contained in the <PE> XML block that breaks out all of the Windows PE header information. It contains information about the File header, the characteristics of the file, Windows header information and section header information.\\
 
 The file \texttt{winprefetch.txt} contains the information from carved files Windows Prefetch that were discovered anywhere on the drive. \bulk will carve the Prefetch files from unallocated space. This extremely useful because Prefetch files are frequently deleted. A single line in the prefetch output file is also very long. The following is only the beginning of one line from the file:
 \lstset{style=customfile}
@@ -776,7 +776,7 @@ AES encryption implementation system sometimes leaves keys in memory and \bulk f
 33 35 f1 54 9a 79 36 e7 1c 94 02 28 78 	AES256
 \end{lstlisting}
 
-The file \texttt{hex.txt} contains extracted hexidecimal strings of a special length. The block sizes cotained within it are either 128 or 256 due to the fact that those are the sizes used for encryption keys and hash values. The disk image used in this example does not have any of those and the file is blank.\\
+The file \texttt{hex.txt} contains extracted hexadecimal strings of a special length. The block sizes contained within it are either 128 or 256 due to the fact that those are the sizes used for encryption keys and hash values. The disk image used in this example does not have any of those and the file is blank.\\
 
 \bulk produces network information including PCAP files, Ethernet addresses, and TCP/IP connections. The files \texttt{ether.txt} and \texttt{ether\_histogram.txt} provide a list of ethernet  addresses from packets and ASCII. These are the addresses found on the disk and located in \texttt{ether.txt}:
 \lstset{style=customfile}
@@ -787,7 +787,7 @@ The file \texttt{hex.txt} contains extracted hexidecimal strings of a special le
 2435865088	00:50:56:E0:FE:24	 (ether_shost)
 22637986225	00:80:C7:8F:6C:96	 apter.\x0AExample: 00:80:C7:8F:6C:96\x00\x00
 \end{lstlisting}
-The file {ether\_histogram.txt} groups these ethernet addresses in a histogram:
+The file \texttt{ether\_histogram.txt} groups these ethernet addresses in a histogram:
 \lstset{style=customfile}
 \begin{lstlisting}
 n=2	00:0C:29:26:BB:CD
@@ -818,7 +818,7 @@ n=2	209.85.147.109
 n=2	65.55.15.242
 \end{lstlisting}
 
-The file \texttt{packets.pcap} is a pcap file made from carved packet. To view that file, use any packet analysis tool you like (such as \textbf{tcpdump}). Only packets carved from a PCAP  file will have the correct packet time stamp; others will given a time in 1970.\\
+The file \texttt{packets.pcap} is a pcap file made from carved packets. To view that file, use any packet analysis tool you like (such as \textbf{tcpdump}). Only packets carved from a PCAP file will have the correct packet time stamp; others will be given a time in 1970.\\
 
 Finally, the file \texttt{tcp.txt} contains details about TCP (and UDP) network flows. It contains more detail than \texttt{ip.txt} but investigators should be careful of false positives, as there are often many in this file. The following are the two lines found in that file:
 \lstset{style=customfile}

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -21,13 +21,13 @@ such as accented characters (\`{e} ), funny symbols
 (\charpicture{otherPics/U+2234}) and the occasional Chinese
 character (\charpicture{otherPics/U+611B}) that may show up in the
 files are legitimate. Glyphs from language, for example, Cyrillic
-(\charpicture{otherPics/U+0428}) or Arabic (\charpicture{otherPics/U+062D}) may show up in features files as all
+(\charpicture{otherPics/U+0428}) or Arabic (\charpicture{otherPics/U+062D}) may show up in feature files as all
 foreign languages can be coded in UTF-8 format. It is perfectly
 appropriate and typical to open up a feature file and see characters
 that the user may not recognize.\\
 
 \section{2009-M57 Patents Scenario}
-The 2009-M57-Patents scenario tracks the first four weeks of corporate history of the (fictional) M57 Patents company. The company started operation on Friday, November 13th, 2009, and ceased operation on Saturday, December 12, 2009. This specific scenario was built to be used as a teaching tool both as a disk forensics exercise and as a network forensics exercise. The scenario data is also useful for computer forensics research because the hard drive of each computer and each computers memory were imaged every day. In this example, we are not particularly interested in the exercises related to illegal activity, exfiltration and eavesdropping; they do however provide interesting components for us to examine in the example data\cite{m57scenario}.
+The 2009-M57-Patents scenario tracks the first four weeks of corporate history of the (fictional) M57 Patents company. The company started operation on Friday, November 13th, 2009, and ceased operation on Saturday, December 12, 2009. This specific scenario was built to be used as a teaching tool both as a disk forensics exercise and as a network forensics exercise. The scenario data is also useful for computer forensics research because the hard drive of each computer and each computer's memory were imaged every day. In this example, we are not particularly interested in the exercises related to illegal activity, exfiltration and eavesdropping; they do however provide interesting components for us to examine in the example data\cite{m57scenario}.
 
 \subsection{Run \bulk with the Data}
 For this example, we downloaded and utilized one of the disk images from the 2009-M57-Patents Scenario. Those images are available at \url{http://digitalcorpora.org/corp/nps/scenarios/2009-m57-patents/drives-redacted/}. The file used throughout this example is called \texttt{charlie-2009-12-11.E01}. Running \bulk on the command line produces the following output (text input by the user is bold):\\
@@ -724,7 +724,7 @@ PointerToLinenumbers="0" ><Characteristics><IMAGE_SCN_CNT_INITIALIZED_DATA />
 \end{lstlisting}
 The first number is the offset and tells you where to find the file. Most executables are not fragmented. The second is the MD5 hash of the first 4k of the file that can be used to deduplicate and look up the file in the hash database. Finally, the bulk of the information is contained in the <PE> XML block that breaks out all of the Windows PE header information. It contains information about the File header, the characteristics of the file, Windows header information and section header information.\\
 
-The file \texttt{winprefetch.txt} contains the information from carved files Windows Prefetch that were discovered anywhere on the drive. \bulk will carve the Prefetch files from unallocated space. This extremely useful because Prefetch files are frequently deleted. A single line in the prefetch output file is also very long. The following is only the beginning of one line from the file:
+The file \texttt{winprefetch.txt} contains information from carved Windows Prefetch files that were discovered anywhere on the drive. \bulk will carve Prefetch files from unallocated space. This is extremely useful because Prefetch files are frequently deleted. A single line in the prefetch output file is also very long. The following is only the beginning of one line from the file:
 \lstset{style=customfile}
 \begin{lstlisting}
 55758336	MSIEXEC.EXE	<prefetch><os>Windows

--- a/doc/latex_manuals/BEWorkedExamples.tex
+++ b/doc/latex_manuals/BEWorkedExamples.tex
@@ -287,7 +287,7 @@ uspto.gov/patft/index.html"><img src="/net
 175198500	http://www.uspto.gov/patft/help/help.htm e></a>\x0A<AHREF="http://www.
 uspto.gov/patft/help/help.htm"><IMG BORDER="0
 \end{lstlisting}
-The file \texttt{url\_histogram.txt} provides the histogram of the potential urls. In that file, UTF-16 formatted text is converted to UTF-8. Note that not all URLs contained in the histogram file are accurate. The are actually URLs that were typed into a web browser. The following are lines taken from that file:
+The file \texttt{url\_histogram.txt} provides the histogram of the potential URLs. In that file, UTF-16 formatted text is converted to UTF-8. Note that not all URLs contained in the histogram file are accurate. They are actually URLs that were typed into a web browser. The following are lines taken from that file:
 \lstset{style=customfile}
 \begin{lstlisting}
 n=3922	http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul	(utf16=2609)
@@ -298,7 +298,7 @@ n=2	http://math.nist.gov/~MDonahue/pubs/nan.ps.gz
 n=2	http://math.nist.gov/~RBoisvert/publications/ADL95.ps.gz
 n=2	http://math.nist.gov/~RBoisvert/publications/IMACS97.ps.gz
 \end{lstlisting}
-Because the histogram file converts the UT-16 formatted text to UTF-8, the histogram file is more human readable than the \texttt{url.txt} file alone. The files \texttt{url\_facebook.txt}, \texttt{url\_microsoft-live}, \texttt{url\_services} and \texttt{url\_searches} all extract specific types of information from URLs. The most useful for digital media triage is likely the file \texttt{url\_searches.txt} because it shows histogram of searches from the disk image. Searches frequently convey intent. The following is an excerpt from that file:
+Because the histogram file converts the UTF-16 formatted text to UTF-8, the histogram file is more human readable than the \texttt{url.txt} file alone. The files \texttt{url\_facebook.txt}, \texttt{url\_microsoft-live}, \texttt{url\_services} and \texttt{url\_searches} all extract specific types of information from URLs. The most useful for digital media triage is likely the file \texttt{url\_searches.txt} because it shows histogram of searches from the disk image. Searches frequently convey intent. The following is an excerpt from that file:
 \lstset{style=customfile}
 \begin{lstlisting}
 n=60	1

--- a/doc/latex_manuals/Makefile.am
+++ b/doc/latex_manuals/Makefile.am
@@ -1,6 +1,6 @@
 LATEXMK ?= latexmk
 PDFS = BECurrentGuide.pdf
-USER_MANUAL_DEPS = BEWorkedExamples.tex references.bib \
+USER_MANUAL_DEPS = BECurrentGuide.tex BEWorkedExamples.tex references.bib \
 	$(wildcard archPics/*.pdf installPics/* otherPics/* viewerPics/*) \
 	carvedJPEG.jpg charlieRunOutput.png
 

--- a/doc/latex_manuals/Makefile.am
+++ b/doc/latex_manuals/Makefile.am
@@ -1,8 +1,33 @@
 LATEXMK ?= latexmk
 PDFS = BECurrentGuide.pdf
+USER_MANUAL_ASSETS = \
+	archPics/howitworks.pdf \
+	archPics/margindepiction.pdf \
+	installPics/installer1.png \
+	installPics/installer_download.pdf \
+	installPics/windowsWarning2.pdf \
+	otherPics/LightgrepCheatSheet.pdf \
+	otherPics/U+0428.pdf \
+	otherPics/U+0428.txt \
+	otherPics/U+062D.pdf \
+	otherPics/U+062D.txt \
+	otherPics/U+2234.pdf \
+	otherPics/U+2234.txt \
+	otherPics/U+611B.pdf \
+	otherPics/U+611B.txt \
+	otherPics/WithWithoutStopList.jpg \
+	otherPics/forensicPath.jpg \
+	viewerPics/emailFeatureFile.png \
+	viewerPics/emailHistogramView.png \
+	viewerPics/listOfOutput.png \
+	viewerPics/reportIsReady.png \
+	viewerPics/runBulk.png \
+	viewerPics/runBulkSnippet.png \
+	viewerPics/runCompleteStatus.png \
+	viewerPics/selectOutputDirectory.png \
+	viewerPics/startup.png
 USER_MANUAL_DEPS = BECurrentGuide.tex BEWorkedExamples.tex references.bib \
-	$(wildcard archPics/*.pdf installPics/* otherPics/* viewerPics/*) \
-	carvedJPEG.jpg charlieRunOutput.png
+	$(USER_MANUAL_ASSETS) carvedJPEG.jpg charlieRunOutput.png
 
 EXTRA_DIST = $(USER_MANUAL_DEPS) index.html assets/bulk-extractor-icon.svg
 

--- a/doc/latex_manuals/Makefile.am
+++ b/doc/latex_manuals/Makefile.am
@@ -1,11 +1,18 @@
 LATEXMK ?= latexmk
 PDFS = BECurrentGuide.pdf
+USER_MANUAL_DEPS = BEWorkedExamples.tex references.bib \
+	$(wildcard archPics/*.pdf installPics/* otherPics/* viewerPics/*) \
+	carvedJPEG.jpg charlieRunOutput.png
+
+EXTRA_DIST = $(USER_MANUAL_DEPS) index.html assets/bulk-extractor-icon.svg
 
 .PHONY: all doc pdfs clean
 
 all:
 	@echo "Run make pdfs to build the LaTeX manuals."
 doc pdfs: $(PDFS)
+
+BECurrentGuide.pdf: $(USER_MANUAL_DEPS)
 
 %.pdf: %.tex
 	$(LATEXMK) -pdf -halt-on-error -file-line-error $<

--- a/doc/latex_manuals/index.html
+++ b/doc/latex_manuals/index.html
@@ -127,7 +127,7 @@
           <div class="label">PDF manual</div>
           <h3>Programmer's Manual</h3>
           <p>Architecture, API, concurrency, output, examples, testing, and implementation guidance for contributors and maintainers.</p>
-          <a href="BEProgrammersManual.pdf">Open developer manual (PDF)</a>
+          <a href="BEProgrammersManual.pdf">Open programmer's manual (PDF)</a>
         </article>
         <article class="card">
           <div class="label">Reference</div>

--- a/doc/latex_manuals/index.html
+++ b/doc/latex_manuals/index.html
@@ -114,19 +114,19 @@
     <section id="manuals" aria-labelledby="manuals-heading">
       <div class="section-heading">
         <h2 id="manuals-heading">Documentation</h2>
-        <p>Start with the operating guide for practical use, then use the developer manual when extending or maintaining the project.</p>
+        <p>Start with the user manual for practical and investigative use, then use the programmer's manual when extending or maintaining the project.</p>
       </div>
       <div class="grid">
         <article class="card">
           <div class="label">PDF manual</div>
-          <h3>Current Operating Guide</h3>
-          <p>Build, configure, and run bulk_extractor for forensic investigation workflows.</p>
-          <a href="BECurrentGuide.pdf">Open operating guide (PDF)</a>
+          <h3>User Manual</h3>
+          <p>Understand, build, configure, run, tune, and interpret bulk_extractor through practical forensic workflows and worked investigations.</p>
+          <a href="BECurrentGuide.pdf">Open user manual (PDF)</a>
         </article>
         <article class="card">
           <div class="label">PDF manual</div>
-          <h3>Developer Manual</h3>
-          <p>Architecture and implementation guidance for contributors and maintainers.</p>
+          <h3>Programmer's Manual</h3>
+          <p>Architecture, API, concurrency, output, examples, testing, and implementation guidance for contributors and maintainers.</p>
           <a href="BEProgrammersManual.pdf">Open developer manual (PDF)</a>
         </article>
         <article class="card">

--- a/doc/latex_manuals/references.bib
+++ b/doc/latex_manuals/references.bib
@@ -9,7 +9,7 @@ programmerstex,
 @misc{
 installreadme,
 	Author = {Simson Garfinkel},
-	title={Readme File for \textit{\bulk}},
+	title={Readme File for \bulk},
 	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/README.md}",
 	year={2013},
 	month={June}

--- a/doc/latex_manuals/references.bib
+++ b/doc/latex_manuals/references.bib
@@ -50,7 +50,7 @@ dfxmlpaper,
 	title = {Digital forensics XML and the DFXML toolset},
 	journal ={Digital Investigation},
 	volume={8},
-	issues={3-4},
+	number={3-4},
 	month={February},
 	year={2012},
 	pages={161-174}

--- a/doc/latex_manuals/references.bib
+++ b/doc/latex_manuals/references.bib
@@ -1,0 +1,132 @@
+@misc{
+programmerstex,
+	author = {Simson Garfinkel},
+	title = "Programmer Documentation",
+	url= "https://github.com/simsong/bulk_extractor/blob/master/doc/user_misc/programmer.tex",
+	month={December},
+	year={2012}
+}
+@misc{
+installreadme,
+	Author = {Simson Garfinkel},
+	title={Readme File for \textit{\bulk\_extractor}},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/readme.txt}",
+	year={2013},
+	month={June}
+}
+
+@misc{
+pluginsreadme,
+	Author = {Simson Garfinkel},
+	Title = {Readme File for Plug-ins},
+	url = "https://github.com/simsong/bulk_extractor/blob/master/plugins/README_PLUGINS.txt",
+	month={October},
+	year={2013}
+}
+@article{
+programmingUnicode,
+	Author ={Simson Garfinkel},
+	Title={Programming Unicode},
+	journal={login - Usenix.org},
+	month={April},
+	year={2012},
+	pages={25-37}
+}
+
+@article{
+digitalmediatriage,
+	Author={Simson Garfinkel},
+	Title={Digital media triage with bulk data analysis and bulk\_extractor},
+	journal={Computers \& Security},
+	volume={32},
+	month={October},
+	year={2012},
+	pages={56-72}
+}
+
+@article{
+dfxmlpaper,
+	Author={Simson Garfinkel},
+	title = {Digital forensics XML and the DFXML toolset},
+	journal ={Digital Investigation},
+	volume={8},
+	issues={3-4},
+	month={February},
+	year={2012},
+	pages={161-174}
+}
+
+@misc{
+parashift,
+	Author={Cline, Marshall},
+	Title={FAQ Const-Correctness},
+	howpublished="Website:\url{http://www.parashift.com/c++-faq/const-correctness.html}",
+	year={2013},
+	note="[Online; accessed May 2013]"
+}
+
+@misc{
+m57scenario,
+	Title={M57 Patents Scenario},
+	howpublished="Website:\url{http://digitalcorpora.org/corpora/scenarios/m57-patents-scenario}",
+	month={May},
+	year={2013},
+	note="[Online; accessed August 2013]"
+}
+
+@misc{
+npsdiskimages,
+	Title={Disk Images},
+	howpublished="Website:\url{http://digitalcorpora.org/corpora/disk-images}",
+	month={June},
+	year={2013},
+	note="[Online; accessed August 2013]"
+}
+
+
+@misc{
+bulkguidelines,
+	Author={Simson Garfinkel},
+	Title={Coding Standards for \textit{bulk\_extractor}},
+	howpublished ="Website:\url{https://github.com/simsong/be13_api/blob/master/CODING\_STANDARDS.txt}",
+	month={December},
+	year={2012}
+}
+
+
+@article{
+hashEncoding,
+	Author={Young, J and Foster, K and Garfinkel, S and Fairbanks, K},
+	Title={Distinct sector hashes for target file detection},
+	journal={IEEE Computer},
+	month= {December},
+	year={2012}
+}
+
+@article{
+encodedEvidence,
+	Author={Simson Garfinkel},
+	Title={The Prevalence Of Encoded Digital Trace Evidence in the Non-File Space of Computer Media},
+	journal={Journal of Forensic Sciences},
+	year={2013}
+}
+
+@misc{
+programmersmanual,
+	Author={Bradley, Jessica and Simson Garfinkel},
+	Title={Programmers Manual for Developing Scanner Plug-ins},
+	url="http://digitalcorpora.org/downloads/bulk_extractor/doc/BEProgrammersManual.pdf",
+	month={July},
+	year={2013}
+}
+
+@article{
+bulkdataanalysis,
+	Author ={Simson Garfinkel and Nelson, Alex and White, Douglas and Roussev, Vassil},
+	Title={Using purpose-built functions and block hashes to enable small block and sub-file forensics},
+	journal={Digital Investigation},
+	volume={7},
+	month={August},
+	year={2010},
+	pages={S13-S23}
+}

--- a/doc/latex_manuals/references.bib
+++ b/doc/latex_manuals/references.bib
@@ -2,15 +2,15 @@
 programmerstex,
 	author = {Simson Garfinkel},
 	title = "Programmer Documentation",
-	url= "https://github.com/simsong/bulk_extractor/blob/master/doc/user_misc/programmer.tex",
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/doc/programmer_manual/BEProgrammersManual.tex}",
 	month={December},
 	year={2012}
 }
 @misc{
 installreadme,
 	Author = {Simson Garfinkel},
-	title={Readme File for \textit{\bulk\_extractor}},
-	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/readme.txt}",
+	title={Readme File for \textit{\bulk}},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/README.md}",
 	year={2013},
 	month={June}
 }
@@ -18,8 +18,8 @@ installreadme,
 @misc{
 pluginsreadme,
 	Author = {Simson Garfinkel},
-	Title = {Readme File for Plug-ins},
-	url = "https://github.com/simsong/bulk_extractor/blob/master/plugins/README_PLUGINS.txt",
+	Title = {Scanner API and Plug-in Development Guide},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/doc/scanner_api.md}",
 	month={October},
 	year={2013}
 }
@@ -115,7 +115,7 @@ encodedEvidence,
 programmersmanual,
 	Author={Bradley, Jessica and Simson Garfinkel},
 	Title={Programmers Manual for Developing Scanner Plug-ins},
-	url="http://digitalcorpora.org/downloads/bulk_extractor/doc/BEProgrammersManual.pdf",
+	howpublished="Website:\url{https://github.com/simsong/bulk_extractor/blob/main/doc/programmer_manual/BEProgrammersManual.tex}",
 	month={July},
 	year={2013}
 }

--- a/doc/programmer_manual/BEProgrammersManual.tex
+++ b/doc/programmer_manual/BEProgrammersManual.tex
@@ -6,9 +6,9 @@
 \usepackage{longtable}
 \newcommand{\bulk}{\textit{bulk\_extractor}}
 \newcommand{\code}[1]{\texttt{#1}}
-\title{bulk\_extractor 2.x Developer Manual}
-\author{bulk\_extractor project}
-\date{July 2026}
+\title{bulk\_extractor 2.2 Programmer's Manual}
+\author{Jessica R. Bradley, Simson L. Garfinkel, and the bulk\_extractor project}
+\date{August 2026}
 
 \begin{document}
 \maketitle
@@ -357,6 +357,457 @@ feeding equivalent decoded data back into the scanner set. \\
 \end{longtable}
 
 \clearpage
+\section{Architecture in detail}
+
+The version 1 manual described \bulk as an integrated but compact pipeline.
+That description remains useful in 2.x even though the concrete classes and
+callbacks changed. The principal components are:
+
+\begin{itemize}
+\item an image-processing layer that opens a raw, split-raw, EWF, mapped-file,
+  directory, or supported raw-device source and produces primary sbufs;
+\item a scanner set that discovers built-in and loadable scanners, runs INIT,
+  applies scanner selection, creates feature recorders, and runs INIT2;
+\item a work queue that presents eligible sbufs to enabled scanners on worker
+  threads;
+\item recursive processing that returns validated derived sbufs to the scanner
+  set while preserving their forensic paths;
+\item feature recorders that serialize findings, apply stop and alert lists,
+  update histograms, and perform configured carving; and
+\item DFXML reporting that records source, configuration, provenance,
+  diagnostics, timing, and completion state in \code{report.xml}.
+\end{itemize}
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[height=.68\textheight,keepaspectratio]{scannerloop.pdf}
+\caption{Historical scanner-loop diagram. In 2.x the scanner set and work
+queue implement the loop, and one scanner function may be entered concurrently.}
+\end{figure}
+
+The framework owns sequencing between these components. A scanner should not
+open the report directory directly for ordinary findings, build its own
+histogram in SCAN, invent a parallel work queue, or bypass the recursion API.
+Doing so loses stop-list, alert-list, quoting, provenance, shutdown, and
+write-error behavior that the framework supplies.
+
+\subsection{Input pages and margins}
+
+A primary sbuf contains \code{pagesize} bytes owned by the current page and may
+contain additional bytes up to \code{bufsize} as a margin. A scanner normally
+starts a finding only in the page and may read into the margin to finish it.
+This convention prevents a feature that spans two pages from being missed or
+reported twice. A scanner that performs its own boundary ownership rule risks
+both errors.
+
+Derived sbufs also carry a page size. Preserve intentional page and margin
+semantics when creating a derived buffer. Tests for a scanner that can match a
+long feature must place the start immediately before a page boundary and
+assert one correctly positioned output record.
+
+\subsection{Scanner discovery and selection}
+
+Built-in scanners are registered by the executable. Loadable scanners are
+discovered in each \code{-P} and \code{BE\_PATH} directory. Discovery calls
+INIT so the framework can learn a scanner's name, metadata, flags, recorder
+definitions, histogram definitions, limits, and settings. Selection commands
+are then applied. Only enabled scanners receive INIT2, SCAN, and SHUTDOWN, but
+every loaded scanner receives CLEANUP.
+
+Scanner names are user-visible interfaces. Changing a name changes \code{-e},
+\code{-x}, logs, tests, and saved procedures. Recorder names likewise determine
+feature filenames and recorder-specific \code{-S} names such as
+\code{jpeg\_carve\_mode}. Treat both as compatibility-sensitive.
+
+\section{The safer-buffer API}
+
+\code{sbuf\_t} associates immutable bytes with a \code{pos0\_t}, a buffer size,
+and a page size. Its checked accessors throw on invalid reads. Important
+properties and operations include:
+
+\begin{longtable}{p{.29\linewidth}p{.65\linewidth}}
+\hline
+\textbf{Member or operation} & \textbf{Meaning} \\
+\hline
+\endfirsthead
+\hline
+\textbf{Member or operation} & \textbf{Meaning} \\
+\hline
+\endhead
+\code{pos0} & Forensic position of byte zero, including transformations. \\
+\code{bufsize} & Total readable bytes, including any margin. \\
+\code{pagesize} & Bytes owned by this page; never greater than bufsize. \\
+\code{operator[]} & Bounds-checked byte access. \\
+\code{substr()} & A checked string copy of a byte range. \\
+\code{slice()} & A non-owning child view that must not outlive its parent. \\
+\code{new\_slice\_copy()} & An independently owned copy of a range. \\
+\code{sbuf\_malloc()} & A writable, owned buffer used for derived data. \\
+\code{depth()} & Transformation depth encoded by the forensic path. \\
+\hline
+\end{longtable}
+
+Use an integer reader with the correct byte order for structured fields and
+check that the complete structure is present before interpreting dependent
+lengths or offsets. Do not prove that two bytes are readable and then trust a
+length that requires a third or fourth byte. Compute sizes with overflow-aware
+arithmetic before slicing or allocating.
+
+The raw pointer returned by \code{get\_buf()} is an explicit abstraction
+escape. Prefer checked accessors. If a third-party API requires a pointer, first
+validate the entire range, pass the minimum range, and do not retain it. Neither
+\code{scanner\_params}, \code{sp.sbuf}, a slice, nor a pointer into an sbuf may
+outlive the SCAN callback unless the data have been copied into scanner-owned
+storage with an explicit lifetime.
+
+\subsection{Forensic positions}
+
+Adding an ordinary byte offset to \code{sbuf.pos0} produces the position of a
+feature in the current buffer. A decoder appends a named transformation when it
+creates derived data. Names such as \code{GZIP}, \code{PDF}, or
+\code{XOR(255)} explain how to reproduce the feature from its source.
+
+Do not replace a supplied path with a bare integer, and do not use a display
+filename as provenance. Forensic paths may refer to bytes that no file-system
+parser can associate with an allocated file. If a transformation has its own
+internal offset, append that offset consistently so feature recorders can add
+the feature's local position.
+
+\section{Feature recorders and forensic output}
+
+One feature recorder normally corresponds to one feature file. Multiple
+scanners may share it. A scanner declares a \code{feature\_recorder\_def} in
+INIT and retrieves the recorder by name in INIT2. In SCAN it normally uses one
+of these interfaces:
+
+\begin{itemize}
+\item \code{write(pos, feature, context)} when all fields are already
+  available;
+\item \code{write\_buf(sbuf, offset, length)} to record bytes and obtain
+  standard context without unsafe pointer arithmetic; and
+\item \code{carve(sbuf, extension)} for a recorder declared with carving
+  support.
+\end{itemize}
+
+Record the smallest meaningful feature and enough bounded context to validate
+it. Recorders quote non-UTF-8 bytes, enforce maximum feature and context sizes,
+serialize concurrent writes, and propagate disk-write failures. XML recorders
+use a distinct quoting mode; declaring arbitrary text as XML can create invalid
+output.
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=.70\linewidth,height=.36\textheight,keepaspectratio]{writetoemail.pdf}
+\caption{Historical example of multiple discoveries reaching an email feature
+recorder. The recorder remains the synchronization and policy boundary in 2.x.}
+\end{figure}
+
+\subsection{Stop lists, alert lists, and banners}
+
+The recorder set applies the global stop and alert lists. A stopped feature is
+diverted to the corresponding stopped recorder; an alerting feature is copied
+to the alert recorder. Scanner code should not reimplement these lists. Flags
+exist for special recorders that must not honor one of them, but the exception
+must be justified by the output contract.
+
+Feature-file banners are also handled by the recorder layer. Writing directly
+to a file in the report directory can omit the banner and produce output that
+appears authoritative but is outside the normal evidence-handling path.
+
+\subsection{Histograms}
+
+A \code{histogram\_def} declares the source recorder, optional extraction
+pattern, output suffix, and normalization flags. Histograms are normally
+updated incrementally as features are recorded and written at shutdown. A
+scanner declares the histogram in INIT and writes ordinary features; it does
+not increment a separate global map in SCAN.
+
+\begin{figure}[htbp]
+\centering
+\includegraphics[width=.62\linewidth,height=.48\textheight,keepaspectratio]{histogramprocessing.pdf}
+\caption{Features feed histogram processing through the recorder system.}
+\end{figure}
+
+Choose normalization deliberately. Lowercasing is appropriate for domains and
+many email comparisons but not for every identifier. A histogram regular
+expression should have a focused test that proves the captured value, ignored
+input, and handling of malformed or unexpectedly large features.
+
+\subsection{Carving}
+
+A carving recorder declares the carve flag, default mode, and minimum and
+maximum sizes. The framework implements mode 0 (none), mode 1 (derived or
+encoded paths), mode 2 (all accepted objects), hashing, deduplication, safe
+filenames, and the carving feature record. The scanner remains responsible for
+validating that the candidate is a real object and for passing its correct
+extent. A signature alone is rarely sufficient validation.
+
+\section{DFXML and run provenance}
+
+DFXML represents forensic processing, sources, hashes, files, timestamps, and
+tool metadata in a form that independent programs can exchange
+\cite{dfxmlpaper}. \bulk writes a DFXML 1.2.0 \code{report.xml} and places
+program-specific configuration, runtime, source-detail, and final-report data
+in its extension namespace.
+
+Scanners usually contribute findings through feature recorders rather than
+writing XML into \code{report.xml}. A scanner that has scanner-owned summary
+output to finish does so in SHUTDOWN before recorder shutdown. Diagnostics and
+exceptions should flow through framework facilities so the final report and
+exit status do not claim success after a failed write or unexpected exception.
+
+Do not assume \code{report.xml} is complete while a scan is running. It is also
+the restart record: the input pages in progress at interruption are deliberately
+skipped on resume to avoid repeating a data-dependent failure. Code that
+changes page reporting or shutdown ordering must preserve this contract and
+the schema-validation test.
+
+\section{Developing robust scanner logic}
+
+\subsection{Acceptance criteria and false positives}
+
+A scanner should state what byte sequence constitutes a candidate, what
+additional fields validate it, what corruption is tolerated, and what evidence
+is reported when validation is partial. The more common a magic sequence is,
+the stronger the structural validation must be.
+
+For example, a JPEG/EXIF candidate is stronger after validating byte order,
+the TIFF marker, application-marker lengths, and the bounds of referenced
+fields than after matching only \code{Exif}. Checksums, reserved bits, internal
+length consistency, plausible timestamps, and expected terminators are common
+validation tools. Apply each only when the format specification supports it;
+an over-strict validator can hide damaged but valuable evidence.
+
+Tests should include a valid object, a near miss, truncated data at each length
+boundary, a candidate spanning the primary-page boundary, and hostile values
+that would overflow size or offset calculations. Use a public or generated
+fixture small enough to inspect. Avoid mocking the scanner framework when the
+real scanner set and recorder path can exercise the contract.
+
+\subsection{Concurrency rules}
+
+INIT, INIT2, SHUTDOWN, and CLEANUP are serialized on the main thread, but SCAN
+may be entered simultaneously on several worker threads. Local variables are
+the simplest safe state. Immutable tables initialized before SCAN are safe.
+Shared counters may use atomics; larger state requires a narrowly scoped mutex
+or a data structure with a documented concurrency contract.
+
+Thread-local state is not initialized by the removed
+\code{PHASE\_THREAD\_BEFORE\_SCAN}. Use C++ \code{thread\_local} with care or
+redesign the dependency. Never assume that a particular worker will call the
+scanner again or that shutdown executes on a worker that owns its state.
+
+Do not hold a scanner mutex while calling a recorder or recursion entry point
+unless the lock ordering is explicit and proven safe. Those calls can allocate,
+write, or invoke substantial framework work. Copy the minimum state under the
+lock, release it, then call the framework.
+
+\subsection{Recursion rules}
+
+Recurse only when a decoder has produced intentional derived data. Append a
+specific transformation to the path, preserve the source offset, set an
+appropriate page size, and transfer ownership exactly once with
+\code{sp.recurse()}. The scanner must not use the child afterward.
+
+Every recursive scanner needs a termination argument. It may reject a path
+already ending in its own transformation, impose a format-specific size or
+depth limit, require the transformation to change the data, or combine these.
+Test both successful recursion and an input that would repeat indefinitely
+without the guard.
+
+\section{Two scanner examples}
+
+The version 1 manual taught the API through an ASCII-sequence scanner and an
+XOR decoder. The examples below retain their lessons using the 2.x contract.
+They are pedagogical; production code should start from
+\code{doc/scanner\_template.cpp} and use the project's maintained parsers and
+tests.
+
+\subsection{ASCII-sequence feature scanner}
+
+This fragment records printable ASCII runs of at least six bytes. INIT declares
+the recorder, INIT2 retrieves it, and SCAN starts runs only before the page
+margin. It uses \code{write\_buf()} so position and context come from the sbuf.
+
+\begin{Verbatim}[fontsize=\small]
+namespace {
+feature_recorder *ascii = nullptr;
+
+void scan_ascii_sequence(scanner_params &sp)
+{
+    switch (sp.phase) {
+    case scanner_params::PHASE_INIT:
+        sp.check_version();
+        sp.info->set_name("ascii_sequence");
+        sp.info->author = "Example";
+        sp.info->description = "Records printable ASCII runs.";
+        sp.info->scanner_version = "1";
+        sp.info->feature_defs.emplace_back("ascii_sequence");
+        return;
+
+    case scanner_params::PHASE_INIT2:
+        ascii = &sp.named_feature_recorder("ascii_sequence");
+        return;
+
+    case scanner_params::PHASE_SCAN: {
+        const sbuf_t &sbuf = *sp.sbuf;
+        for (size_t start = 0; start < sbuf.pagesize; ) {
+            while (start < sbuf.pagesize &&
+                   (sbuf[start] < 0x20 || sbuf[start] > 0x7e)) {
+                ++start;
+            }
+            size_t end = start;
+            while (end < sbuf.bufsize &&
+                   sbuf[end] >= 0x20 && sbuf[end] <= 0x7e) {
+                ++end;
+            }
+            if (end - start >= 6) {
+                ascii->write_buf(sbuf, start, end - start);
+            }
+            start = end == start ? start + 1 : end;
+        }
+        return;
+    }
+
+    case scanner_params::PHASE_CLEANUP:
+        ascii = nullptr;
+        return;
+    default:
+        return;
+    }
+}
+}
+\end{Verbatim}
+
+The focused test should assert a normal run, a five-byte near miss, non-ASCII
+separation, one run crossing the page boundary, and correct forensic position.
+It must run through a real recorder; testing only a private printable-byte
+predicate proves little about scanner integration.
+
+\subsection{Recursive XOR decoder}
+
+The maintained \code{src/scan\_xor.cpp} demonstrates a decoder. It declares
+itself recursive and disabled by default, validates an \code{xor\_mask}
+setting, rejects a zero mask, and refuses paths that show it would repeat an
+equivalent transformation. During SCAN it allocates an owned sbuf with a path
+component such as \code{XOR(255)}, XORs every byte, and transfers the child to
+\code{sp.recurse()}.
+
+The important lesson is not the XOR loop; it is the ownership and termination
+contract. A test must prove that another scanner finds a known feature in the
+decoded child, that the output path records XOR, and that already transformed
+input does not recurse indefinitely.
+
+\section{Packaging and portability}
+
+The old manual described platform-specific shared libraries and a separate API
+submodule. In 2.x, in-tree sources use Automake manifests, and
+\code{src/test\_plugin.cpp} plus \code{scan\_test\_plugin.la} are the maintained
+loadable-module example. A separate plug-in project should compile against the
+same source and ABI as the executable and export only the C-linkage factory.
+
+Keep a scanner in one focused implementation file when practical. Add headers
+when they provide a real interface or isolate testable logic, not by habit. Add
+every distributed source and fixture to the authoritative Automake manifests,
+then run \code{make distcheck}; a local build does not prove the release archive
+contains the file.
+
+Do not guess raw \code{.so}, \code{.dylib}, or \code{.dll} linker flags for an
+in-tree module. Follow the Libtool target. A load test must discover the module
+through \code{-P}, call the exported factory, perform the scanner version check,
+and exercise cleanup.
+
+\section{C++ and project style}
+
+The historical style guide emphasized readable, reusable, testable, and
+thread-safe code. The current source and repository formatting checks are the
+authority. The enduring rules are:
+
+\begin{itemize}
+\item use spaces rather than adding tabs, and keep control flow compact enough
+  to inspect;
+\item make ownership explicit; prefer automatic storage and RAII to raw owning
+  pointers;
+\item use const correctness to make read-only data and APIs evident;
+\item check input bounds and integer arithmetic before access or allocation;
+\item keep scanner-global mutable state to the minimum and document its
+  synchronization;
+\item use standard C++ synchronization rather than platform-specific thread
+  primitives;
+\item report findings through feature recorders and derived data through the
+  recursion API; and
+\item write focused tests that prove emitted evidence, negative cases,
+  provenance, lifecycle, and concurrency where relevant.
+\end{itemize}
+
+Warnings are treated as defects. New code must build without compiler warnings
+on supported configurations. Avoid compiler-specific extensions unless a
+guarded platform requirement makes them necessary. A scanner that depends on
+an optional library must configure, compile, and test both with and without
+that dependency.
+
+\subsection{Formatting conventions}
+
+Do not add tab characters; indent with four spaces. Keep an opening brace on
+the same line as an \code{if}, \code{for}, \code{while}, or similar control
+statement. The established scanner functions normally place the opening brace
+of a non-inline function on the following line. Preserve the local style when
+editing older code instead of mechanically reformatting unrelated lines.
+
+Editors can express the essential indentation rule with the historical Emacs
+file-local declaration:
+
+\begin{Verbatim}[fontsize=\small]
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+\end{Verbatim}
+
+Names, comments, and functions should explain the forensic or format concept,
+not merely restate the implementation. Split code when a helper creates a real
+testable contract or removes repeated parsing; do not fragment a short scanner
+into pro-forma classes and headers.
+
+\subsection{Thread-safe library use and lock scope}
+
+Do not call a library interface that stores shared mutable state when SCAN may
+run concurrently. Prefer reentrant or state-owning interfaces, such as a
+platform's safe time-conversion routine, and test both supported platforms when
+the interfaces differ.
+
+Do not place a single ``giant lock'' around an otherwise non-thread-safe scan
+algorithm. That can make the scanner correct while eliminating all parallelism
+whenever it dominates the workload. Redesign the state into immutable tables,
+per-call objects, thread-local objects with explicit cleanup, or independent
+locked shards. If serialization is inherent in an external dependency,
+document the limitation, minimize the protected region, and measure its effect
+on realistic input \cite{programmerstex}.
+
+\subsection{Const correctness and pointers}
+
+Const correctness prevents accidental mutation through an interface and makes
+review of shared state easier. It is not a synchronization mechanism: a const
+object may contain mutable state, and another reference may still modify the
+same object. Pointer declarations are read from the identifier outward:
+
+\begin{longtable}{p{.38\linewidth}p{.56\linewidth}}
+\hline
+\textbf{Declaration} & \textbf{Meaning} \\
+\hline
+\endfirsthead
+\hline
+\textbf{Declaration} & \textbf{Meaning} \\
+\hline
+\endhead
+\code{const std::string *p} & Pointer to a string that cannot be changed through p. \\
+\code{std::string *const p} & Constant pointer to a string that may be changed. \\
+\code{const std::string *const p} & Constant pointer to a string that cannot be changed through p. \\
+\hline
+\end{longtable}
+
+Use const references for non-owning read-only parameters, and prefer an owning
+value or smart pointer when ownership transfers. Avoid \code{const\_cast}; it
+defeats the type-level guarantee and often hides an ownership or API design
+problem \cite{parashift}.
+
+\clearpage
 \section{Further reading and release checklist}
 
 \begin{itemize}
@@ -393,5 +844,8 @@ Before requesting review, answer these questions from the code and its test:
 \item Does a disabled scanner clean up safely without assuming it initialized
   a recorder or processed an sbuf?
 \end{itemize}
+
+\bibliographystyle{plain}
+\bibliography{references}
 
 \end{document}

--- a/doc/programmer_manual/Makefile
+++ b/doc/programmer_manual/Makefile
@@ -4,7 +4,10 @@ LATEXMK ?= latexmk
 
 all: BEProgrammersManual.pdf
 
-BEProgrammersManual.pdf: BEProgrammersManual.tex
+BEProgrammersManual.pdf: BEProgrammersManual.tex references.bib \
+	extractinformationreprocess.pdf histogramprocessing.pdf \
+	margindepiction.pdf scannerloop.pdf scannersextractfeatures.pdf \
+	system_diagram.pdf writetoemail.pdf
 	$(LATEXMK) -pdf -halt-on-error -file-line-error $<
 
 clean:

--- a/doc/programmer_manual/Makefile.am
+++ b/doc/programmer_manual/Makefile.am
@@ -1,9 +1,14 @@
 LATEXMK ?= latexmk
 PDFS = BEProgrammersManual.pdf
+PROGRAMMER_MANUAL_DEPS = references.bib extractinformationreprocess.pdf \
+	histogramprocessing.pdf margindepiction.pdf scannerloop.pdf \
+	scannersextractfeatures.pdf system_diagram.pdf writetoemail.pdf
 
 .PHONY: all pdfs clean
 
 all pdfs: $(PDFS)
+
+BEProgrammersManual.pdf: $(PROGRAMMER_MANUAL_DEPS)
 
 %.pdf: %.tex
 	$(LATEXMK) -pdf -halt-on-error -file-line-error $<

--- a/doc/programmer_manual/Makefile.am
+++ b/doc/programmer_manual/Makefile.am
@@ -1,6 +1,7 @@
 LATEXMK ?= latexmk
 PDFS = BEProgrammersManual.pdf
-PROGRAMMER_MANUAL_DEPS = references.bib extractinformationreprocess.pdf \
+PROGRAMMER_MANUAL_DEPS = BEProgrammersManual.tex references.bib \
+	extractinformationreprocess.pdf \
 	histogramprocessing.pdf margindepiction.pdf scannerloop.pdf \
 	scannersextractfeatures.pdf system_diagram.pdf writetoemail.pdf
 

--- a/doc/programmer_manual/references.bib
+++ b/doc/programmer_manual/references.bib
@@ -2,15 +2,15 @@
 programmerstex,
 	author = {Garfinkel, Simson},
 	title = {Programmer Documentation},
-	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/master/doc/user_misc/programmer.tex}",
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/doc/programmer_manual/BEProgrammersManual.tex}",
 	month={December},
 	year={2012}
 }
 @misc{
 installreadme,
 	Author = {Garfinkel, Simson},
-	title={Readme File for \textit{\bulk\_extractor}},
-	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/readme.txt}",
+	title={Readme File for \textit{\bulk}},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/README.md}",
 	year={2013},
 	month={June}
 }
@@ -18,8 +18,8 @@ installreadme,
 @misc{
 pluginsreadme,
 	Author = {Garfinkel, Simson},
-	Title = {Readme File for Plug-ins},
-	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/master/plugins/README_PLUGINS.txt}",
+	Title = {Scanner API and Plug-in Development Guide},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/doc/scanner_api.md}",
 	month={October},
 	year={2013}
 }

--- a/doc/programmer_manual/references.bib
+++ b/doc/programmer_manual/references.bib
@@ -9,7 +9,7 @@ programmerstex,
 @misc{
 installreadme,
 	Author = {Garfinkel, Simson},
-	title={Readme File for \textit{\bulk}},
+	title={Readme File for \bulk},
 	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/main/README.md}",
 	year={2013},
 	month={June}

--- a/doc/programmer_manual/references.bib
+++ b/doc/programmer_manual/references.bib
@@ -39,7 +39,7 @@ dfxmlpaper,
 	title = {Digital forensics XML and the DFXML toolset},
 	journal ={Digital Investigation},
 	volume={8},
-	issues={3-4},
+	number={3-4},
 	month={February},
 	year={2012},
 	pages={161-174}

--- a/doc/programmer_manual/references.bib
+++ b/doc/programmer_manual/references.bib
@@ -1,0 +1,55 @@
+@misc{
+programmerstex,
+	author = {Garfinkel, Simson},
+	title = {Programmer Documentation},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/master/doc/user_misc/programmer.tex}",
+	month={December},
+	year={2012}
+}
+@misc{
+installreadme,
+	Author = {Garfinkel, Simson},
+	title={Readme File for \textit{\bulk\_extractor}},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/readme.txt}",
+	year={2013},
+	month={June}
+}
+
+@misc{
+pluginsreadme,
+	Author = {Garfinkel, Simson},
+	Title = {Readme File for Plug-ins},
+	howpublished = "Website:\url{https://github.com/simsong/bulk_extractor/blob/master/plugins/README_PLUGINS.txt}",
+	month={October},
+	year={2013}
+}
+
+@misc{
+bulkguidelines,
+	Author={Garfinkel, Simson},
+	Title={Coding Standards for \textit{bulk\_extractor}},
+	howpublished ="Website:\url{https://github.com/simsong/be13_api/blob/master/CODING\_STANDARDS.txt}",
+	month={December},
+	year={2012}
+}
+
+@article{
+dfxmlpaper,
+	Author={Garfinkel, Simson},
+	title = {Digital forensics XML and the DFXML toolset},
+	journal ={Digital Investigation},
+	volume={8},
+	issues={3-4},
+	month={February},
+	year={2012},
+	pages={161-174}
+}
+
+@misc{
+parashift,
+	Author={Cline, Marshall},
+	Title={FAQ Const-Correctness},
+	howpublished="Website:\url{http://www.parashift.com/c++-faq/const-correctness.html}",
+	year={2013},
+	note="[Online; accessed May 2013]"
+}


### PR DESCRIPTION
## Summary

- restore the comprehensive bulk_extractor user manual, retaining applicable 1.x material while updating commands, scanners, installation, output, tuning, and post-processing for the 2.2 release
- restore the detailed programmer manual's architecture, scanner lifecycle, APIs, concurrency guidance, examples, packaging, and coding practices for the current 2.x implementation
- preserve the historical worked investigations and move BEViewer material to a clearly labeled appendix: it worked with 1.x, is not included in 2.2, and is planned to return during 2.x
- add the restored bibliographies and build dependencies, update the manuals landing page, and record the documentation restoration in the 2.2 release notes

The prior rewrite had substantially reduced both manuals and removed useful material originally developed for the 1.x documentation. This change restores that material wherever it remains applicable and explicitly labels historical-only behavior.

## Validation

- `make -C doc pdfs`
- generated and visually inspected the 37-page user manual and 20-page programmer's manual after rendering every page with Poppler
- confirmed the final LaTeX logs contain no overfull boxes, undefined controls/references, or oversized floats
- `git diff --cached --check`

The generated PDFs are build artifacts; this PR commits their LaTeX sources and build metadata.
