### PR TITLE
Attach tested Snap packages to releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.yml
+++ b/.github/ISSUE_TEMPLATE/release.yml
@@ -76,10 +76,13 @@ body:
       placeholder: |
         - [ ] Source archive:
         - [ ] Windows executable:
+        - [ ] amd64 Snap package:
+        - [ ] arm64 Snap package:
         - [ ] Debian package:
         - [ ] RPM package:
         - [ ] AWS validation summary:
         - [ ] SHA256SUMS:
+        - [ ] Public GitHub Release URL:
     validations:
       required: true
   - type: checkboxes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
             --repo "$GITHUB_REPOSITORY" \
             --output-dir release-assets
 
-      - name: Add Snap packages and regenerate checksums
+      - name: Add Snap packages and append checksums
         run: |
           set -euo pipefail
           amd64=$(find snap-assets -type f -name '*_amd64.snap' -print -quit)
@@ -91,10 +91,9 @@ jobs:
           test -s "$amd64"
           test -s "$arm64"
           cp "$amd64" "$arm64" release-assets/
-          rm release-assets/SHA256SUMS
           (
             cd release-assets
-            sha256sum bulk_extractor-*.tar.gz bulk_extractor64.exe *.snap > SHA256SUMS
+            sha256sum "$(basename "$amd64")" "$(basename "$arm64")" >> SHA256SUMS
           )
 
       - name: Upload release assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,48 @@ permissions:
   actions: read
 
 jobs:
+  snap:
+    name: Build release Snap (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-24.04
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref_name }}
+
+      - name: Build Snap
+        id: snap
+        uses: canonical/action-build@v1
+
+      - name: Install and test the Snap
+        run: |
+          set -euo pipefail
+          sudo snap install --dangerous "${{ steps.snap.outputs.snap }}"
+          sudo snap connect bulk-extractor:home :home
+          image="$HOME/bulk_extractor-fat32.dmg"
+          output="$HOME/bulk_extractor-snap-output"
+          cp src/tests/1mb_fat32.dmg "$image"
+          snap run bulk-extractor -0q -o "$output" "$image"
+          test -s "$output/report.xml"
+
+      - name: Upload Snap
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-snap-${{ matrix.arch }}
+          path: ${{ steps.snap.outputs.snap }}
+          if-no-files-found: error
+
   assemble:
     name: Assemble draft release
+    needs: snap
     runs-on: ubuntu-latest
 
     steps:
@@ -25,6 +65,13 @@ jobs:
         with:
           ref: ${{ inputs.tag || github.ref_name }}
           fetch-depth: 0
+
+      - name: Download tested Snap packages
+        uses: actions/download-artifact@v8
+        with:
+          pattern: release-snap-*
+          path: snap-assets
+          merge-multiple: true
 
       - name: Assemble release assets
         env:
@@ -35,6 +82,20 @@ jobs:
             --tag "$RELEASE_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --output-dir release-assets
+
+      - name: Add Snap packages and regenerate checksums
+        run: |
+          set -euo pipefail
+          amd64=$(find snap-assets -type f -name '*_amd64.snap' -print -quit)
+          arm64=$(find snap-assets -type f -name '*_arm64.snap' -print -quit)
+          test -s "$amd64"
+          test -s "$arm64"
+          cp "$amd64" "$arm64" release-assets/
+          rm release-assets/SHA256SUMS
+          (
+            cd release-assets
+            sha256sum bulk_extractor-*.tar.gz bulk_extractor64.exe *.snap > SHA256SUMS
+          )
 
       - name: Upload release assets
         uses: actions/upload-artifact@v4
@@ -81,4 +142,5 @@ jobs:
             --generate-notes \
             release-assets/bulk_extractor-*.tar.gz \
             release-assets/bulk_extractor64.exe \
+            release-assets/*.snap \
             release-assets/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,43 +16,7 @@ permissions:
 
 jobs:
   snap:
-    name: Build release Snap (${{ matrix.arch }})
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubuntu-24.04
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.tag || github.ref_name }}
-
-      - name: Build Snap
-        id: snap
-        uses: canonical/action-build@v1
-
-      - name: Install and test the Snap
-        run: |
-          set -euo pipefail
-          sudo snap install --dangerous "${{ steps.snap.outputs.snap }}"
-          sudo snap connect bulk-extractor:home :home
-          image="$HOME/bulk_extractor-fat32.dmg"
-          output="$HOME/bulk_extractor-snap-output"
-          cp src/tests/1mb_fat32.dmg "$image"
-          snap run bulk-extractor -0q -o "$output" "$image"
-          test -s "$output/report.xml"
-
-      - name: Upload Snap
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-snap-${{ matrix.arch }}
-          path: ${{ steps.snap.outputs.snap }}
-          if-no-files-found: error
+    uses: ./.github/workflows/snap.yml
 
   assemble:
     name: Assemble draft release
@@ -69,7 +33,7 @@ jobs:
       - name: Download tested Snap packages
         uses: actions/download-artifact@v8
         with:
-          pattern: release-snap-*
+          pattern: bulk-extractor-snap-*
           path: snap-assets
           merge-multiple: true
 
@@ -104,6 +68,71 @@ jobs:
           name: release-assets
           path: release-assets
           if-no-files-found: error
+
+  publish-snaps:
+    name: Publish annotated-tag snaps to stable
+    if: github.event_name == 'push'
+    needs: snap
+    runs-on: ubuntu-24.04
+    environment: snap-store
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Determine whether protected Store credentials are available
+        id: store
+        run: |
+          if [ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Snap Store credentials are not configured; leaving this tagged build unpublished."
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify the annotated release tag and version
+        if: steps.store.outputs.publish == 'true'
+        run: |
+          set -euo pipefail
+          tag=${GITHUB_REF_NAME}
+          version=$(sed -n 's/^AC_INIT(\[BULK_EXTRACTOR\],\[\([^]]*\)\].*/\1/p' configure.ac)
+          test "$tag" = "v$version"
+          test "$(git cat-file -t "refs/tags/$tag")" = tag
+
+      - uses: actions/download-artifact@v4
+        if: steps.store.outputs.publish == 'true'
+        with:
+          pattern: bulk-extractor-snap-*
+          path: snaps
+          merge-multiple: true
+
+      - name: Select architecture-specific packages
+        if: steps.store.outputs.publish == 'true'
+        id: snap-files
+        run: |
+          set -euo pipefail
+          amd64=$(find snaps -name '*_amd64.snap' -type f -print -quit)
+          arm64=$(find snaps -name '*_arm64.snap' -type f -print -quit)
+          test -n "$amd64"
+          test -n "$arm64"
+          printf 'amd64=%s\narm64=%s\n' "$amd64" "$arm64" >> "$GITHUB_OUTPUT"
+
+      - name: Publish amd64 snap
+        if: steps.store.outputs.publish == 'true'
+        uses: canonical/action-publish@v1
+        with:
+          snap: ${{ steps.snap-files.outputs.amd64 }}
+          release: stable
+
+      - name: Publish arm64 snap
+        if: steps.store.outputs.publish == 'true'
+        uses: canonical/action-publish@v1
+        with:
+          snap: ${{ steps.snap-files.outputs.arm64 }}
+          release: stable
 
   publish:
     name: Publish draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ permissions:
 jobs:
   snap:
     uses: ./.github/workflows/snap.yml
+    with:
+      ref: ${{ inputs.tag || github.ref_name }}
 
   assemble:
     name: Assemble draft release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,8 @@ jobs:
           set -euo pipefail
           amd64=$(find snap-assets -type f -name '*_amd64.snap' -print -quit)
           arm64=$(find snap-assets -type f -name '*_arm64.snap' -print -quit)
+          test -n "$amd64"
+          test -n "$arm64"
           test -s "$amd64"
           test -s "$arm64"
           cp "$amd64" "$arm64" release-assets/

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -2,6 +2,11 @@ name: Snap build and test
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        description: Git ref to build; defaults to the triggering ref.
+        required: false
+        type: string
   pull_request:
     paths:
       - '.github/workflows/snap.yml'
@@ -37,6 +42,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Build snap
         id: snap

--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -1,6 +1,7 @@
 name: Snap build and test
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - '.github/workflows/snap.yml'
@@ -10,7 +11,6 @@ on:
       - 'src/**'
   push:
     branches: [main]
-    tags: ['v*']
     paths:
       - '.github/workflows/snap.yml'
       - 'snap/**'
@@ -59,68 +59,3 @@ jobs:
           name: bulk-extractor-snap-${{ matrix.arch }}
           path: ${{ steps.snap.outputs.snap }}
           if-no-files-found: error
-
-  publish-stable:
-    name: Publish annotated-tag snaps to stable
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    needs: build-and-test
-    runs-on: ubuntu-24.04
-    environment: snap-store
-    env:
-      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Determine whether protected Store credentials are available
-        id: store
-        run: |
-          if [ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]; then
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "Snap Store credentials are not configured; leaving this tagged build unpublished."
-          else
-            echo "publish=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Verify the annotated release tag and version
-        if: steps.store.outputs.publish == 'true'
-        run: |
-          set -euo pipefail
-          tag=${GITHUB_REF_NAME}
-          version=$(sed -n 's/^AC_INIT(\[BULK_EXTRACTOR\],\[\([^]]*\)\].*/\1/p' configure.ac)
-          test "$tag" = "v$version"
-          test "$(git cat-file -t "refs/tags/$tag")" = tag
-
-      - uses: actions/download-artifact@v4
-        if: steps.store.outputs.publish == 'true'
-        with:
-          pattern: bulk-extractor-snap-*
-          path: snaps
-          merge-multiple: true
-
-      - name: Select architecture-specific packages
-        if: steps.store.outputs.publish == 'true'
-        id: snap-files
-        run: |
-          set -euo pipefail
-          amd64=$(find snaps -name '*_amd64.snap' -type f -print -quit)
-          arm64=$(find snaps -name '*_arm64.snap' -type f -print -quit)
-          test -n "$amd64"
-          test -n "$arm64"
-          printf 'amd64=%s\narm64=%s\n' "$amd64" "$arm64" >> "$GITHUB_OUTPUT"
-
-      - name: Publish amd64 snap
-        if: steps.store.outputs.publish == 'true'
-        uses: canonical/action-publish@v1
-        with:
-          snap: ${{ steps.snap-files.outputs.amd64 }}
-          release: stable
-
-      - name: Publish arm64 snap
-        if: steps.store.outputs.publish == 'true'
-        uses: canonical/action-publish@v1
-        with:
-          snap: ${{ steps.snap-files.outputs.arm64 }}
-          release: stable

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -307,6 +307,9 @@ through the project's normal pull-request and CI process.
   ([#621](https://github.com/simsong/bulk_extractor/issues/621)).
 - The release workflow now assembles and verifies artifacts in a read-only job;
   only its separate draft-publishing job receives repository write permission.
+- Added a step-by-step release-manager runbook covering the release issue,
+  final version promotion, signed tag, automated or manual draft, asset review,
+  public publication, and downstream follow-up.
 - Release managers can run an AWS OIDC large-image gate that uses a disposable,
   fixed-size instance with an eight-hour shutdown cap, encrypted temporary
   storage, least-privilege input/output access, cleanup, and an attested,

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -299,10 +299,11 @@ through the project's normal pull-request and CI process.
   checkout, and copies generated `.deb`, `.dsc`, `.changes`, `.buildinfo`,
   `.orig.tar.gz`, and `.debian.tar.*` artifacts to `$(RELEASE_ARTIFACT_DIR)`
   on the host.
-- Added tag-driven draft-release assembly for the source archive and tested
-  Windows executable. The Python driver derives the version from `configure.ac`,
-  can assemble and checksum supplied artifacts with `--dry-run`, and never
-  publishes a GitHub Release without a release-manager action
+- Added tag-driven draft-release assembly for the source archive, tested
+  Windows executable, and tested amd64/arm64 Snap packages. The Python driver
+  derives the version from `configure.ac`, can assemble and checksum supplied
+  artifacts with `--dry-run`, and never publishes a GitHub Release without a
+  release-manager action
   ([#621](https://github.com/simsong/bulk_extractor/issues/621)).
 - The release workflow now assembles and verifies artifacts in a read-only job;
   only its separate draft-publishing job receives repository write permission.

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -31,9 +31,10 @@ or reuse it. There are two supported ways to create the GitHub *draft* release:
 
 1. **Automated draft:** Push the signed tag, or dispatch
    `.github/workflows/release.yml` for that tag. The workflow waits for the
-   successful source-distribution and MinGW runs for the tagged commit,
-   assembles the source archive, Windows executable, and `SHA256SUMS`, then
-   creates a draft release.
+   successful source-distribution and MinGW runs for the tagged commit, builds
+   and install-tests amd64 and arm64 Snap packages, assembles the source
+   archive, Windows executable, Snap packages, and `SHA256SUMS`, then creates
+   a draft release.
 2. **Manual draft:** Go to [Releases](https://github.com/simsong/bulk_extractor/releases),
    click **Draft a new release**, choose the existing signed tag, title it
    `BE vX.Y.Z`, generate or paste the reviewed notes, attach the verified
@@ -194,6 +195,7 @@ The staged set must contain:
 | --- | --- | --- |
 | Source archive | `make distcheck` | Version and source-tag match |
 | Windows `.exe` | MinGW workflow | Exact artifact passed Windows test |
+| Snap packages | Release workflow | amd64 and arm64 packages passed confined install tests |
 | Debian `.deb` | [#622][deb-issue] | Clean package build and installed-package smoke test; direct-download artifact only |
 | RPM/SRPM | [#623][rpm-issue] | Clean RPM build and installed-package smoke test; direct-download artifact only |
 | AWS summary | [#624][aws-issue] | Redacted large-image build/scan result and cleanup evidence |
@@ -270,11 +272,11 @@ clicking **Publish release** unless the release issue makes them a gate:
 
 - [#624][aws-issue]: budget-capped AWS large-image validation and secure
   reporting.
-- [#626][snap-issue]: optional project-owned Snap Store publication for Ubuntu
-  users; it does not replace the Debian-to-Ubuntu path. The strict-confinement
-  interface model, local `make snap` entry point, amd64/arm64 install-test
-  workflow, and protected annotated-tag stable publication are documented in
-  [doc/snap.md](snap.md).
+- [#626][snap-issue]: project-owned Snap Store publication for Ubuntu users;
+  it does not replace the Debian-to-Ubuntu path. The release workflow attaches
+  its tested amd64 and arm64 `.snap` packages to the GitHub draft release.
+  Uploading those same packages to the Store remains a protected, separate
+  annotated-tag action documented in [doc/snap.md](snap.md).
 
 Once these are complete, a release manager should be able to direct Codex to
 prepare a release PR, validate the tag, trigger the protected workflow, and

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -50,6 +50,90 @@ Use a `release/X.Y` branch only when maintaining an established release line
 while `main` continues with new development. Do not create a release branch for
 an ordinary single-release cycle.
 
+## Step-by-step GitHub release runbook
+
+Follow these steps in order for a normal upstream release. The release manager
+performs the manual GitHub actions; Codex can prepare the release PR, run the
+local checks, create the signed tag when authorized, and inspect the resulting
+draft.
+
+1. **Open the release issue.** Use the
+   [release issue template](../.github/ISSUE_TEMPLATE/release.yml). Record the
+   target `X.Y.Z` package version, proposed `vX.Y.Z` tag, intended commit SHA,
+   required validation gates, and the people authorized for downstream package
+   submissions. Do not include credentials or forensic data.
+2. **Prepare the release PR.** Starting from `main`, change `configure.ac` to
+   the final package version `X.Y.Z` (without a leading `v`), update
+   `doc/RELEASE_NOTES.md`, package metadata, and any release documentation.
+   For example, promote the current development version `v2.2.0alpha1` to
+   `2.2.0` before making tag `v2.2.0`. Review the PR, address review feedback,
+   and merge it only after its required checks are green.
+3. **Record validation evidence.** On the reviewed commit, run the gates
+   selected in the release issue. At minimum, record the macOS
+   `make distcheck` result and the required GitHub Actions results. Include
+   container, large-image, Debian, and RPM gates only when the release issue
+   makes them required. Record job URLs, artifact names, and checksums in the
+   release issue.
+4. **Create the immutable tag.** Update the local `main` checkout, verify that
+   the selected SHA is the reviewed merged commit, then create and verify a
+   signed annotated tag. Substitute the actual version and SHA:
+
+   ```sh
+   git switch main
+   git pull --ff-only
+   git tag -s -a vX.Y.Z <reviewed-commit-sha> -m "bulk_extractor vX.Y.Z"
+   git verify-tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+   Never retag a release. If the tag does not match the final
+   `configure.ac` value exactly (`v` + package version), stop and correct the
+   release PR before proceeding.
+5. **Let GitHub build the draft release.** Pushing the tag starts the source,
+   Windows, Snap, and draft-release workflows. The release workflow waits for
+   the tagged source and Windows results, builds and install-tests amd64 and
+   arm64 Snaps, then creates a draft GitHub Release. Wait for the workflow to
+   finish successfully; do not create a second draft while it is running.
+6. **Inspect the draft.** Go to
+   [Releases](https://github.com/simsong/bulk_extractor/releases) and open the
+   draft for `vX.Y.Z`. Confirm the title is `BE vX.Y.Z`, the tag points to the
+   reviewed SHA, and the notes accurately describe the release. Confirm these
+   assets and their entries in `SHA256SUMS`:
+
+   - `bulk_extractor-X.Y.Z.tar.gz`;
+   - `bulk_extractor64.exe`;
+   - one tested `*_amd64.snap` and one tested `*_arm64.snap`.
+
+   GitHub also shows its automatically generated source ZIP and tarball. Leave
+   them in place, but treat the verified `bulk_extractor-X.Y.Z.tar.gz` as the
+   project source artifact.
+7. **Add selected manual artifacts.** If the release issue requires direct
+   download packages, run `make release-deb RELEASE_TAG=vX.Y.Z` or
+   `make release-rpm RELEASE_TAG=vX.Y.Z` in a clean tagged checkout, verify
+   the resulting package artifacts, add them to the draft, and regenerate or
+   extend `SHA256SUMS`. Debian, Fedora, and openSUSE archive submissions use
+   source packages and their own signing/build systems; attaching a binary to
+   GitHub is not an archive submission.
+8. **Publish the GitHub Release.** Recheck the title, notes, tag, commit,
+   asset names, checksums, and required validation links. Click
+   **Publish release**. This is the manual action that makes the GitHub release
+   public; saving a draft never publishes it.
+9. **Complete post-publication work.** Add the public release URL and final
+   artifact URLs to the release issue. Verify the tagged Snap workflow's Store
+   result separately; it uploads to the stable channel only when the protected
+   `snap-store` credentials and approvals are configured. Record downstream
+   package submission URLs and, for 2.2.0, complete the CVE advisory follow-up
+   after confirming the public release contains the fix.
+
+### Manual-draft fallback
+
+Use this only when the automated draft workflow is intentionally unavailable
+or has been repaired and rerun. From **Releases**, choose **Draft a new
+release**, select the already-pushed signed `vX.Y.Z` tag, set the title to
+`BE vX.Y.Z`, add the reviewed notes, and upload only artifacts verified for
+that exact tag with their checksums. Saving the draft is safe; use the review
+checklist in step 6 before publishing it.
+
 ## Prerequisites
 
 Before beginning, open a release issue and record:
@@ -161,12 +245,13 @@ make release \
 To use a different empty staging directory, pass
 `RELEASE_ARTIFACT_DIR=/absolute/path` to `make release`.
 
-### GitHub source and Windows assembly
+### GitHub release assembly
 
 `scripts/assemble_github_release.py` is the testable assembly path for the
-GitHub source archive and tested MinGW executable. It reads the version only
-from `configure.ac`, verifies that the source archive embeds that same version,
-and writes these files to an empty output directory:
+GitHub source archive and tested MinGW executable. The release workflow then
+adds its tested Snap packages and regenerates the checksums. The script reads
+the version only from `configure.ac`, verifies that the source archive embeds
+that same version, and writes these files to an empty output directory:
 
 - `bulk_extractor-X.Y.Z.tar.gz`
 - `bulk_extractor64.exe`

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -249,9 +249,10 @@ To use a different empty staging directory, pass
 
 `scripts/assemble_github_release.py` is the testable assembly path for the
 GitHub source archive and tested MinGW executable. The release workflow then
-adds its tested Snap packages and regenerates the checksums. The script reads
-the version only from `configure.ac`, verifies that the source archive embeds
-that same version, and writes these files to an empty output directory:
+adds its tested Snap packages and appends their checksums to the checksum file.
+The script reads the version only from `configure.ac`, verifies that the source
+archive embeds that same version, and writes these files to an empty output
+directory:
 
 - `bulk_extractor-X.Y.Z.tar.gz`
 - `bulk_extractor64.exe`

--- a/doc/RELEASE_PROCEDURE.md
+++ b/doc/RELEASE_PROCEDURE.md
@@ -90,9 +90,9 @@ draft.
    `configure.ac` value exactly (`v` + package version), stop and correct the
    release PR before proceeding.
 5. **Let GitHub build the draft release.** Pushing the tag starts the source,
-   Windows, Snap, and draft-release workflows. The release workflow waits for
-   the tagged source and Windows results, builds and install-tests amd64 and
-   arm64 Snaps, then creates a draft GitHub Release. Wait for the workflow to
+   Windows, and draft-release workflows. The release workflow reuses the Snap
+   build-and-test workflow for amd64 and arm64, then creates a draft GitHub
+   Release. Wait for the workflow to
    finish successfully; do not create a second draft while it is running.
 6. **Inspect the draft.** Go to
    [Releases](https://github.com/simsong/bulk_extractor/releases) and open the
@@ -119,9 +119,9 @@ draft.
    **Publish release**. This is the manual action that makes the GitHub release
    public; saving a draft never publishes it.
 9. **Complete post-publication work.** Add the public release URL and final
-   artifact URLs to the release issue. Verify the tagged Snap workflow's Store
-   result separately; it uploads to the stable channel only when the protected
-   `snap-store` credentials and approvals are configured. Record downstream
+   artifact URLs to the release issue. Verify the release workflow's protected
+   Snap Store job separately; it uploads to the stable channel only when the
+   protected `snap-store` credentials and approvals are configured. Record downstream
    package submission URLs and, for 2.2.0, complete the CVE advisory follow-up
    after confirming the public release contains the fix.
 


### PR DESCRIPTION
## Summary

- reuse one amd64/arm64 Snap build-and-install-test matrix for tag releases
- attach both verified `.snap` files to the draft GitHub Release and append their hashes to the assembler-generated `SHA256SUMS`
- keep Snap Store publication in a separate protected job
- fail clearly when either expected architecture artifact is missing

## Analysis

A GitHub Release should provide the exact tested Snap artifacts that are eligible for Store publication, without making Store credentials or approval a prerequisite for creating the draft release.

Copilot first identified that recomputing all checksums coupled the workflow to the assembler's asset list; signed commit `64f518ea` now appends only the Snap hashes. Its next review found stale runbook wording and unclear empty-artifact failures; signed commit `53c395ac` corrected both.

The following review found that `release.yml` and tag-triggered `snap.yml` would each build and test both architectures. Signed commit `f4e90278` makes `snap.yml` reusable, calls that matrix once from `release.yml`, removes the separate tag trigger, and moves stable publication into a distinct protected release job. Signed commit `15d988e0` also passes the selected tag into the reusable workflow so manual release dispatch builds the requested tag rather than the workflow branch. Pull requests and pushes to `main` retain their existing Snap validation.

## Impact

Draft GitHub Releases gain the exact confined-install-tested Snap packages for both supported architectures without duplicate tag-release builds. Snap Store publication remains separately gated by the `snap-store` environment, credentials, and approvals.

## Validation

- parsed `.github/workflows/release.yml` and `.github/workflows/snap.yml` as YAML
- `bash bootstrap.sh && ./configure && make check -j4`
- `git diff --check`
