### PR TITLE
Test scanner offsets and remove Node 20 Snap actions

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -47,7 +47,23 @@ jobs:
 
       - name: Build snap
         id: snap
-        uses: canonical/action-build@v1
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo groupadd --force --system lxd
+          sudo usermod --append --groups lxd "$USER"
+          sudo snap install lxd
+          sudo lxd init --auto
+          sudo iptables -P FORWARD ACCEPT
+          sudo snap install snapcraft --classic
+          export SNAPCRAFT_BUILD_ENVIRONMENT=lxd
+          export SNAPCRAFT_BUILD_INFO=1
+          export SNAPCRAFT_IMAGE_INFO="{\"build_url\":\"${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+          sudo -u "$USER" -E snapcraft pack
+          shopt -s nullglob
+          snaps=( ./*.snap )
+          test "${#snaps[@]}" -eq 1
+          echo "snap=${snaps[0]}" >> "$GITHUB_OUTPUT"
 
       - name: Install and run the strictly confined snap
         run: |
@@ -61,7 +77,7 @@ jobs:
           test -s "$output/report.xml"
 
       - name: Upload snap
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bulk-extractor-snap-${{ matrix.arch }}
           path: ${{ steps.snap.outputs.snap }}

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -223,6 +223,8 @@ through the project's normal pull-request and CI process.
 - AddressSanitizer now runs on every pull request while redundant workflow
   execution has been reduced
   ([PR #514](https://github.com/simsong/bulk_extractor/pull/514)).
+- Snap builds use native Snapcraft and LXD commands plus Node 24-compatible
+  artifact upload tooling, removing deprecated Node 20 action dependencies.
 - Optional Exiv2 configuration is honored, tested, and disabled by default; its
   version is recorded in DFXML when enabled
   ([PR #532](https://github.com/simsong/bulk_extractor/pull/532)).

--- a/src/test_be.h
+++ b/src/test_be.h
@@ -1,6 +1,9 @@
 #ifndef TEST_BE_H
 #define TEST_BE_H
 
+#include <array>
+#include <cstddef>
+
 /* We assume that the tests are being run out of bulk_extractor/src/.
  * This returns the directory of the test subdirectory.
  */
@@ -15,10 +18,15 @@ sbuf_t *map_file(std::filesystem::path p);
 
 // look for specific output in a file, and throw an exception if it cannot be found
 void grep(const std::string str, std::filesystem::path fname );
-void grep(const Feature &exp, std::filesystem::path fname );
+void grep(const Feature &exp, std::filesystem::path fname, size_t delta=0);
 
 std::filesystem::path test_scanners(const std::vector<scanner_t *> & scanners, sbuf_t *sbuf);
 std::filesystem::path test_scanner(scanner_t scanner, sbuf_t *sbuf);
+constexpr std::array<size_t, 2> SCANNER_TEST_OFFSETS {0, 65};
+bool position_shifted_by(const std::string &before, const std::string &after, size_t delta);
+void verify_shifted_feature_positions(const std::filesystem::path &baseline,
+                                      const std::filesystem::path &shifted,
+                                      size_t delta);
 bool requireFeature(const std::vector<std::string> &lines, const std::string feature);
 
 extern const std::string JSON1;

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -15,6 +15,7 @@
 #include "config.h"
 
 #include <cstdint>
+#include <cctype>
 #include <algorithm>
 #include <cstring>
 #include <fstream>
@@ -23,6 +24,8 @@
 #include <filesystem>
 #include <cstdio>
 #include <iterator>
+#include <limits>
+#include <map>
 #include <stdexcept>
 #include <unistd.h>
 #include <string>
@@ -257,7 +260,79 @@ bool requireFeature(const std::vector<std::string> &lines, const std::string fea
     return false;
 }
 
-std::filesystem::path test_scanners(const std::vector<scanner_t *> & scanners, sbuf_t *sbuf)
+static sbuf_t *prefixed_sbuf(const sbuf_t &sbuf, size_t prefix_size)
+{
+    auto *prefixed = sbuf_t::sbuf_malloc(sbuf.pos0,
+                                         sbuf.bufsize + prefix_size,
+                                         sbuf.pagesize + prefix_size);
+    std::memset(prefixed->malloc_buf(), 0xa5, prefix_size);
+    std::memcpy(static_cast<uint8_t *>(prefixed->malloc_buf()) + prefix_size,
+                sbuf.get_buf(), sbuf.bufsize);
+    return prefixed;
+}
+
+static std::map<std::filesystem::path, std::vector<std::string>>
+feature_positions(const std::filesystem::path &outdir)
+{
+    std::map<std::filesystem::path, std::vector<std::string>> positions;
+    for (const auto &entry : std::filesystem::directory_iterator(outdir)) {
+        if (!entry.is_regular_file() || entry.path().extension() != ".txt") continue;
+        auto &file_positions = positions[entry.path().filename()];
+        for (const auto &line : getLines(entry.path())) {
+            const auto fields = split(line, '\t');
+            if (fields.size() < 2 || fields[0].empty() ||
+                !std::isdigit(static_cast<unsigned char>(fields[0][0]))) continue;
+            file_positions.push_back(fields[0]);
+        }
+        if (file_positions.empty()) positions.erase(entry.path().filename());
+    }
+    return positions;
+}
+
+bool position_shifted_by(const std::string &before, const std::string &after, size_t delta)
+{
+    const auto before_parts = split(before, '-');
+    const auto after_parts = split(after, '-');
+    if (before_parts.size() != after_parts.size()) return false;
+    bool shifted = false;
+    for (size_t i = 0; i < before_parts.size(); i++) {
+        if (before_parts[i] == after_parts[i]) continue;
+        const auto digits = [](unsigned char ch) { return std::isdigit(ch); };
+        if (shifted || before_parts[i].empty() || after_parts[i].empty() ||
+            !std::all_of(before_parts[i].begin(), before_parts[i].end(), digits) ||
+            !std::all_of(after_parts[i].begin(), after_parts[i].end(), digits)) return false;
+        const uint64_t bvalue = std::stoull(before_parts[i]);
+        const uint64_t avalue = std::stoull(after_parts[i]);
+        if (bvalue > std::numeric_limits<uint64_t>::max() - delta || avalue != bvalue + delta) return false;
+        shifted = true;
+    }
+    return shifted;
+}
+
+void verify_shifted_feature_positions(const std::filesystem::path &baseline,
+                                      const std::filesystem::path &shifted,
+                                      size_t delta)
+{
+    const auto expected = feature_positions(baseline);
+    auto actual = feature_positions(shifted);
+    REQUIRE(actual.size() == expected.size());
+    for (const auto &[filename, positions] : expected) {
+        auto found_file = actual.find(filename);
+        REQUIRE(found_file != actual.end());
+        auto &shifted_positions = found_file->second;
+        REQUIRE(shifted_positions.size() == positions.size());
+        for (const auto &position : positions) {
+            const auto found = std::find_if(shifted_positions.begin(), shifted_positions.end(),
+                                            [&](const auto &shifted_position) {
+                                                return position_shifted_by(position, shifted_position, delta);
+                                            });
+            REQUIRE(found != shifted_positions.end());
+            shifted_positions.erase(found);
+        }
+    }
+}
+
+static std::filesystem::path run_scanners(const std::vector<scanner_t *> & scanners, sbuf_t *sbuf)
 {
     debug = getenv_debug("DEBUG");
 
@@ -294,6 +369,17 @@ std::filesystem::path test_scanners(const std::vector<scanner_t *> & scanners, s
     }
     ss.shutdown();
     return sc.outdir;
+}
+
+std::filesystem::path test_scanners(const std::vector<scanner_t *> &scanners, sbuf_t *sbuf)
+{
+    std::array<sbuf_t *, SCANNER_TEST_OFFSETS.size()> inputs {
+        sbuf, prefixed_sbuf(*sbuf, SCANNER_TEST_OFFSETS[1])
+    };
+    std::array<std::filesystem::path, SCANNER_TEST_OFFSETS.size()> outputs;
+    for (size_t i = 0; i < inputs.size(); i++) outputs[i] = run_scanners(scanners, inputs[i]);
+    verify_shifted_feature_positions(outputs[0], outputs[1], SCANNER_TEST_OFFSETS[1]);
+    return outputs[0];
 }
 
 std::filesystem::path test_scanner(scanner_t scanner, sbuf_t *sbuf)

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -293,20 +293,15 @@ bool position_shifted_by(const std::string &before, const std::string &after, si
 {
     const auto before_parts = split(before, '-');
     const auto after_parts = split(after, '-');
-    if (before_parts.size() != after_parts.size()) return false;
-    bool shifted = false;
-    for (size_t i = 0; i < before_parts.size(); i++) {
-        if (before_parts[i] == after_parts[i]) continue;
-        const auto digits = [](unsigned char ch) { return std::isdigit(ch); };
-        if (shifted || before_parts[i].empty() || after_parts[i].empty() ||
-            !std::all_of(before_parts[i].begin(), before_parts[i].end(), digits) ||
-            !std::all_of(after_parts[i].begin(), after_parts[i].end(), digits)) return false;
-        const uint64_t bvalue = std::stoull(before_parts[i]);
-        const uint64_t avalue = std::stoull(after_parts[i]);
-        if (bvalue > std::numeric_limits<uint64_t>::max() - delta || avalue != bvalue + delta) return false;
-        shifted = true;
-    }
-    return shifted;
+    const auto digits = [](unsigned char ch) { return std::isdigit(ch); };
+    if (before_parts.empty() || before_parts.size() != after_parts.size() ||
+        before_parts[0].empty() || after_parts[0].empty() ||
+        !std::all_of(before_parts[0].begin(), before_parts[0].end(), digits) ||
+        !std::all_of(after_parts[0].begin(), after_parts[0].end(), digits) ||
+        !std::equal(before_parts.begin() + 1, before_parts.end(), after_parts.begin() + 1)) return false;
+    const uint64_t bvalue = std::stoull(before_parts[0]);
+    const uint64_t avalue = std::stoull(after_parts[0]);
+    return bvalue <= std::numeric_limits<uint64_t>::max() - delta && avalue == bvalue + delta;
 }
 
 void verify_shifted_feature_positions(const std::filesystem::path &baseline,
@@ -389,6 +384,11 @@ std::filesystem::path test_scanner(scanner_t scanner, sbuf_t *sbuf)
     return test_scanners(scanners, sbuf);
 }
 
+TEST_CASE("forensic paths shift only at the top level", "[support]")
+{
+    CHECK(position_shifted_by("0-GZIP-0", "65-GZIP-0", 65));
+    CHECK_FALSE(position_shifted_by("0-GZIP-0", "0-GZIP-65", 65));
+}
 
 TEST_CASE("base64_forensic", "[support]") {
     sbuf_t::debug_range_exception = true;

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -9,6 +9,7 @@
 
 #include "config.h"
 
+#include <cctype>
 #include <cstring>
 #include <array>
 #include <iostream>
@@ -123,7 +124,18 @@ TEST_CASE("test_validate", "[phase1]" ) {
 }
 
 
-bool feature_match(const Feature &feature, const std::string &line)
+static std::string normalize_embedded_position(std::string value, const std::string &position)
+{
+    for (const char delimiter : {'-', '.', '_', '/'}) {
+        const std::string from = "/" + position + delimiter;
+        for (size_t at = 0; (at = value.find(from, at)) != std::string::npos; at += 3) {
+            value.replace(at, from.size(), "/<>" + std::string(1, delimiter));
+        }
+    }
+    return value;
+}
+
+bool feature_match(const Feature &feature, const std::string &line, size_t delta=0)
 {
     auto words = split(line, '\t');
     if (words.size() <2 || words.size() > 3) return false;
@@ -140,27 +152,39 @@ bool feature_match(const Feature &feature, const std::string &line)
         }
     }
 
-    if ( pos0_t(words[0]) != feature.pos ){
+    const bool position_matches = delta > 0 && !feature.pos.path.empty() &&
+        std::isdigit(static_cast<unsigned char>(feature.pos.path[0]))
+        ? position_shifted_by(feature.pos.path, words[0], delta)
+        : pos0_t(words[0]) == feature.pos;
+    if (!position_matches) {
         if (debug) std::cerr << "  pos " << feature.pos.str() << " does not match '" << words[0] << "'" << std::endl;
         return false;
     }
 
-    if ( words[1] != feature.feature ){
+    const std::string expected_feature = delta > 0
+        ? normalize_embedded_position(feature.feature, feature.pos.path) : feature.feature;
+    const std::string actual_feature = delta > 0
+        ? normalize_embedded_position(words[1], words[0]) : words[1];
+    if (actual_feature != expected_feature) {
         if (debug)std::cerr << "  feature '" << feature.feature << "' does not match feature '" << words[1] << "'" << std::endl;
         return false;
     }
 
-    std::string ctx = feature.context;
+    std::string ctx = delta > 0
+        ? normalize_embedded_position(feature.context, feature.pos.path) : feature.context;
     if (words.size()==2) return ctx=="";
 
-    if ( (ctx=="") || (ctx==words[2]) )  return true;
+    const std::string actual_context = delta > 0
+        ? normalize_embedded_position(words[2], words[0]) : words[2];
+
+    if ( (ctx=="") || (ctx==actual_context) )  return true;
 
     if (debug) std::cerr << "  context '" << ctx << "' (len=" << ctx.size() << ") "
-                         << "does not match context '" << words[2] << "' (" << words[2].size() << ")\n";
+                         << "does not match context '" << actual_context << "' (" << actual_context.size() << ")\n";
 
     if ( ends_with(ctx, "*") ) {
         ctx.resize(ctx.size()-1 );
-        if (starts_with(words[2], ctx )){
+        if (starts_with(actual_context, ctx )){
             return true;
         }
         if (debug) std::cerr << "  context did not start with '" << ctx << "'\n";
@@ -201,7 +225,7 @@ void grep(const std::string str, std::filesystem::path fname )
 }
 
 /* Look for a line in a file and print an error if not found */
-void grep(const Feature &feature, std::filesystem::path fname )
+void grep(const Feature &feature, std::filesystem::path fname, size_t delta)
 {
     for (int pass=0 ; pass<2 ; pass++){
         std::string line;
@@ -214,7 +238,7 @@ void grep(const Feature &feature, std::filesystem::path fname )
         while (std::getline(inFile, line)) {
             switch (pass) {
             case 0:
-                if (feature_match(feature, line)){
+                if (feature_match(feature, line, delta)){
                     return;             // found!
                 }
                 break;
@@ -236,7 +260,11 @@ void grep(const Feature &feature, std::filesystem::path fname )
  * Run all of the built-in scanners on a specific image, look for the given features, and return the directory.
  * These are run single-threading for ease of debugging.
  */
-std::filesystem::path validate(std::string image_fname, std::vector<Check> &expected, bool recurse=true, size_t offset=0)
+static std::filesystem::path validate_once(const std::string &image_fname,
+                                           const std::vector<Check> &expected,
+                                           bool recurse,
+                                           size_t offset,
+                                           size_t prefix_size)
 {
     int start_sbuf_count = sbuf_t::sbuf_count;
 
@@ -251,19 +279,20 @@ std::filesystem::path validate(std::string image_fname, std::vector<Check> &expe
 
     std::cerr << "## image_fname: " << image_fname << " outdir: " << sc.outdir << std::endl;
 
-    if (offset==0) {
+    if (offset == 0 && prefix_size == 0) {
         sc.input_fname = test_dir() / image_fname;
     } else {
-        std::filesystem::path offset_name = sc.outdir / "offset_file";
+        const std::filesystem::path offset_name = sc.outdir / "offset_file";
 
         std::ifstream in(  test_dir() / image_fname, std::ios::binary);
-        std::ofstream out( offset_name );
+        std::ofstream out(offset_name, std::ios::binary);
+        REQUIRE(in.is_open());
+        REQUIRE(out.is_open());
         in.seekg(offset);
+        for (size_t i = 0; i < prefix_size; i++) out.put(static_cast<char>(0xa5));
         char ch;
-        //size_t written = 0;
         while (in.get(ch)) {
             out << ch;
-            //written ++;
         }
         in.close();
         out.close();
@@ -307,10 +336,21 @@ std::filesystem::path validate(std::string image_fname, std::vector<Check> &expe
     delete xreport;
 
     for (const auto &exp : expected ) {
-        grep( exp.feature, sc.outdir / exp.fname );
+        grep(exp.feature, sc.outdir / exp.fname, prefix_size);
     }
     REQUIRE(start_sbuf_count == sbuf_t::sbuf_count);
     return sc.outdir;
+}
+
+std::filesystem::path validate(std::string image_fname, std::vector<Check> &expected,
+                               bool recurse=true, size_t offset=0)
+{
+    std::array<std::filesystem::path, SCANNER_TEST_OFFSETS.size()> outputs;
+    for (size_t i = 0; i < SCANNER_TEST_OFFSETS.size(); i++) {
+        outputs[i] = validate_once(image_fname, expected, recurse, offset,
+                                   SCANNER_TEST_OFFSETS[i]);
+    }
+    return outputs[0];
 }
 
 


### PR DESCRIPTION
Addresses #238.

## Summary

- run shared direct-scanner fixtures with 0- and 65-byte prefixes
- require each positional recorder entry to retain its forensic path with exactly one numeric component increased by 65
- run phase-1 fixture checks at both offsets, including carved filenames, without duplicating individual test bodies
- replace the unreleased Node 20-based Canonical Snap build action with its equivalent native Snapcraft/LXD commands
- upgrade artifact upload to the Node 24-based `actions/upload-artifact@v7`

## Validation

- `make -C src test_be`
- Makefile-driven `test_be` groups: `[phase1]`, `[scanners]`, and `[support]` all pass
- full `make check TESTS=test_be` progressed beyond the scanner coverage, then reproduced the unchanged baseline hang at `bulk_extractor --notify_async -Ro ... ./tests`
- Snap workflow YAML parses successfully and `git diff --check` passes
- hosted amd64 and arm64 Snap build/install tests pass, and both check runs have zero annotations
- Makefile-driven `[support]` suite passes after the review fix (10 test cases, 157 assertions)

The BE2.2 release notes document the Snap workflow dependency update.
