### PR TITLE
Eliminate bootstrap portability warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,8 @@ SUBDIRS = doc doc/latex_manuals man src src/tests specfiles tests
 
 include Makefile.auto_defs
 
+ACLOCAL_AMFLAGS = -I m4
+
 EXTRA_DIST = $(SRC_WIN_DIST) $(AUTO_DOC_FILES) $(AUTO_ETC_FILES) $(AUTO_LICENSES) \
 	$(srcdir)/etc/Dockerfile.fedora-distcheck \
 	$(srcdir)/etc/Dockerfile.ubuntu-distcheck \
@@ -41,9 +43,6 @@ EXTRA_DIST = $(SRC_WIN_DIST) $(AUTO_DOC_FILES) $(AUTO_ETC_FILES) $(AUTO_LICENSES
 	$(srcdir)/dfxml_schema/dfxml.xsd \
 	$(srcdir)/dfxml_schema/ref/dc.xsd \
 	$(srcdir)/dfxml_schema/ref/xml.xsd
-
-
-# ACLOCAL_AMFLAGS = ${ACLOCAL_FLAGS} -I m4
 
 distclean2:
 	@echo Deleting:

--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,6 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE
-AC_PROG_RANLIB
 AC_PREFIX_PROGRAM(bulk_extractor) dnl build for same location
 
 # Programs we will be using

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -211,6 +211,8 @@ through the project's normal pull-request and CI process.
 
 ### Build, configuration, and testing
 
+- Source-tree bootstrap no longer reports obsolete Libtool setup or GNU Make
+  portability warnings from the project Autotools inputs.
 - A build configured with `--disable-rar` now omits RAR-only tests without
   breaking `make check`, and explicitly warns that RAR coverage was not run.
 - A multi-stage Debian Bookworm container image provides a reproducible,

--- a/doc/latex_manuals/Makefile.am
+++ b/doc/latex_manuals/Makefile.am
@@ -1,5 +1,6 @@
 LATEXMK ?= latexmk
-PDFS = BECurrentGuide.pdf
+MANUAL = BECurrentGuide
+PDFS = $(MANUAL).pdf
 USER_MANUAL_ASSETS = \
 	archPics/howitworks.pdf \
 	archPics/margindepiction.pdf \
@@ -37,10 +38,8 @@ all:
 	@echo "Run make pdfs to build the LaTeX manuals."
 doc pdfs: $(PDFS)
 
-BECurrentGuide.pdf: $(USER_MANUAL_DEPS)
-
-%.pdf: %.tex
-	$(LATEXMK) -pdf -halt-on-error -file-line-error $<
+$(PDFS): $(USER_MANUAL_DEPS)
+	$(LATEXMK) -pdf -halt-on-error -file-line-error $(MANUAL).tex
 
 clean:
-	$(LATEXMK) -C $(basename $(PDFS))
+	$(LATEXMK) -C $(MANUAL)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,7 +12,6 @@ EXTRA_DIST = .gitignore scan_headers.flex scan_httpheader_lg.cpp $(AUTO_EXTRA_DI
 	be20_api/tests/unilang8.htm
 
 ETAGS = etags-emacs
-ACLOCAL_AMFLAGS = -I m4
 
 # So that relative imports from be20_api work
 AM_CPPFLAGS = @RE2_CFLAGS@ -I$(top_srcdir)/src/be20_api -I$(top_srcdir)/src/be20_api/utfcpp/source -isystem $(top_srcdir)/src/third_party/spdlog


### PR DESCRIPTION
## Summary

- advertise the top-level `m4` directory to `aclocal` from the root Automake input
- rely on `LT_INIT` to configure `ranlib` instead of invoking obsolete `AC_PROG_RANLIB`
- replace the LaTeX manual's GNU Make pattern and `basename` expressions with an explicit portable rule
- document the warning-free source bootstrap in the 2.2.0 release notes

## Root cause

The `ACLOCAL_AMFLAGS` setting was placed in `src/Makefile.am`, where Libtool could not use it for the top-level macro directory. The configuration also retained a redundant `AC_PROG_RANLIB`, and the configured LaTeX Makefile used GNU Make-only syntax that Automake reports under portability checks.

## Validation

- `sh bootstrap.sh` — completes without the four reported warnings
- `./configure`
- `make -s -C src check TESTS='test_pcap_fake test_dfxml test_be20_api'` — 3/3 pass
- `make -C doc/latex_manuals -n pdfs`
- `make -C doc/latex_manuals -n clean`
- `make -s dist`
- `git diff --cached --check`

The local full `make -s -j4 check` built all targets and passed the three shorter test executables, but `test_be` remained asleep at 0% CPU in its existing context-stop-list case for more than ten minutes and was interrupted. The pull-request CI matrix will provide full-suite validation on clean runners.
