### PR TITLE
Report process memory and fix memory display

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -110,9 +110,13 @@ through the project's normal pull-request and CI process.
 - Progress displays now adapt to Windows console-width changes, matching the
   periodic terminal-width refresh already used on Unix-like systems
   ([#311](https://github.com/simsong/bulk_extractor/issues/311)).
-- The progress display now provides the explicit `available_memory_bytes`
-  metric alongside the legacy `available_memory` alias, and renders byte-valued
-  status metrics in MiB ([#240](https://github.com/simsong/bulk_extractor/issues/240)).
+- Realtime statistics provide cross-platform `process_memory_bytes` and the
+  explicit `available_memory_bytes` metric alongside the legacy
+  `available_memory` alias. The progress display suppresses the duplicate
+  explicit field everywhere and the misleading available-memory value on macOS,
+  while rendering displayed byte-valued metrics in MiB
+  ([#240](https://github.com/simsong/bulk_extractor/issues/240),
+  [#672](https://github.com/simsong/bulk_extractor/issues/672)).
 - Email extraction now enforces independent 64-octet local-part and 253-octet
   domain limits for ASCII and UTF-16 input, avoiding truncated suffix features
   from overlong addresses ([#585](https://github.com/simsong/bulk_extractor/issues/585)).

--- a/src/be20_api/machine_stats.h
+++ b/src/be20_api/machine_stats.h
@@ -121,7 +121,7 @@ struct machine_stats {
 	FILE *f = fopen(statm_path,"r");
 	if(f){
 	    unsigned long size, resident, share, text, lib, data, dt;
-	    if(fscanf(f,"%ld %ld %ld %ld %ld %ld %ld", &size,&resident,&share,&text,&lib,&data,&dt) == 7){
+	    if(fscanf(f,"%lu %lu %lu %lu %lu %lu %lu", &size,&resident,&share,&text,&lib,&data,&dt) == 7){
 		const long page_size = sysconf(_SC_PAGESIZE);
 		if (page_size > 0) {
 		    *virtual_size  = size * static_cast<uint64_t>(page_size);

--- a/src/be20_api/machine_stats.h
+++ b/src/be20_api/machine_stats.h
@@ -18,6 +18,11 @@
 #include <sys/vmmeter.h>
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#include <psapi.h>
+#endif
+
 #include <cmath>
 #include <unistd.h>
 
@@ -45,6 +50,11 @@ struct machine_stats {
     };
 
     static uint64_t get_available_memory() {
+#ifdef _WIN32
+        MEMORYSTATUSEX memory_status{};
+        memory_status.dwLength = sizeof(memory_status);
+        return GlobalMemoryStatusEx(&memory_status) ? memory_status.ullAvailPhys : 0;
+#else
         // If there is a /proc/meminfo, use it
         std::ifstream meminfo("/proc/meminfo");
         if (meminfo.is_open()) {
@@ -76,11 +86,21 @@ struct machine_stats {
 #else
 	return 0;
 #endif
+#endif
     };
 
     static void get_memory(uint64_t *virtual_size, uint64_t *resident_size) {
         *virtual_size = 0;
         *resident_size = 0;
+
+#ifdef _WIN32
+        PROCESS_MEMORY_COUNTERS_EX counters{};
+        if (GetProcessMemoryInfo(GetCurrentProcess(),
+                                 reinterpret_cast<PROCESS_MEMORY_COUNTERS *>(&counters),
+                                 sizeof(counters))) {
+            *resident_size = static_cast<uint64_t>(counters.WorkingSetSize);
+        }
+#else
 
 #ifdef HAVE_TASK_INFO
         kern_return_t error;
@@ -102,14 +122,18 @@ struct machine_stats {
 	if(f){
 	    unsigned long size, resident, share, text, lib, data, dt;
 	    if(fscanf(f,"%ld %ld %ld %ld %ld %ld %ld", &size,&resident,&share,&text,&lib,&data,&dt) == 7){
-		*virtual_size  = size * 4096;
-		*resident_size = resident * 4096;
+		const long page_size = sysconf(_SC_PAGESIZE);
+		if (page_size > 0) {
+		    *virtual_size  = size * static_cast<uint64_t>(page_size);
+		    *resident_size = resident * static_cast<uint64_t>(page_size);
+		}
                 fclose(f);
 		return ;
 	    }
+	    fclose(f);
 	}
-	fclose(f);
 	return ;
+#endif
     };
 };
 

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -247,9 +247,7 @@ std::map<std::string, std::string> scanner_set::get_realtime_stats() const
     uint64_t virtual_size = 0;
     uint64_t resident_size = 0;
     machine_stats::get_memory(&virtual_size, &resident_size);
-    if (resident_size != 0) {
-        ret[PROCESS_MEMORY_STR] = std::to_string(resident_size);
-    }
+    ret[PROCESS_MEMORY_STR] = std::to_string(resident_size);
     ret[SBUFS_CREATED_STR]   = std::to_string(sbuf_t::sbuf_total);
     ret[SBUFS_REMAINING_STR] = std::to_string(sbuf_t::sbuf_count);
     return ret;

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -244,6 +244,12 @@ std::map<std::string, std::string> scanner_set::get_realtime_stats() const
         ret[AVAILABLE_MEMORY_STR] = std::to_string(available_memory);
         ret[AVAILABLE_MEMORY_LEGACY_STR] = std::to_string(available_memory);
     }
+    uint64_t virtual_size = 0;
+    uint64_t resident_size = 0;
+    machine_stats::get_memory(&virtual_size, &resident_size);
+    if (resident_size != 0) {
+        ret[PROCESS_MEMORY_STR] = std::to_string(resident_size);
+    }
     ret[SBUFS_CREATED_STR]   = std::to_string(sbuf_t::sbuf_total);
     ret[SBUFS_REMAINING_STR] = std::to_string(sbuf_t::sbuf_count);
     return ret;

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -199,6 +199,7 @@ public:
     static const inline std::string BYTES_QUEUED_STR {"bytes_queued"};
     static const inline std::string AVAILABLE_MEMORY_STR {"available_memory_bytes"};
     static const inline std::string AVAILABLE_MEMORY_LEGACY_STR {"available_memory"};
+    static const inline std::string PROCESS_MEMORY_STR {"process_memory_bytes"};
     static const inline std::string SBUFS_CREATED_STR {"sbufs_created"};
     static const inline std::string SBUFS_REMAINING_STR {"sbufs_remaining"};
     static const inline std::string MAX_OFFSET {"max_offset"};

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1357,8 +1357,12 @@ void scan_duplicate_opt_in_test(scanner_params& sp) {
 }
 
 #ifdef _WIN32
-TEST_CASE("machine_stats", "[!mayfail][machine_stats]") {
-    WARN("machine_stats not implemented on Windows (ps and /proc/ don't exist)");
+TEST_CASE("machine_stats", "[machine_stats]") {
+    REQUIRE(machine_stats::get_available_memory() != 0);
+    uint64_t virtual_size = 0;
+    uint64_t resident_size = 0;
+    machine_stats::get_memory(&virtual_size, &resident_size);
+    REQUIRE(resident_size > 0);
 }
 #else
 TEST_CASE("machine_stats", "[machine_stats]") {
@@ -1385,6 +1389,8 @@ TEST_CASE("scanner_stats", "[scanner_set]") {
     std::map<scanner_t*, const struct scanner_params::scanner_info*> scanner_info_db{};
     atomic_set<std::string> seen_set {}; // hex hash values of sbuf pages that have been seen
     auto ss = new scanner_set(sc, feature_recorder_set::flags_t(), nullptr);
+    const auto stats = ss->get_realtime_stats();
+    REQUIRE(std::stoull(stats.at(scanner_set::PROCESS_MEMORY_STR)) > 0);
     delete ss;
 }
 

--- a/src/notify_thread.cpp
+++ b/src/notify_thread.cpp
@@ -38,10 +38,24 @@ int notify_thread::terminal_width( int default_width )
     return default_width;
 }
 
+bool notify_thread::should_display_stat(const std::string &name)
+{
+    if (name == scanner_set::AVAILABLE_MEMORY_STR) {
+        return false;
+    }
+#ifdef __APPLE__
+    if (name == scanner_set::AVAILABLE_MEMORY_LEGACY_STR) {
+        return false;
+    }
+#endif
+    return true;
+}
+
 std::string notify_thread::format_stat_value(const std::string &name, const std::string &value)
 {
     if (name != scanner_set::AVAILABLE_MEMORY_STR &&
         name != scanner_set::AVAILABLE_MEMORY_LEGACY_STR &&
+        name != scanner_set::PROCESS_MEMORY_STR &&
         name != scanner_set::DEPTH0_BYTES_QUEUED_STR &&
         name != scanner_set::BYTES_QUEUED_STR &&
         name != scanner_set::MAX_OFFSET) {
@@ -121,6 +135,9 @@ void *notify_thread::run()
         if ( !cfg.opt_legacy) {
             os << ho << "bulk_extractor      " << asctime( &timeinfo) << "  " << std::endl;
             for( const auto &it : stats ){
+                if (!should_display_stat(it.first)) {
+                    continue;
+                }
                 const std::string value = format_stat_value(it.first, it.second);
                 os << it.first << ": " << value;
                 if ( ce[0] ){

--- a/src/notify_thread.h
+++ b/src/notify_thread.h
@@ -24,6 +24,7 @@ public:
         phase_changed() {};
     ~notify_thread();
     static int terminal_width( int default_width );
+    static bool should_display_stat(const std::string &name);
     static std::string format_stat_value(const std::string &name, const std::string &value);
     std::ostream &os;
     scanner_set &ss;

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -115,9 +115,22 @@ TEST_CASE("notify_thread formats byte statistics as MiB", "[notify]")
 {
     REQUIRE(notify_thread::format_stat_value("available_memory_bytes", "10485760") == "10 MiB");
     REQUIRE(notify_thread::format_stat_value("available_memory", "1048576") == "1 MiB");
+    REQUIRE(notify_thread::format_stat_value("process_memory_bytes", "20971520") == "20 MiB");
     REQUIRE(notify_thread::format_stat_value("max_offset", "2097152") == "2 MiB");
     REQUIRE(notify_thread::format_stat_value("bytes_queued", "1048575") == "0 MiB");
     REQUIRE(notify_thread::format_stat_value("tasks_queued", "12") == "12");
+}
+
+TEST_CASE("notify_thread suppresses the duplicate memory statistic", "[notify]")
+{
+    REQUIRE_FALSE(notify_thread::should_display_stat("available_memory_bytes"));
+#ifdef __APPLE__
+    REQUIRE_FALSE(notify_thread::should_display_stat("available_memory"));
+#else
+    REQUIRE(notify_thread::should_display_stat("available_memory"));
+#endif
+    REQUIRE(notify_thread::should_display_stat("process_memory_bytes"));
+    REQUIRE(notify_thread::should_display_stat("bytes_queued"));
 }
 
 /* return --notify_async or --notify_main_thread depending on if DEBUG_THREAD_SANITIZER is set or not */


### PR DESCRIPTION
## Summary

- report the process resident/working-set memory as `process_memory_bytes` on Linux, Windows, and macOS
- continue displaying available memory on Linux and Windows, while suppressing the misleading macOS value
- suppress the duplicate `available_memory_bytes` display field on every platform while preserving both available-memory keys in realtime statistics
- use the runtime page size for Linux `/proc/self/statm` values and avoid closing a null file handle

## Root cause

The progress display emitted both `available_memory` and `available_memory_bytes` from the same underlying value. On macOS that value was Mach's strictly free-page count, which is not comparable to Linux `MemAvailable` and can misleadingly resemble process memory usage. The existing process-memory helper supported Linux and macOS but was not exposed as a realtime statistic and had no Windows implementation.

## User impact

The display now shows `process_memory_bytes` as MiB on every supported platform. Linux and Windows also show the legacy `available_memory` value; macOS does not show an available-memory value because it has no direct equivalent to Linux `MemAvailable` suitable for this display.

## Validation

- `make -C src check TESTS='test_be test_be20_api' -j1`
- MinGW compile/link check for the Windows machine-statistics implementation with `-lpsapi`
- `git diff --check`

Addresses #672.
