### PR TITLE
Avoid winpe range exceptions on incomplete carves

### DIFF
--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -129,6 +129,9 @@ through the project's normal pull-request and CI process.
   reading their length fields, and unexpected top-level exceptions are reported
   as diagnostics with a nonzero exit status
   ([PR #605](https://github.com/simsong/bulk_extractor/pull/605)).
+- Windows PE scanning no longer reports `sbuf` range exceptions when a
+  recognized executable extends beyond the current scanner buffer; its feature
+  is recorded, but the incomplete executable is not carved.
 - Follow-up parser hardening rejects overflowing scaled-size arguments,
   malformed Windows volume paths, invalid or truncated network headers, and
   unsafe HTTP-log backtracking before accessing their bytes.

--- a/src/scan_winpe.cpp
+++ b/src/scan_winpe.cpp
@@ -1064,8 +1064,9 @@ void scan_winpe (scanner_params &sp)
 
 		xml = scan_winpe_verify(data);
 		if (xml != "") {
-		    // If we have 4096 bytes, generate hash of first 4K
-                    sbuf_t first4k = data.slice(0, 4096);
+		    // Generate a hash of up to the first 4K.
+                    const size_t hash_size = data.bufsize < 4096 ? data.bufsize : 4096;
+                    sbuf_t first4k = data.slice(0, hash_size);
 		    f.write(data.pos0, first4k.hash(), xml);
 
                     size_t carve_size = get_carve_size(data);

--- a/src/scan_winpe.cpp
+++ b/src/scan_winpe.cpp
@@ -1069,8 +1069,10 @@ void scan_winpe (scanner_params &sp)
 		    f.write(data.pos0, first4k.hash(), xml);
 
                     size_t carve_size = get_carve_size(data);
-                    feature_recorder &f_carved = sp.named_feature_recorder("winpe_carved");
-                    f_carved.carve(data.slice(0, carve_size), ".winpe");
+                    if (carve_size <= data.bufsize) {
+                        feature_recorder &f_carved = sp.named_feature_recorder("winpe_carved");
+                        f_carved.carve(data.slice(0, carve_size), ".winpe");
+                    }
 		}
 	    }
 	}

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -870,8 +870,12 @@ TEST_CASE("winpe hashes short sbufs", "[phase1]") {
 TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
     std::unique_ptr<sbuf_t> source(map_file("hello_win64_exe"));
     REQUIRE(source->bufsize >= 0x3c + sizeof(uint32_t));
-    auto *patched = sbuf_t::sbuf_malloc(source->pos0, source->bufsize, source->pagesize);
-    std::memcpy(patched->malloc_buf(), source->get_buf(), source->bufsize);
+    constexpr size_t omitted_size = 4096;
+    REQUIRE(source->bufsize > omitted_size);
+    REQUIRE(source->bufsize <= std::numeric_limits<uint32_t>::max());
+    const size_t scan_size = source->bufsize - omitted_size;
+    auto *patched = sbuf_t::sbuf_malloc(source->pos0, scan_size, scan_size);
+    std::memcpy(patched->malloc_buf(), source->get_buf(), scan_size);
 
     // Point the PE certificate table beyond the bytes available to this scanner call.
     const size_t optional_header_offset = source->get32u(0x3c) + 4 + 20;
@@ -881,16 +885,16 @@ TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
     const size_t data_directory_offset = optional_header_offset
         + (optional_header_magic == 0x10b ? 96 : 112);
     const size_t certificate_directory_offset = data_directory_offset + 4 * 8;
-    REQUIRE(certificate_directory_offset + 8 <= source->bufsize);
-    const uint32_t certificate_offset = static_cast<uint32_t>(source->bufsize + 4096);
+    REQUIRE(certificate_directory_offset + 8 <= scan_size);
+    constexpr uint32_t certificate_size = 512;
+    const uint32_t certificate_offset = static_cast<uint32_t>(source->bufsize - certificate_size);
     auto *bytes = static_cast<uint8_t *>(patched->malloc_buf());
     for (size_t i = 0; i < sizeof(certificate_offset); i++) {
         bytes[certificate_directory_offset + i] = (certificate_offset >> (i * 8)) & 0xff;
     }
-    bytes[certificate_directory_offset + 4] = 0x00;
-    bytes[certificate_directory_offset + 5] = 0x02;
-    bytes[certificate_directory_offset + 6] = 0x00;
-    bytes[certificate_directory_offset + 7] = 0x00;
+    for (size_t i = 0; i < sizeof(certificate_size); i++) {
+        bytes[certificate_directory_offset + 4 + i] = (certificate_size >> (i * 8)) & 0xff;
+    }
 
     const auto outdir = test_scanner(scan_winpe, patched);
     REQUIRE(requireFeature(getLines(outdir / "winpe.txt"), "<PE>"));

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -856,6 +856,7 @@ TEST_CASE("test_winpe", "[phase1]") {
 TEST_CASE("winpe hashes short sbufs", "[phase1]") {
     std::unique_ptr<sbuf_t> source(map_file("hello_win64_exe"));
     constexpr size_t short_size = 512;
+    REQUIRE(source->bufsize >= short_size);
     auto *short_pe = sbuf_t::sbuf_malloc(source->pos0, short_size, short_size);
     std::memcpy(short_pe->malloc_buf(), source->get_buf(), short_size);
 
@@ -868,16 +869,19 @@ TEST_CASE("winpe hashes short sbufs", "[phase1]") {
 
 TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
     std::unique_ptr<sbuf_t> source(map_file("hello_win64_exe"));
+    REQUIRE(source->bufsize >= 0x3c + sizeof(uint32_t));
     auto *patched = sbuf_t::sbuf_malloc(source->pos0, source->bufsize, source->pagesize);
     std::memcpy(patched->malloc_buf(), source->get_buf(), source->bufsize);
 
     // Point the PE certificate table beyond the bytes available to this scanner call.
     const size_t optional_header_offset = source->get32u(0x3c) + 4 + 20;
+    REQUIRE(optional_header_offset + sizeof(uint16_t) <= source->bufsize);
     const uint16_t optional_header_magic = source->get16u(optional_header_offset);
     REQUIRE((optional_header_magic == 0x10b || optional_header_magic == 0x20b));
     const size_t data_directory_offset = optional_header_offset
         + (optional_header_magic == 0x10b ? 96 : 112);
     const size_t certificate_directory_offset = data_directory_offset + 4 * 8;
+    REQUIRE(certificate_directory_offset + 8 <= source->bufsize);
     const uint32_t certificate_offset = static_cast<uint32_t>(source->bufsize + 4096);
     auto *bytes = static_cast<uint8_t *>(patched->malloc_buf());
     for (size_t i = 0; i < sizeof(certificate_offset); i++) {

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -852,3 +852,28 @@ TEST_CASE("test_winpe", "[phase1]") {
     };
     validate("hello_win64_exe", ex2);
 }
+
+TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
+    std::unique_ptr<sbuf_t> source(map_file("hello_win64_exe"));
+    auto *truncated = sbuf_t::sbuf_malloc(source->pos0, source->bufsize, source->pagesize);
+    std::memcpy(truncated->malloc_buf(), source->get_buf(), source->bufsize);
+
+    // Point the PE certificate table beyond the bytes available to this scanner call.
+    constexpr size_t certificate_directory_offset = 280;
+    const uint32_t certificate_offset = static_cast<uint32_t>(source->bufsize + 4096);
+    auto *bytes = static_cast<uint8_t *>(truncated->malloc_buf());
+    for (size_t i = 0; i < sizeof(certificate_offset); i++) {
+        bytes[certificate_directory_offset + i] = (certificate_offset >> (i * 8)) & 0xff;
+    }
+    bytes[certificate_directory_offset + 4] = 0x00;
+    bytes[certificate_directory_offset + 5] = 0x02;
+    bytes[certificate_directory_offset + 6] = 0x00;
+    bytes[certificate_directory_offset + 7] = 0x00;
+
+    const auto outdir = test_scanner(scan_winpe, truncated);
+    REQUIRE(requireFeature(getLines(outdir / "winpe.txt"), "<PE>"));
+    for (const auto &line : getLines(outdir / "alerts.txt")) {
+        REQUIRE(line.find("sbuf_t::range_exception_t") == std::string::npos);
+    }
+    REQUIRE_FALSE(std::filesystem::exists(outdir / "winpe_carved"));
+}

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -859,7 +859,12 @@ TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
     std::memcpy(truncated->malloc_buf(), source->get_buf(), source->bufsize);
 
     // Point the PE certificate table beyond the bytes available to this scanner call.
-    constexpr size_t certificate_directory_offset = 280;
+    const size_t optional_header_offset = source->get32u(0x3c) + 4 + 20;
+    const uint16_t optional_header_magic = source->get16u(optional_header_offset);
+    REQUIRE((optional_header_magic == 0x10b || optional_header_magic == 0x20b));
+    const size_t data_directory_offset = optional_header_offset
+        + (optional_header_magic == 0x10b ? 96 : 112);
+    const size_t certificate_directory_offset = data_directory_offset + 4 * 8;
     const uint32_t certificate_offset = static_cast<uint32_t>(source->bufsize + 4096);
     auto *bytes = static_cast<uint8_t *>(truncated->malloc_buf());
     for (size_t i = 0; i < sizeof(certificate_offset); i++) {

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -853,10 +853,23 @@ TEST_CASE("test_winpe", "[phase1]") {
     validate("hello_win64_exe", ex2);
 }
 
+TEST_CASE("winpe hashes short sbufs", "[phase1]") {
+    std::unique_ptr<sbuf_t> source(map_file("hello_win64_exe"));
+    constexpr size_t short_size = 512;
+    auto *short_pe = sbuf_t::sbuf_malloc(source->pos0, short_size, short_size);
+    std::memcpy(short_pe->malloc_buf(), source->get_buf(), short_size);
+
+    const auto outdir = test_scanner(scan_winpe, short_pe);
+    REQUIRE(requireFeature(getLines(outdir / "winpe.txt"), "<PE>"));
+    for (const auto &line : getLines(outdir / "alerts.txt")) {
+        REQUIRE(line.find("sbuf_t::range_exception_t") == std::string::npos);
+    }
+}
+
 TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
     std::unique_ptr<sbuf_t> source(map_file("hello_win64_exe"));
-    auto *truncated = sbuf_t::sbuf_malloc(source->pos0, source->bufsize, source->pagesize);
-    std::memcpy(truncated->malloc_buf(), source->get_buf(), source->bufsize);
+    auto *patched = sbuf_t::sbuf_malloc(source->pos0, source->bufsize, source->pagesize);
+    std::memcpy(patched->malloc_buf(), source->get_buf(), source->bufsize);
 
     // Point the PE certificate table beyond the bytes available to this scanner call.
     const size_t optional_header_offset = source->get32u(0x3c) + 4 + 20;
@@ -866,7 +879,7 @@ TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
         + (optional_header_magic == 0x10b ? 96 : 112);
     const size_t certificate_directory_offset = data_directory_offset + 4 * 8;
     const uint32_t certificate_offset = static_cast<uint32_t>(source->bufsize + 4096);
-    auto *bytes = static_cast<uint8_t *>(truncated->malloc_buf());
+    auto *bytes = static_cast<uint8_t *>(patched->malloc_buf());
     for (size_t i = 0; i < sizeof(certificate_offset); i++) {
         bytes[certificate_directory_offset + i] = (certificate_offset >> (i * 8)) & 0xff;
     }
@@ -875,7 +888,7 @@ TEST_CASE("winpe skips carves beyond the sbuf", "[phase1]") {
     bytes[certificate_directory_offset + 6] = 0x00;
     bytes[certificate_directory_offset + 7] = 0x00;
 
-    const auto outdir = test_scanner(scan_winpe, truncated);
+    const auto outdir = test_scanner(scan_winpe, patched);
     REQUIRE(requireFeature(getLines(outdir / "winpe.txt"), "<PE>"));
     for (const auto &line : getLines(outdir / "alerts.txt")) {
         REQUIRE(line.find("sbuf_t::range_exception_t") == std::string::npos);


### PR DESCRIPTION
## Summary

- skip Windows PE carving when the computed executable extent is larger than the current scanner buffer
- preserve the recognized `winpe.txt` feature while avoiding a partial carve and `sbuf_t::range_exception_t` alert
- add a regression test based on a valid PE whose certificate table extends beyond the supplied `sbuf`

## Diagnosis

The first reported Domexusers alert is reproducible from logical page offset `335544320`. The triggering PE starts `8060416` bytes into that page. Its certificate table declares offset `24383488` and size `7024`, so `get_carve_size()` returns the alert's exact `24390512` length. Only `12911104` bytes remain in the scanner buffer, and `data.slice(0, carve_size)` therefore reads past the end.

This is an incomplete carve window, not an invalid PE header. The scanner can retain the feature metadata, but it cannot carve bytes that were not supplied in the current callback.

## Validation

- Makefile-driven `test_be` regression: valid PE is recognized, no range alert is emitted, and no partial carve is created
- Makefile-driven `[phase1]` scanner test group
- Makefile-driven `test_be20_api`, `test_dfxml`, and `test_pcap_fake`
