### PR TITLE
Restore mutex-protected worker shutdown tracking

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 # and http://www.bioinf.uni-freiburg.de/~mmann/HowTo/automake.html
 
 AC_PREREQ([2.69])
-AC_INIT([BULK_EXTRACTOR],[2.2.0beta1],[bugs@digitalcorpora.org])
+AC_INIT([BULK_EXTRACTOR],[2.2.0beta2],[bugs@digitalcorpora.org])
 AC_CONFIG_MACRO_DIR(m4)
 
 AC_MSG_NOTICE([at start CPPFLAGS are $CPPFLAGS])

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ linked from the [historical source map](#historical-source-map).
 ## 2.2.0 (draft)
 
 **Status:** Unreleased. The source version is currently
-`2.2.0beta1`; the corresponding Git tag will be `v2.2.0beta1`.
+`2.2.0beta2`; the corresponding Git tag will be `v2.2.0beta2`.
 
 ### Executive summary
 

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -163,6 +163,9 @@ through the project's normal pull-request and CI process.
 - Fixed notifier and disk-write error shutdown so worker failures are reported
   and cleaned up instead of hanging or terminating incorrectly
   ([PR #513](https://github.com/simsong/bulk_extractor/pull/513)).
+- Thread-pool shutdown again tracks live workers under the pool mutex, preventing
+  timed joins from sleeping until their deadline after every worker has exited
+  ([#678](https://github.com/simsong/bulk_extractor/issues/678)).
 - `-Z` now removes stale nested output directories as well as files before a
   new run ([#239](https://github.com/simsong/bulk_extractor/issues/239)).
 - Fixed scanner controls: `jpeg_carve_mode=0` now disables JPEG carving, and

--- a/src/be20_api/test_be20_threadpool.cpp
+++ b/src/be20_api/test_be20_threadpool.cpp
@@ -83,6 +83,30 @@ TEST_CASE("idle_workers_shutdown", "[thread_pool]") {
     ss.shutdown();
 }
 
+TEST_CASE("timed_join_stops_all_idle_workers", "[thread_pool]") {
+    constexpr size_t attempts = 25;
+    constexpr size_t worker_count = 32;
+
+    for (size_t attempt = 0; attempt < attempts; attempt++) {
+        scanner_config sc;
+        sc.outdir = get_tempdir() / "timed_join_stops_all_idle_workers" / std::to_string(attempt);
+        std::filesystem::create_directories(sc.outdir);
+
+        feature_recorder_set::flags_t f;
+        scanner_set ss(sc, f, nullptr);
+        ss.apply_scanner_commands();
+        ss.phase_scan();
+        ss.launch_workers(worker_count);
+
+        INFO("shutdown attempt " << attempt);
+        REQUIRE(ss.get_worker_count() == worker_count);
+        REQUIRE(ss.join(std::chrono::seconds(5)));
+        REQUIRE(ss.get_worker_count() == 0);
+        REQUIRE(ss.get_tasks_queued() == 0);
+        ss.shutdown();
+    }
+}
+
 TEST_CASE("timed_join_reports_timeout", "[thread_pool]") {
     scanner_config sc;
     sc.outdir = get_tempdir() / "timed_join_reports_timeout";

--- a/src/be20_api/threadpool.cpp
+++ b/src/be20_api/threadpool.cpp
@@ -2,6 +2,8 @@
 #include "threadpool.h"
 #include "scanner_set.h"
 
+#include <memory>
+
 thread_pool::thread_pool(scanner_set &ss_): ss(ss_)
 {
 }
@@ -9,9 +11,21 @@ thread_pool::thread_pool(scanner_set &ss_): ss(ss_)
 void thread_pool::launch_workers(size_t num_workers)
 {
     for (size_t i=0; i < num_workers; i++){
-        class worker *w = new worker(*this,i);
-        workers_running.fetch_add(1, std::memory_order_relaxed);
-        threads.insert(new std::thread( &worker::start_worker, static_cast<void *>(w) ));
+        auto w = std::make_unique<worker>(*this, i);
+        auto thread = std::make_unique<std::thread>();
+        std::lock_guard<std::mutex> lock(M);
+        workers.insert(w.get());
+        try {
+            threads.insert(thread.get());
+            *thread = std::thread(&worker::start_worker, static_cast<void *>(w.get()));
+        }
+        catch (...) {
+            workers.erase(w.get());
+            threads.erase(thread.get());
+            throw;
+        }
+        w.release();
+        thread.release();
     }
 }
 
@@ -55,6 +69,7 @@ void thread_pool::join()
     std::unique_lock<std::mutex> lock(M);
     mode = 2;
     TO_WORKER.notify_all();
+    TO_MAIN.wait(lock, [this] { return workers.empty(); });
     lock.unlock();
     for (auto *thread : threads) {
         if (thread->joinable()) {
@@ -87,9 +102,7 @@ bool thread_pool::join(std::chrono::seconds maximum_wait)
     }
     mode = 2;
     TO_WORKER.notify_all();
-    if (!TO_MAIN.wait_until(lock, deadline, [this] {
-            return workers_running.load(std::memory_order_relaxed) == 0;
-        })) {
+    if (!TO_MAIN.wait_until(lock, deadline, [this] { return workers.empty(); })) {
         return false;
     }
     lock.unlock();
@@ -161,7 +174,8 @@ int thread_pool::get_free_count() const
 
 size_t thread_pool::get_worker_count() const
 {
-    return workers_running.load(std::memory_order_relaxed);
+    std::lock_guard<std::mutex> lock(M);
+    return workers.size();
 }
 
 size_t thread_pool::get_tasks_queued() const
@@ -256,7 +270,10 @@ void *worker::run()
     if (tp.debug) std::cerr << std::this_thread::get_id() << " exiting "<< std::endl;
     tp.total_worker_wait_ns.fetch_add(worker_wait_timer.running_nanoseconds(), std::memory_order_relaxed);
     tp.ss.thread_set_status("exited");
-    tp.workers_running.fetch_sub(1, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lock(tp.M);
+        tp.workers.erase(this);
+    }
     tp.TO_MAIN.notify_all();
     return nullptr;
 }

--- a/src/be20_api/threadpool.h
+++ b/src/be20_api/threadpool.h
@@ -74,13 +74,14 @@ public:
         scanner_t *scanner {nullptr};        // if set, use only this scanner, otherwise use all.
     };
 
+    using worker_set_t = std::set<class worker *>;
+    worker_set_t                        workers {}; // protected by M
     std::set<std::thread *>             threads {};
     mutable std::mutex                  M {};
     std::condition_variable	        TO_MAIN {};
     std::condition_variable	        TO_WORKER {};
     std::atomic<int>                    working_workers {0};
     std::atomic<int>                    freethreads {0};
-    std::atomic<size_t>                 workers_running {0};
 
     // bulk_extractor specialiations
     class scanner_set &ss;		// one for all the threads; fs and fr are threadsafe


### PR DESCRIPTION
## Summary

- restore the live-worker set as the authoritative shutdown predicate
- protect worker registration, removal, observation, and join predicates with the pool mutex
- retain explicit `std::thread::join()` calls and make worker/thread registration rollback-safe
- add 25 timed shutdown attempts with 32 idle workers per attempt
- document the user-visible shutdown fix in the 2.2.0 release notes
- prepare this open PR head as the `v2.2.0beta2` release candidate tracked in #680

## Root cause

The atomic `workers_running` counter was changed and followed by a condition-variable notification without holding the mutex used by `thread_pool::join()`. With multiple workers exiting, the last notification could occur after the join predicate was checked but before the joining thread actually slept. The counter could then be zero with no future notifier, leaving the timed join asleep until its deadline.

The restored worker set closes that window because worker removal and `workers.empty()` are ordered by the same mutex used by `TO_MAIN`.

Addresses #678.

## Validation

- `make -C src check TESTS=test_be20_api` — pass
- `make check` — pass (4/4 test programs; 0 failures, 0 errors)
- `make distcheck` — pass (clean archive build, install/uninstall, and 4/4 test programs)
- GitHub Actions — pass on current head `cbc2cc994d9b47330e27b582947e9a40d82c738b`, including macOS, Ubuntu, AddressSanitizer, Windows runtime, MinGW, Codecov, documentation, Snap, and CodeQL
- Current-head Copilot review — pass on `cbc2cc994d9b47330e27b582947e9a40d82c738b`; 5/5 changed files reviewed with no new comments and no review threads

## Beta test release

The signed, reviewed open-PR head is published as
[`v2.2.0beta2`](https://github.com/simsong/bulk_extractor/releases/tag/v2.2.0beta2).
PR #679 remains open and unmerged while beta feedback is collected.
