### PR TITLE
Add beta4 deduplication modes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@
 # and http://www.bioinf.uni-freiburg.de/~mmann/HowTo/automake.html
 
 AC_PREREQ([2.69])
-AC_INIT([BULK_EXTRACTOR],[2.2.0beta2],[bugs@digitalcorpora.org])
+AC_INIT([BULK_EXTRACTOR],[2.2.0beta4],[bugs@digitalcorpora.org])
 AC_CONFIG_MACRO_DIR(m4)
 
 AC_MSG_NOTICE([at start CPPFLAGS are $CPPFLAGS])
@@ -396,6 +396,3 @@ echo "#define CFLAGS   \"$CFLAGS\""   >> config.h
 echo "#define CXXFLAGS \"$CXXFLAGS\"" >> config.h
 echo "#define LIBS     \"$LIBS\""     >> config.h
 echo "#define LDFLAGS  \"$LDFLAGS\""  >> config.h
-if test x"$GIT_COMMIT" != "x" ; then
-  echo "#define GIT_COMMIT  \"$GIT_COMMIT\""  >> config.h
-fi

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -224,6 +224,9 @@ through the project's normal pull-request and CI process.
 
 ### Build, configuration, and testing
 
+- Release source archives now define unavailable Git metadata as `unknown`, so
+  their `make check` target compiles and runs outside a Git checkout
+  ([#681](https://github.com/simsong/bulk_extractor/issues/681)).
 - Source-tree bootstrap no longer reports obsolete Libtool setup or GNU Make
   portability warnings from the project Autotools inputs.
 - A build configured with `--disable-rar` now omits RAR-only tests without

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -14,7 +14,7 @@ linked from the [historical source map](#historical-source-map).
 ## 2.2.0 (draft)
 
 **Status:** Unreleased. The source version is currently
-`2.2.0beta2`; the corresponding Git tag will be `v2.2.0beta2`.
+`2.2.0beta3`; the corresponding Git tag will be `v2.2.0beta3`.
 
 ### Executive summary
 
@@ -94,6 +94,12 @@ through the project's normal pull-request and CI process.
 
 ### Reliability and correctness
 
+- Buffer deduplication is now disabled by default so concurrent runs
+  preserve every forensic path for equal content. `--deduplicate` restores the
+  previous space-saving behavior, whose first-seen path can depend on worker
+  scheduling. Every scan creates `duplicates.txt`; its deterministic rows list
+  the canonical first path, each additional path, and the SHA-1 content hash
+  ([#682](https://github.com/simsong/bulk_extractor/issues/682)).
 - Restart records the start of each page so a resumed run deliberately skips
   pages that were in progress at the crash, avoiding repeated data-dependent
   crashes; the behavior is covered by a controlled-crash regression test

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -224,6 +224,11 @@ through the project's normal pull-request and CI process.
 
 ### Build, configuration, and testing
 
+- Recursive duplicate processing is now controlled by `--deduplciate-mode`.
+  Mode 0 (the default) preserves all recursive paths and carved objects; mode 1
+  deduplicates ZIP recursion; mode 2 preserves the legacy recursive and carved-object
+  deduplication behavior. ZIP recursion now defaults to four nested ZIP levels and
+  is configurable with `-S max_zip_depth=N`.
 - Release source archives now define unavailable Git metadata as `unknown`, so
   their `make check` target compiles and runs outside a Git checkout
   ([#681](https://github.com/simsong/bulk_extractor/issues/681)).

--- a/doc/carving.md
+++ b/doc/carving.md
@@ -20,18 +20,21 @@ build.
 | --- | --- |
 | `0` | Do not write carved files or entries in the carving feature file. |
 | `1` | Write only objects reached through an encoded or derived input path, such as decompressed or Base64-decoded data. A bare object found directly in the input is not carved. |
-| `2` | Write every object passed to that recorder's carver, subject to validation, deduplication, and its minimum and maximum carve sizes. |
+| `2` | Write every object passed to that recorder's carver, subject to validation and its minimum and maximum carve sizes. |
 
 Mode `1` is the default for JPEG and RAR recorders (`rar` and
 `unrar_carved`). It focuses on objects that ordinary file carvers are less
 likely to recover while avoiding a second copy of bare objects from the
 original image. `zip_carved` and `sqlite_carved` default to mode `2`.
 
-The carving feature file records files actually carved (or a cached duplicate),
-not every object that a different mode could have carved. Some scanners also
+The global `--deduplciate-mode` controls duplicate carved-object handling.
+Modes `0` and `1` record every accepted carved object; mode `2` retains the
+legacy content cache and records later duplicate objects as `<CACHED>`. Some scanners also
 emit separate metadata feature records regardless of carve mode; for example,
 `zip.txt` describes recognized ZIP components. Use mode `2` when an inventory
 of every validated object for a carving recorder is required.
 
 There is currently no one-option global carve-mode override. Supply one `-S`
-setting for each carving recorder whose default you want to change.
+setting for each carving recorder whose default you want to change. ZIP recursion
+is independently limited to four nested ZIP levels by default; use
+`-S max_zip_depth=N` to change that limit.

--- a/doc/latex_manuals/BECurrentGuide.tex
+++ b/doc/latex_manuals/BECurrentGuide.tex
@@ -495,7 +495,9 @@ bulk_extractor -S jpeg_carve_mode=2 -o output image.raw
 
 Mode 0 disables carving, mode 1 carves objects reached through an encoded or
 derived path, and mode 2 carves every object accepted by that recorder, subject
-to validation, deduplication, and size limits. JPEG and RAR recorders default
+to validation and size limits. The global code{--deduplciate-mode} controls
+duplicate-object handling; modes 0 and 1 preserve every accepted object, while
+mode 2 retains the legacy cache. JPEG and RAR recorders default
 to mode 1; \code{zip\_carved} and \code{sqlite\_carved} default to mode 2.
 There is no global carve-mode switch. Consult \code{doc/carving.md} and
 \code{-H} for current recorder names, defaults, and size settings.

--- a/doc/latex_manuals/BECurrentGuide.tex
+++ b/doc/latex_manuals/BECurrentGuide.tex
@@ -495,7 +495,7 @@ bulk_extractor -S jpeg_carve_mode=2 -o output image.raw
 
 Mode 0 disables carving, mode 1 carves objects reached through an encoded or
 derived path, and mode 2 carves every object accepted by that recorder, subject
-to validation and size limits. The global code{--deduplciate-mode} controls
+to validation and size limits. The global \code{--deduplciate-mode} controls
 duplicate-object handling; modes 0 and 1 preserve every accepted object, while
 mode 2 retains the legacy cache. JPEG and RAR recorders default
 to mode 1; \code{zip\_carved} and \code{sqlite\_carved} default to mode 2.

--- a/doc/latex_manuals/BECurrentGuide.tex
+++ b/doc/latex_manuals/BECurrentGuide.tex
@@ -299,8 +299,19 @@ Scanners receive bounds-checked safe buffers, or \code{sbuf}s. A recursive
 scanner can decode a validated region and return the derived buffer to the
 framework for another pass. This permits, for example, the email scanner to
 find an address in text extracted from a PDF or decompressed from a GZIP
-stream. Depth limits, duplicate detection, buffer characteristics, and scanner
-flags prevent or limit inappropriate recursion.
+stream. Depth limits, buffer characteristics, and scanner flags prevent or
+limit inappropriate recursion. By default, equal recursive buffers are all
+scanned so that their distinct forensic paths are preserved. The optional
+\code{--deduplicate} switch suppresses repeated buffer content to reduce work
+and output size, but concurrent runs may retain different paths for that equal
+content.
+
+Every scan creates \code{duplicates.txt}. Its data rows have the form
+\code{path1<TAB>path2<TAB>hash}, where \code{path1} is the lowest forensic
+path for the content, \code{path2} is each additional path, and \code{hash} is
+the SHA-1 content hash. Hashes and paths are written in sorted order, so the
+report itself does not depend on worker scheduling. The file is empty when the
+scan finds no duplicate buffers.
 
 \begin{figure}[ht]
 \centering
@@ -845,6 +856,7 @@ the installed \code{bulk\_extractor(1)} manual are authoritative.
 \code{-G BYTES} & Set the primary page size. \\
 \code{-g BYTES} & Set the page margin. \\
 \code{-M N} & Set maximum recursive depth. \\
+\code{--deduplicate} & Bypass buffers whose content was already processed; disabled by default. \\
 \code{-s FRACTION[:PASSES]} & Randomly sample the input. \\
 \code{--max\_minute\_wait N} & Bound processing and shutdown wait time. \\
 \code{--max\_bad\_alloc\_errors N} & Set tolerated allocation failures. \\

--- a/doc/programmer_manual/BEProgrammersManual.tex
+++ b/doc/programmer_manual/BEProgrammersManual.tex
@@ -648,8 +648,9 @@ input, and handling of malformed or unexpectedly large features.
 
 A carving recorder declares the carve flag, default mode, and minimum and
 maximum sizes. The framework implements mode 0 (none), mode 1 (derived or
-encoded paths), mode 2 (all accepted objects), hashing, deduplication, safe
-filenames, and the carving feature record. The scanner remains responsible for
+encoded paths), mode 2 (all accepted objects), hashing, safe filenames, and
+the carving feature record. Global code{--deduplciate-mode} selects whether
+carved objects are deduplicated; only mode 2 retains the legacy cache. The scanner remains responsible for
 validating that the candidate is a real object and for passing its correct
 extent. A signature alone is rarely sufficient validation.
 

--- a/doc/programmer_manual/BEProgrammersManual.tex
+++ b/doc/programmer_manual/BEProgrammersManual.tex
@@ -649,7 +649,7 @@ input, and handling of malformed or unexpectedly large features.
 A carving recorder declares the carve flag, default mode, and minimum and
 maximum sizes. The framework implements mode 0 (none), mode 1 (derived or
 encoded paths), mode 2 (all accepted objects), hashing, safe filenames, and
-the carving feature record. Global code{--deduplciate-mode} selects whether
+the carving feature record. Global \code{--deduplciate-mode} selects whether
 carved objects are deduplicated; only mode 2 retains the legacy cache. The scanner remains responsible for
 validating that the candidate is a real object and for passing its correct
 extent. A signature alone is rarely sufficient validation.

--- a/doc/scanner_api.md
+++ b/doc/scanner_api.md
@@ -115,9 +115,12 @@ callback returns. feature_recorder::write() and write_buf() are safe for
 concurrent scanner calls; protect any other shared scanner state with an
 appropriate mutex or atomics.
 
-The framework can bypass a scanner for a small buffer, a duplicate buffer, an
-ngram buffer, excessive depth, or scanner flags. A scanner must not assume it
-will see every input buffer.
+The framework can bypass a scanner for a small buffer, an ngram buffer,
+excessive depth, or scanner flags. `--deduplciate-mode 2` also bypasses a
+buffer whose content hash was seen earlier; mode 0 preserves every path, and
+mode 1 limits deduplication to recursive ZIP processing. Duplicate detection
+always produces `duplicates.txt`; a scanner must not assume it will see every
+input buffer in mode 2.
 
 ## Feature recorders
 

--- a/m4/dfxml_configure.m4
+++ b/m4/dfxml_configure.m4
@@ -24,13 +24,22 @@ AC_CHECK_LIB([expat],[XML_ParserCreate],,[have_expat="no ";AC_MSG_WARN([expat no
 # Determine UTC date offset
 CPPFLAGS="$CPPFLAGS -DUTC_OFFSET=`TZ=UTC date +%z`"
 
-# Get the GIT commit into the GIT_COMMIT variable
+# Get the Git commit when configuring a checkout. Release archives have no
+# repository metadata, so use an explicit fallback instead of omitting it.
+GIT_COMMIT=unknown
 AC_CHECK_PROG([git],[git],[yes],[no])
 AM_CONDITIONAL([FOUND_GIT],[test "x$git" = xyes])
 AM_COND_IF([FOUND_GIT],
-        [GIT_COMMIT=`git describe --dirty --always`
-         AC_MSG_NOTICE([git commit $GIT_COMMIT])],
+        [if test -e "$srcdir/.git"; then
+           git_commit=`git -C "$srcdir" describe --dirty --always 2>/dev/null`
+           if test -n "$git_commit"; then
+             GIT_COMMIT=$git_commit
+           fi
+         fi],
         [AC_MSG_WARN([git not found])])
+AC_MSG_NOTICE([git commit $GIT_COMMIT])
+AC_DEFINE_UNQUOTED([GIT_COMMIT], ["$GIT_COMMIT"],
+                   [Define to the Git commit description or "unknown".])
 
 # Do we have the CPUID instruction?
 # Based on https://www.gnu.org/software/autoconf-archive/ax_gcc_x86_cpuid.html

--- a/man/bulk_extractor.1
+++ b/man/bulk_extractor.1
@@ -159,6 +159,13 @@ Set the page margin size.
 .B -M, --max_depth \fIN\fR
 Set the maximum recursive-processing depth.
 .TP
+.B --deduplciate-mode \fIN\fR
+Set duplicate processing: 0 preserves all recursive paths and carved objects,
+1 deduplicates ZIP recursion, and 2 uses legacy recursive and carved-object
+deduplication. The default is 0. Set the ZIP recursion limit with
+.B -S max_zip_depth=\fIN\fR
+(default 4).
+.TP
 .B -s, --sampling \fIFRACTION\fR[:\fIPASSES\fR]
 Set random-sampling parameters.
 .TP

--- a/man/bulk_extractor.1
+++ b/man/bulk_extractor.1
@@ -237,6 +237,11 @@ is not supplied.
 .I outdir/report.xml
 DFXML report describing the scan.
 .TP
+.I outdir/duplicates.txt
+Duplicate-buffer report.  Each data row contains the canonical first forensic
+path, an additional path, and the SHA-1 content hash, separated by tabs.  The
+file is created even when no duplicate buffers are found.
+.TP
 .I outdir/bulk_extractor.log
 Default diagnostic log file.
 .SH SEE ALSO

--- a/src/be20_api/demos/regex_examples.cpp
+++ b/src/be20_api/demos/regex_examples.cpp
@@ -1,3 +1,4 @@
+// Regular-expression examples for the be20 API component.
 #include <iostream>
 #include <regex>
 #include <string>

--- a/src/be20_api/dfxml_cpp/src/README_win32.md
+++ b/src/be20_api/dfxml_cpp/src/README_win32.md
@@ -9,8 +9,8 @@ sudo yum install mingw32-libgcrypt-static mingw64-libgcrypt-static  mingw32-zlib
 export WINEPATH=/usr/x86_64-w64-mingw32/sys-root/mingw/bin/
 sh bootstrap.sh
 mingw64-configure --quiet --enable-silent-rules
-make test_dfxml.exe
-wine test_dfxml.exe
+make dfxml_cpp_test.exe
+wine dfxml_cpp_test.exe
 ```
 To compile under ubuntu:
 ```

--- a/src/be20_api/dfxml_cpp/src/dfxml_cpp_test.cpp
+++ b/src/be20_api/dfxml_cpp/src/dfxml_cpp_test.cpp
@@ -1,4 +1,5 @@
 
+// Standalone tests for the bundled DFXML C++ component.
 #define CATCH_CONFIG_MAIN
 #include "config.h"
 

--- a/src/be20_api/feature_recorder.cpp
+++ b/src/be20_api/feature_recorder.cpp
@@ -342,7 +342,7 @@ std::string feature_recorder::carve(const sbuf_t& header, const sbuf_t& data, st
         if (fs.sc.deduplicate_mode == scanner_config::deduplicate_mode_t::LEGACY) {
             myfileNumber = carved_file_count++; // atomic operation
         } else {
-            myfileNumber = std::stoll(carved_hash_hexvalue.substr(0, 8), nullptr, 16) % 1000;
+            myfileNumber = (std::stoll(carved_hash_hexvalue.substr(0, 8), nullptr, 16) % 1000) * 1000;
         }
         std::ostringstream seq;
         seq << std::setw(3) << std::setfill('0') << int(myfileNumber / 1000);

--- a/src/be20_api/feature_recorder.cpp
+++ b/src/be20_api/feature_recorder.cpp
@@ -331,13 +331,19 @@ std::string feature_recorder::carve(const sbuf_t& header, const sbuf_t& data, st
     std::string carved_hash_hexvalue = hash(data);
     std::string carved_relative_path; // carved path reported in feature file, relative to outdir
     std::filesystem::path carved_absolute_path; // used for opening
-    bool in_cache = carve_cache.check_for_presence_and_insert(carved_hash_hexvalue);
+    const bool in_cache = fs.sc.deduplicate_mode == scanner_config::deduplicate_mode_t::LEGACY
+                          && carve_cache.check_for_presence_and_insert(carved_hash_hexvalue);
 
     if (in_cache) {
         carved_relative_path = CACHED;
     } else {
         /* Determine the directory and filename */
-        int64_t myfileNumber = carved_file_count++; // atomic operation
+        int64_t myfileNumber = 0;
+        if (fs.sc.deduplicate_mode == scanner_config::deduplicate_mode_t::LEGACY) {
+            myfileNumber = carved_file_count++; // atomic operation
+        } else {
+            myfileNumber = std::stoll(carved_hash_hexvalue.substr(0, 8), nullptr, 16) % 1000;
+        }
         std::ostringstream seq;
         seq << std::setw(3) << std::setfill('0') << int(myfileNumber / 1000);
         const std::string thousands{seq.str()};

--- a/src/be20_api/scanner_config.h
+++ b/src/be20_api/scanner_config.h
@@ -9,7 +9,7 @@
  * This class is also used to build the help string.
  *
  * All of the scanners get the same config, so the names that the scanners want need to be unique.
- * We could have adopted a system where each scanner had its own configuraiton space, but we didn't.
+ * We could have adopted a system where each scanner had its own configuration space, but we didn't.
  * Scanner histograms are added to 'histograms' by machinery.
  */
 
@@ -59,6 +59,12 @@ private:
     scanner_commands_t scanner_commands {};
 
 public:
+    enum class deduplicate_mode_t : uint8_t {
+        NONE = 0,      // Preserve every recursive path and carved object.
+        RECURSIVE = 1, // Deduplicate ZIP recursion only.
+        LEGACY = 2,    // Deduplicate recursive scanner work and carved objects.
+    };
+
     const scanner_commands_t get_scanner_commands() {
         return static_cast<const scanner_commands_t>(scanner_commands);
     }
@@ -114,6 +120,7 @@ public:
     std::string hash_algorithm {"sha1"};          // which hash algorithm are using; default to SHA1
 
     bool allow_recurse { true };         // can be turned off for testing
+    deduplicate_mode_t deduplicate_mode {deduplicate_mode_t::NONE};
 
     inline static const std::string NO_INPUT = "<NO-INPUT>"; // 'filename' indicator that the FRS has no input file
     inline static const std::string NO_OUTDIR = "<NO-OUTDIR>"; // 'dirname' indicator that the FRS produces no file output

--- a/src/be20_api/scanner_params.cpp
+++ b/src/be20_api/scanner_params.cpp
@@ -31,7 +31,8 @@ feature_recorder& scanner_params::named_feature_recorder(const std::string featu
 bool scanner_params::check_previously_processed(const sbuf_t &s) const
 {
     assert(ss!=nullptr);
-    return ss->previously_processed_count(s)==0;
+    const bool seen_before = ss->previously_processed_count(s) > 0;
+    return sc.deduplicate_mode != scanner_config::deduplicate_mode_t::NONE && seen_before;
 }
 
 void scanner_params::recurse(const sbuf_t* new_sbuf) const {

--- a/src/be20_api/scanner_params.cpp
+++ b/src/be20_api/scanner_params.cpp
@@ -31,8 +31,11 @@ feature_recorder& scanner_params::named_feature_recorder(const std::string featu
 bool scanner_params::check_previously_processed(const sbuf_t &s) const
 {
     assert(ss!=nullptr);
+    if (sc.deduplicate_mode == scanner_config::deduplicate_mode_t::NONE) {
+        return false;
+    }
     const bool seen_before = ss->previously_processed_count(s) > 0;
-    return sc.deduplicate_mode != scanner_config::deduplicate_mode_t::NONE && seen_before;
+    return seen_before;
 }
 
 void scanner_params::recurse(const sbuf_t* new_sbuf) const {

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -79,6 +79,11 @@ scanner_set::scanner_set(scanner_config& sc_, const feature_recorder_set::flags_
     fs.banner_filename                     = sc.banner_file;
     pool.debug                             = getenv_debug("DEBUG_THREAD_POOL");
 
+    feature_recorder_def::flags_t duplicate_flags;
+    duplicate_flags.no_stoplist = true;
+    duplicate_flags.no_alertlist = true;
+    fs.create_feature_recorder(feature_recorder_def(DUPLICATES_RECORDER_NAME, duplicate_flags));
+
     const char *dsi = std::getenv("DEBUG_SCANNERS_IGNORE");
     if (dsi!=nullptr) debug_flags.debug_scanners_ignore=dsi;
 
@@ -1008,15 +1013,13 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp)
 
     update_maximum<unsigned int>(max_depth_seen, sbuf.depth());
 
-    /* Determine if we have seen this buffer before.
-     * Some scanners are okay with duplicate processing, but the default is that they are not.
-     * Nevertheless, we will add dupliate bytes to the hash of the disk image.
-     */
+    /* Always record duplicate paths. Only mark or bypass duplicate content when requested. */
+    const bool seen_before = previously_processed_count(sbuf) > 0;
     sbufp->seen_before = sc.deduplicate_mode == scanner_config::deduplicate_mode_t::LEGACY
-                         && previously_processed_count(sbuf) > 0; // abstraction violation
-    if (sbufp->seen_before) {
+                         && seen_before; // abstraction violation
+    if (seen_before) {
         dup_bytes_encountered += sbuf.bufsize;
-        if (!scan_seen_before_enabled) {
+        if (sbufp->seen_before && !scan_seen_before_enabled) {
             duplicate_sbufs_bypassed++;
             if (debug_flags.debug_benchmark && writer) {
                 writer->xmlout("debug:bypass", "",
@@ -1143,6 +1146,7 @@ void scanner_set::shutdown()
     scanner_params sp(sc, this, nullptr, scanner_params::PHASE_SHUTDOWN, nullptr);
     for (const auto &it : enabled_scanners) { (*it)(sp); }
 
+    write_duplicate_report();
     fs.feature_recorders_shutdown();
 
     /* Tell every feature recorder to flush all of its histograms if they haven't been generated.
@@ -1177,6 +1181,23 @@ std::string scanner_set::hash(const sbuf_t& sbuf) const
 }
 
 uint64_t scanner_set::previously_processed_count(const sbuf_t& sbuf) {
-    std::string hash = sbuf.hash();
-    return previously_processed_counter[ hash ]++;
+    const std::string hash = sbuf.hash();
+    const std::lock_guard<std::mutex> lock(Mpreviously_processed);
+    auto &paths = previously_processed[hash];
+    const uint64_t count = paths.size();
+    paths.insert(sbuf.pos0);
+    return count;
+}
+
+void scanner_set::write_duplicate_report() {
+    feature_recorder &recorder = fs.named_feature_recorder(DUPLICATES_RECORDER_NAME);
+    const std::lock_guard<std::mutex> lock(Mpreviously_processed);
+    for (const auto &[hash, paths] : previously_processed) {
+        if (paths.size() < 2) continue;
+        const auto first = paths.begin();
+        auto path = first;
+        for (++path; path != paths.end(); ++path) {
+            recorder.write(*first, path->str(), hash);
+        }
+    }
 }

--- a/src/be20_api/scanner_set.cpp
+++ b/src/be20_api/scanner_set.cpp
@@ -1012,7 +1012,8 @@ void scanner_set::process_sbuf(const sbuf_t* sbufp)
      * Some scanners are okay with duplicate processing, but the default is that they are not.
      * Nevertheless, we will add dupliate bytes to the hash of the disk image.
      */
-    sbufp->seen_before = previously_processed_count(sbuf) > 0; // abstraction violation
+    sbufp->seen_before = sc.deduplicate_mode == scanner_config::deduplicate_mode_t::LEGACY
+                         && previously_processed_count(sbuf) > 0; // abstraction violation
     if (sbufp->seen_before) {
         dup_bytes_encountered += sbuf.bufsize;
         if (!scan_seen_before_enabled) {

--- a/src/be20_api/scanner_set.h
+++ b/src/be20_api/scanner_set.h
@@ -16,7 +16,6 @@
 #endif
 
 #include "utils.h"
-#include "atomic_map.h"
 #include "sbuf.h"
 #include "scanner_config.h"
 #include "scanner_params.h"
@@ -119,7 +118,9 @@ class scanner_set {
     void *cpu_benchmark();
     static void launch_cpu_benchmark_thread(void *arg);
     class feature_recorder_set fs;      // the feature recorders
-    atomic_map<std::string, std::atomic<uint64_t>> previously_processed_counter {};
+    std::map<std::string, std::multiset<pos0_t>> previously_processed {};
+    mutable std::mutex Mpreviously_processed {};
+    void write_duplicate_report();
     std::map<std::thread::id, std::string> thread_status {}; // the status of each thread::id
     mutable std::mutex Mthread_status {};                       // mutex for thread_status
 
@@ -203,6 +204,7 @@ public:
     static const inline std::string SBUFS_CREATED_STR {"sbufs_created"};
     static const inline std::string SBUFS_REMAINING_STR {"sbufs_remaining"};
     static const inline std::string MAX_OFFSET {"max_offset"};
+    static const inline std::string DUPLICATES_RECORDER_NAME {"duplicates"};
 
     bool get_threading() const   { return threading;};
     int get_worker_count() const { return threading ? pool.get_worker_count()  : 1; };

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1437,6 +1437,15 @@ TEST_CASE("disabled recursive deduplication does not track inputs", "[scanner]")
     REQUIRE(ss.previously_processed_count(sbuf) == 0);
 }
 
+TEST_CASE("duplicates report is always created", "[scanner_set]") {
+    scanner_config sc;
+    sc.outdir = get_tempdir();
+    scanner_set ss(sc, feature_recorder_set::flags_t(), nullptr);
+    const auto report = sc.outdir / "duplicates.txt";
+    REQUIRE(std::filesystem::exists(report));
+    REQUIRE(std::filesystem::file_size(report) == 0);
+}
+
 TEST_CASE("carve deduplication follows the configured mode", "[feature_recorder]") {
     const auto carve_twice = [](scanner_config::deduplicate_mode_t mode) {
         scanner_config sc;
@@ -1535,10 +1544,10 @@ TEST_CASE("enable/disable", "[scanner_set]") {
         REQUIRE(ss.is_scanner_enabled(SHA1_TEST) == true);
         REQUIRE(ss.is_find_scanner_enabled() == false); // only sha1 scanner is enabled
 
-        /* Make sure that the scanner set has a two feature recorders:
-         * the alert recorder and the sha1_bufs recorder
+        /* Make sure that the scanner set has three feature recorders:
+         * alerts, duplicates, and sha1_bufs
          */
-        REQUIRE(ss.feature_recorder_count() == 2);
+        REQUIRE(ss.feature_recorder_count() == 3);
 
         /* Make sure it has a single histogram */
         REQUIRE(ss.histogram_count() == 1);

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1404,8 +1404,57 @@ TEST_CASE("previously_processed", "[scanner_set]") {
     REQUIRE(ss.previously_processed_count(slg) == 2);
 }
 
+TEST_CASE("recursive deduplication follows the configured mode", "[scanner]") {
+    const auto repeated = [](scanner_config::deduplicate_mode_t mode) {
+        scanner_config sc;
+        sc.deduplicate_mode = mode;
+        sc.outdir = get_tempdir();
+        feature_recorder_set::flags_t flags;
+        flags.no_alert = true;
+        scanner_set ss(sc, flags, nullptr);
+        scanner_params sp(sc, &ss, nullptr, scanner_params::PHASE_SCAN, nullptr);
+        const sbuf_t sbuf("duplicate");
+        REQUIRE_FALSE(sp.check_previously_processed(sbuf));
+        return sp.check_previously_processed(sbuf);
+    };
+
+    REQUIRE_FALSE(repeated(scanner_config::deduplicate_mode_t::NONE));
+    REQUIRE(repeated(scanner_config::deduplicate_mode_t::RECURSIVE));
+    REQUIRE(repeated(scanner_config::deduplicate_mode_t::LEGACY));
+}
+
+TEST_CASE("carve deduplication follows the configured mode", "[feature_recorder]") {
+    const auto carve_twice = [](scanner_config::deduplicate_mode_t mode) {
+        scanner_config sc;
+        sc.deduplicate_mode = mode;
+        sc.outdir = get_tempdir();
+        feature_recorder_set::flags_t flags;
+        flags.no_alert = true;
+        feature_recorder_set frs(flags, sc);
+        auto& fr = frs.create_feature_recorder("carved");
+        fr.carve_mode = feature_recorder_def::CARVE_ALL;
+        const auto first = std::unique_ptr<sbuf_t>(sbuf_t::sbuf_malloc(pos0_t("100"), "duplicate"));
+        const auto second = std::unique_ptr<sbuf_t>(sbuf_t::sbuf_malloc(pos0_t("200"), "duplicate"));
+        return std::pair{fr.carve(*first, ".bin"), fr.carve(*second, ".bin")};
+    };
+
+    const auto no_dedup = carve_twice(scanner_config::deduplicate_mode_t::NONE);
+    REQUIRE(no_dedup.first != feature_recorder::CACHED);
+    REQUIRE(no_dedup.second != feature_recorder::CACHED);
+    REQUIRE(std::filesystem::path(no_dedup.first).parent_path() == std::filesystem::path(no_dedup.second).parent_path());
+
+    const auto recursive_only = carve_twice(scanner_config::deduplicate_mode_t::RECURSIVE);
+    REQUIRE(recursive_only.first != feature_recorder::CACHED);
+    REQUIRE(recursive_only.second != feature_recorder::CACHED);
+
+    const auto legacy = carve_twice(scanner_config::deduplicate_mode_t::LEGACY);
+    REQUIRE(legacy.first != feature_recorder::CACHED);
+    REQUIRE(legacy.second == feature_recorder::CACHED);
+}
+
 TEST_CASE("duplicate sbufs bypass scanner fan-out unless requested", "[scanner_set]") {
     scanner_config sc;
+    sc.deduplicate_mode = scanner_config::deduplicate_mode_t::LEGACY;
     sc.outdir = get_tempdir();
     sc.enable_all_scanners();
     const auto dfxml_file = get_tempdir() / "duplicate_bypass.xml";
@@ -1430,6 +1479,7 @@ TEST_CASE("duplicate sbufs bypass scanner fan-out unless requested", "[scanner_s
 
 TEST_CASE("duplicate sbufs reach scanners that opt in", "[scanner_set]") {
     scanner_config sc;
+    sc.deduplicate_mode = scanner_config::deduplicate_mode_t::LEGACY;
     sc.outdir = get_tempdir();
     sc.enable_all_scanners();
     duplicate_bypass_scans = 0;

--- a/src/be20_api/test_be20_api.cpp
+++ b/src/be20_api/test_be20_api.cpp
@@ -1423,6 +1423,20 @@ TEST_CASE("recursive deduplication follows the configured mode", "[scanner]") {
     REQUIRE(repeated(scanner_config::deduplicate_mode_t::LEGACY));
 }
 
+TEST_CASE("disabled recursive deduplication does not track inputs", "[scanner]") {
+    scanner_config sc;
+    sc.outdir = get_tempdir();
+    feature_recorder_set::flags_t flags;
+    flags.no_alert = true;
+    scanner_set ss(sc, flags, nullptr);
+    scanner_params sp(sc, &ss, nullptr, scanner_params::PHASE_SCAN, nullptr);
+    const sbuf_t sbuf("duplicate");
+
+    REQUIRE_FALSE(sp.check_previously_processed(sbuf));
+    REQUIRE_FALSE(sp.check_previously_processed(sbuf));
+    REQUIRE(ss.previously_processed_count(sbuf) == 0);
+}
+
 TEST_CASE("carve deduplication follows the configured mode", "[feature_recorder]") {
     const auto carve_twice = [](scanner_config::deduplicate_mode_t mode) {
         scanner_config sc;

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -226,7 +226,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     ("image_name", image_name_help.c_str(), cxxopts::value<std::string>())
         ("A,offset_add", "Offset added (in bytes) to feature locations", cxxopts::value<int64_t>()->default_value("0"))
         ("b,banner_file", "Path of file whose contents are prepended to top of all feature files",cxxopts::value<std::string>())
-	("C,context_window", "Size of context window reported in bytes",
+        ("C,context_window", "Size of context window reported in bytes",
          cxxopts::value<int>()->default_value(std::to_string(sc.context_window_default)))
         ("d,debug", "enable debug-level diagnostic logging")
         ("E,enable_exclusive", "disable all scanners except the one specified. Same as -x all -E scanner.", cxxopts::value<std::string>())

--- a/src/bulk_extractor.cpp
+++ b/src/bulk_extractor.cpp
@@ -245,7 +245,8 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 	("log-level", "diagnostic log level: trace, debug, info, warning, error, critical, or off", cxxopts::value<std::string>())
 	("log-file", "diagnostic log file (default: <outdir>/bulk_extractor.log)", cxxopts::value<std::string>())
         ("notify_main_thread", "Display notifications in the main thread after phase1 completes. Useful for running with ThreadSanitizer")
-        ("notify_async", "Display notificaitons asynchronously (default)")
+        ("notify_async", "Display notifications asynchronously (default)")
+	("deduplciate-mode", "duplicate processing mode: 0=none, 1=ZIP recursion, 2=legacy", cxxopts::value<unsigned int>()->default_value("0"))
         ("o,outdir",        "output directory [REQUIRED]", cxxopts::value<std::string>())
         ("P,scanner_dir",
          "directories for scanner shared libraries (can be repeated). "
@@ -402,6 +403,12 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
     cfg.opt_notification       = ( result.count( "no_notify" )==0);
     cfg.opt_legacy             = result.count( "version1" );
 
+    const unsigned int deduplicate_mode = result["deduplciate-mode"].as<unsigned int>();
+    if (deduplicate_mode > static_cast<unsigned int>(scanner_config::deduplicate_mode_t::LEGACY)) {
+        throw std::runtime_error("--deduplciate-mode must be 0, 1, or 2");
+    }
+    sc.deduplicate_mode = static_cast<scanner_config::deduplicate_mode_t>(deduplicate_mode);
+
     if (cfg.opt_notify_main_thread && (result.count("notify_async")>0)){
         throw std::runtime_error("--notify_main_thread and --notify_async conflict");
     }
@@ -415,7 +422,7 @@ int bulk_extractor_main( std::ostream &cout, std::ostream &cerr, int argc,char *
 
     /* Create a configuration that will be used to initialize the scanners */
     /* Make individual configuration options appear on the command line interface. */
-    sc.get_global_config( "notify_rate", &cfg.opt_notify_rate, "seconds between notificaiton update" );
+    sc.get_global_config( "notify_rate", &cfg.opt_notify_rate, "seconds between notification updates" );
     sc.get_global_config( "debug_histogram_malloc_fail_frequency",
                          &AtomicUnicodeHistogram::debug_histogram_malloc_fail_frequency,
                          "Set >0 to make histogram maker fail with memory allocations" );

--- a/src/phase1.cpp
+++ b/src/phase1.cpp
@@ -237,7 +237,7 @@ void Phase1::dfxml_write_create(int argc, char * const *argv)
     xreport.xmlout("dc:type","Feature Extraction","",false);
     xreport.pop();
 #ifndef GIT_COMMIT
-#define GIT_COMMIT ""
+#define GIT_COMMIT "unknown"
 #endif
     if (argc && argv){
         xreport.add_DFXML_creator(PACKAGE_NAME, PACKAGE_VERSION, GIT_COMMIT, argc, argv);

--- a/src/phase1.cpp
+++ b/src/phase1.cpp
@@ -236,8 +236,11 @@ void Phase1::dfxml_write_create(int argc, char * const *argv)
     xreport.push("metadata", "xmlns:dc='http://purl.org/dc/elements/1.1/'");
     xreport.xmlout("dc:type","Feature Extraction","",false);
     xreport.pop();
+#ifndef GIT_COMMIT
+#define GIT_COMMIT ""
+#endif
     if (argc && argv){
-        xreport.add_DFXML_creator(PACKAGE_NAME, PACKAGE_VERSION, "", argc, argv);
+        xreport.add_DFXML_creator(PACKAGE_NAME, PACKAGE_VERSION, GIT_COMMIT, argc, argv);
     }
     xreport.push("source");
     xreport.xmlout("image_filename",p.image_fname());

--- a/src/phase1.h
+++ b/src/phase1.h
@@ -76,7 +76,7 @@ public:
         std::atomic<double>    *fraction_done {nullptr};
         bool      opt_legacy {false};
         bool      opt_notification {true}; // run notification thread
-        bool      opt_notify_main_thread {false}; // display notificaitons in the main thread when phase1 is finished
+        bool      opt_notify_main_thread {false}; // display notifications in the main thread when phase1 is finished
         seen_page_ids_t seen_page_ids {};               // pages that were already seen
     };
 

--- a/src/scan_zip.cpp
+++ b/src/scan_zip.cpp
@@ -19,7 +19,20 @@ static const std::string  ZIP_RECORDER_NAME {"zip_carved"};
 static uint32_t  zip_max_uncompr_size = 256*1024*1024; // don't decompress objects larger than this
 static uint32_t  zip_min_uncompr_size = 6;	// don't bother with objects smaller than this
 static uint32_t  zip_name_len_max = 1024;
+static uint32_t  max_zip_depth = 4;
 static const size_t ZIP_CARVE_FILENAME_MAX = 64;
+
+uint32_t zip_depth(const pos0_t &pos0)
+{
+    const std::string path = pos0.str();
+    uint32_t count = 0;
+    size_t pos = 0;
+    while ((pos = path.find("-ZIP-", pos)) != std::string::npos) {
+        ++count;
+        pos += 5;
+    }
+    return count;
+}
 
 std::string zip_carve_filename(const std::string &name)
 {
@@ -135,13 +148,16 @@ inline void scan_zip_component(scanner_params &sp, feature_recorder &zip_recorde
             return;
         }
 
-        /* If depth is more than 0, don't decompress if we have seen this component before */
-        if (sbuf_src.depth() > 0){
-            if (sp.check_previously_processed(sbuf_src)){
-                xmlstream << "<disposition>previously-processed</disposition></zipinfo>";
-                zip_recorder.write(pos0+pos,name,xmlstream.str());
-                return;
-            }
+        if (zip_depth(sbuf.pos0) >= max_zip_depth) {
+            xmlstream << "<disposition>max-zip-depth</disposition></zipinfo>";
+            zip_recorder.write(pos0+pos,name,xmlstream.str());
+            return;
+        }
+
+        if (sp.check_previously_processed(sbuf_src)) {
+            xmlstream << "<disposition>previously-processed</disposition></zipinfo>";
+            zip_recorder.write(pos0+pos,name,xmlstream.str());
+            return;
         }
 
         auto *decomp = sbuf_decompress::sbuf_new_decompress(sbuf_src, uncompr_size, "ZIP", sbuf_decompress::mode_t::ZIP, header_size);
@@ -175,6 +191,7 @@ void scan_zip(scanner_params &sp)
         sp.get_scanner_config("zip_min_uncompr_size",&zip_min_uncompr_size,"Minimum size of a ZIP uncompressed object");
         sp.get_scanner_config("zip_max_uncompr_size",&zip_max_uncompr_size,"Maximum size of a ZIP uncompressed object");
         sp.get_scanner_config("zip_name_len_max",&zip_name_len_max,"Maximum name of a ZIP component filename");
+	sp.get_scanner_config("max_zip_depth", &max_zip_depth, "Maximum nested ZIP recursion depth");
 	return;
     }
 

--- a/src/scan_zip.h
+++ b/src/scan_zip.h
@@ -1,8 +1,12 @@
 #ifndef SCAN_ZIP_H
 #define SCAN_ZIP_H
 
+#include <cstdint>
 #include <string>
 
+class pos0_t;
+
 std::string zip_carve_filename(const std::string &name);
+uint32_t zip_depth(const pos0_t &pos0);
 
 #endif

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -349,6 +349,7 @@ static std::filesystem::path run_scanners(const std::vector<scanner_t *> & scann
     frs_flags.pedantic = true;          // for testing
     scanner_config sc;
     sc.outdir           = NamedTemporaryDirectory();
+    sc.deduplicate_mode = scanner_config::deduplicate_mode_t::LEGACY;
     sc.enable_all_scanners();
 
     scanner_set ss(sc, frs_flags, nullptr);

--- a/src/test_be1.cpp
+++ b/src/test_be1.cpp
@@ -1296,3 +1296,9 @@ TEST_CASE("zip_carve_filename_limit", "[scanners]") {
     REQUIRE(carved.front() == '_');
     REQUIRE(zip_carve_filename("dir\\file") == "_dir_file");
 }
+
+TEST_CASE("zip_depth_counts_only_zip_recursion", "[scanners]") {
+    REQUIRE(zip_depth(pos0_t("0")) == 0);
+    REQUIRE(zip_depth(pos0_t("0-ZIP-0")) == 1);
+    REQUIRE(zip_depth(pos0_t("0-ZIP-0-GZIP-0-ZIP-0")) == 2);
+}

--- a/src/test_be2.cpp
+++ b/src/test_be2.cpp
@@ -274,6 +274,7 @@ static std::filesystem::path validate_once(const std::string &image_fname,
     scanner_config sc;
 
     sc.outdir           = NamedTemporaryDirectory();
+    sc.deduplicate_mode = scanner_config::deduplicate_mode_t::LEGACY;
     sc.enable_all_scanners();
     sc.allow_recurse    = recurse;
 

--- a/src/test_be3.cpp
+++ b/src/test_be3.cpp
@@ -209,6 +209,58 @@ TEST_CASE("report DFXML validates against the bundled schema", "[end-to-end]")
     REQUIRE(std::system(command.c_str()) == 0);
 }
 
+TEST_CASE("deduplication is opt-in and reports duplicate paths", "[end-to-end]")
+{
+    const auto root = NamedTemporaryDirectory();
+    const auto input = root / "duplicate-gzip.raw";
+    const auto gzip_path = test_dir() / "test_hello.gz";
+    std::ifstream gzip_file(gzip_path, std::ios::binary);
+    const std::string gzip((std::istreambuf_iterator<char>(gzip_file)),
+                           std::istreambuf_iterator<char>());
+    std::ofstream input_file(input, std::ios::binary);
+    input_file.write(gzip.data(), gzip.size());
+    input_file.write(gzip.data(), gzip.size());
+    input_file.close();
+
+    const auto run = [&](const std::filesystem::path &outdir, bool legacy_deduplication) {
+        const std::string input_string = input.string();
+        const std::string outdir_string = outdir.string();
+        const char *default_argv[] = {
+            "bulk_extractor", "-0q", "-J", "-x", "all", "-e", "email", "-e", "gzip",
+            "-o", outdir_string.c_str(), input_string.c_str(), nullptr
+        };
+        const char *legacy_deduplication_argv[] = {
+            "bulk_extractor", "-0q", "-J", "--deduplciate-mode", "2", "-x", "all",
+            "-e", "email", "-e", "gzip", "-o", outdir_string.c_str(),
+            input_string.c_str(), nullptr
+        };
+        std::stringstream output;
+        REQUIRE(run_be(output, legacy_deduplication ? legacy_deduplication_argv : default_argv) == 0);
+    };
+
+    const auto default_outdir = root / "default";
+    const auto deduplicate_outdir = root / "legacy-deduplication";
+    run(default_outdir, false);
+    run(deduplicate_outdir, true);
+
+    const auto email_count = [](const std::filesystem::path &outdir) {
+        const auto lines = getLines(outdir / "email.txt");
+        return std::count_if(lines.begin(), lines.end(), [](const auto &line) {
+            return line.find("\thello@world.com\t") != std::string::npos;
+        });
+    };
+    REQUIRE(email_count(default_outdir) == 2);
+    REQUIRE(email_count(deduplicate_outdir) == 1);
+
+    const sbuf_t decoded("hello@world.com\n");
+    const std::string duplicate = "0-GZIP-0\t" + std::to_string(gzip.size())
+        + "-GZIP-0\t" + decoded.hash();
+    for (const auto &outdir : {default_outdir, deduplicate_outdir}) {
+        const auto lines = getLines(outdir / "duplicates.txt");
+        REQUIRE(std::find(lines.begin(), lines.end(), duplicate) != lines.end());
+    }
+}
+
 TEST_CASE("Windows raw-device paths are recognized narrowly", "[image_process]")
 {
     REQUIRE(process_raw::is_windows_raw_device_path(R"(\\.\PhysicalDrive0)"));

--- a/src/test_dfxml.cpp
+++ b/src/test_dfxml.cpp
@@ -26,8 +26,14 @@ TEST_CASE("dfxml writer", "[dfxml]") {
     char program[] = "test_dfxml";
     char *argv[] = {program};
 
+#ifdef GIT_COMMIT
+    const char *git_commit = GIT_COMMIT;
+#else
+    const char *git_commit = "unknown";
+#endif
+
     dfxml_writer writer(output, false);
-    writer.add_DFXML_creator("test_dfxml", VERSION, GIT_COMMIT, 1, argv);
+    writer.add_DFXML_creator("test_dfxml", VERSION, git_commit, 1, argv);
     writer.comment("writer integration test");
     writer.close();
 


### PR DESCRIPTION
## Summary

- replace the prior boolean duplicate-processing behavior with `--deduplciate-mode`: mode 0 preserves all recursive paths and carved objects, mode 1 deduplicates ZIP recursion, and mode 2 retains legacy behavior
- limit nested ZIP recursion with `-S max_zip_depth=N` (default 4)
- make nonlegacy carve buckets hash-derived for reproducible output, and correct notification spelling
- document the behavior and add focused recursive, carve-cache, and ZIP-depth tests

## Validation

- `make -C src -j4 check` (4 passed)
- `git diff --check`

## Notes

The public option spelling is intentionally `--deduplciate-mode`, per the beta4 specification.
