### PR TITLE
Fix signed RAR age arithmetic

### DIFF
--- a/src/rar/timefn.cpp
+++ b/src/rar/timefn.cpp
@@ -317,7 +317,7 @@ void RarTime::SetAgeText(const char *TimeText)
   }
   SetCurrentTime();
   int64 RawTime=GetRaw();
-  SetRaw(RawTime-INT32TO64(0,Seconds)*10000000);
+  SetRaw(RawTime-static_cast<int64>(Seconds)*10000000);
 }
 #endif
 


### PR DESCRIPTION
## Summary

- keep RAR age arithmetic signed before subtracting it from the signed raw timestamp
- avoid the implementation-defined unsigned-to-signed conversion reported by Coverity CID 655320

## Evaluation

`Seconds` is a 32-bit unsigned value, so its maximum scaled value fits in `int64`. Casting before multiplication keeps the entire subtraction in the signed domain and preserves valid negative relative timestamps without relying on an unsigned wrap followed by conversion to `int64`.

## Validation

- `make -j1 -C src test_be`
- `make -j1 -C src scan_test_plugin.la`
- `make -j1 -C src check TESTS=test_be` (1/1 passed)

No release-note entry is included because this corrects internal arithmetic in bundled RAR support without changing an exposed bulk_extractor interface.
