### PR TITLE
Move archived report path into result

### DIFF
--- a/src/bulk_extractor_restarter.h
+++ b/src/bulk_extractor_restarter.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <exception>
 #include <filesystem>
+#include <utility>
 
 #include "be20_api/formatter.h"
 
@@ -97,7 +98,7 @@ public:
         /* Now rename the report filename */
         std::filesystem::path report_path_bak = report_path.string() + "." + std::to_string(time(nullptr));
         std::filesystem::rename(report_path, report_path_bak);
-        return {report_path_bak, cfg.seen_page_ids.size()};
+        return {std::move(report_path_bak), cfg.seen_page_ids.size()};
     }
 #else
     restart_summary restart() {


### PR DESCRIPTION
## Summary

- move the archived report path into `restart_summary`
- eliminate the avoidable `std::filesystem::path` copy reported by Coverity CID 655322

## Evaluation

`report_path_bak` is a local value that is not used after construction of the return object. Moving it is ownership-correct and avoids allocating and copying the archived path string.

## Validation

- `make -j1 -C src test_be`
- `make -j1 -C src scan_test_plugin.la`
- `make -j1 -C src check TESTS=test_be` (1/1 passed, including the restarter test)

No release-note entry is included because this is an internal performance correction with no behavior or interface change.
