### PR TITLE
Document resolved Coverity findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,8 @@ Update [doc/RELEASE_NOTES.md](doc/RELEASE_NOTES.md) in the same pull request
 for every user-visible behavior, build or platform-support, packaging, or
 documentation change. Do not add release-note entries for test-only or purely
 internal refactors.
+
+Every pull request that resolves a Coverity finding must update both
+[doc/RELEASE_NOTES.md](doc/RELEASE_NOTES.md) and [ChangeLog](ChangeLog) in the
+same pull request. Cite each resolved CID and describe the correction, even
+when the change is an internal refactor or performance fix.

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 Entries dated after 2024-04-26 are generated from the public Git history; bracketed commit IDs identify each changeset.
 
+2026-09-01  Codex AI Assistant  <simsong+codex@acm.org>
+
+	* [937b82f8] Kept RAR age subtraction in signed int64 arithmetic
+	  (Coverity CID 655320; PR #689).
+	* [1b5529dd] Moved the archived report path into the restart summary
+	  (Coverity CID 655322; PR #690).
+
 2026-08-17  Simson L. Garfinkel  <simsong@acm.org>
 
 	* [dc87bb61] dedup mode is now --dedupe-mode, with default 2

--- a/doc/RELEASE_NOTES.md
+++ b/doc/RELEASE_NOTES.md
@@ -130,6 +130,11 @@ through the project's normal pull-request and CI process.
 - Hardened the bundled RAR PPM decoder's dictionary-copy boundary handling,
   preventing a malformed archive from writing past its ring buffer
   (fixes CVE-2026-24857; [#601](https://github.com/simsong/bulk_extractor/issues/601)).
+- Resolved two Coverity findings: RAR age subtraction now remains in signed
+  64-bit arithmetic (CID 655320), and restart moves the archived report path
+  into its result instead of copying it (CID 655322)
+  ([PR #689](https://github.com/simsong/bulk_extractor/pull/689),
+  [PR #690](https://github.com/simsong/bulk_extractor/pull/690)).
 - Email extraction now accepts syntactically valid two-to-63-character TLDs,
   including current TLDs such as `.solutions`, without requiring a stale
   scanner-specific allow-list ([#586](https://github.com/simsong/bulk_extractor/issues/586)).


### PR DESCRIPTION
## Summary

- require every Coverity-remediation PR to update both release records
- document resolved Coverity CIDs 655320 and 655322 in the 2.2.0 release notes
- add the exact fix commits and PR numbers to ChangeLog

## Validation

- git diff --check origin/main...HEAD
- documentation-only change; no product code changed